### PR TITLE
Run normal CI on agentlens-local while this repository is private

### DIFF
--- a/.github/workflows/agentcheck-example.yml
+++ b/.github/workflows/agentcheck-example.yml
@@ -18,6 +18,12 @@
 # example baseline here; workflow_dispatch will exit 2 until you create one
 # locally or in a consuming project.
 
+# Runner note: this workflow is deliberately GitHub-hosted, unlike ci.yml.
+# It is a template meant to be copied into a project that uses AgentCheck, so
+# pointing it at a self-hosted label would hand every reader a workflow that
+# runs on exactly one machine. It is workflow_dispatch only, so it costs
+# nothing until someone triggers it. See docs/ci-trust-model.md.
+
 name: AgentCheck
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,28 @@
-# Public-repository CI.
+# Normal AgentCheck CI.
 #
-# SECURITY: every job here runs on GitHub-hosted ephemeral runners. This
-# repository must never attach a self-hosted runner to a workflow triggered by
-# `pull_request`, because that trigger runs code from a contributor's fork. A
-# self-hosted runner is somebody's machine; giving arbitrary pull requests
-# execution on it is a workstation compromise, not a CI configuration choice.
+# ============================================================================
+# READ BEFORE MAKING THIS REPOSITORY PUBLIC
+# ============================================================================
+# Every job below runs on `agentlens-local`, a self-hosted runner that is a
+# maintainer's own workstation. That is acceptable *only* while this repository
+# is private and every branch in it is written by the owner.
 #
-# `pull_request` (not `pull_request_target`) is also deliberate: fork PRs get a
-# read-only GITHUB_TOKEN and no access to repository secrets. `pull_request_target`
-# would run untrusted code with the base repository's token and secrets.
+# The moment this repository becomes public, anyone can open a pull request
+# containing arbitrary code. Running that on this runner is remote code
+# execution on a personal machine with its filesystem, its network, and its
+# credentials.
+#
+# The `if:` guard on each job is what stands in the way: it admits pushes and
+# same-repository pull requests only, so a fork's pull request is skipped
+# rather than executed. Going public therefore does not silently expose the
+# runner -- but it does leave external contributors with no CI at all, which is
+# not a workable open-source project.
+#
+# So before publication, the tests and checks jobs must move back to
+# GitHub-hosted or isolated ephemeral runners. `docs/ci-trust-model.md` records
+# the full argument and the exact change. scripts/check_workflow_safety.py
+# proves the guard holds in the meantime, and it runs as part of this workflow.
+# ============================================================================
 #
 # No job here needs a secret, and none makes a provider call.
 
@@ -34,75 +48,224 @@ env:
 jobs:
   tests:
     name: Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Carried by every job independently: a job-level `if` is not inherited, so
+    # a single unguarded job would be enough to run a fork's code on this
+    # machine.
+    #
+    # An allowlist, not `event_name != 'pull_request'`. A deny-list admits any
+    # trigger added to `on:` later -- a workflow_dispatch from a fork's branch,
+    # a future pull_request_target -- without anyone noticing. Naming the two
+    # trusted contexts means a new trigger has to be added here deliberately
+    # before it can reach this runner.
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, Linux, X64]
+    # The suite measured 20:00 at -n 2 on this machine. 40 leaves real margin
+    # for a workstation's own background load without letting a hung job hold
+    # the single runner all afternoon.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
+        # All three supported versions, on both triggers. There is one runner,
+        # so these queue serially rather than running side by side; that is the
+        # cost of keeping every supported version covered before merge instead
+        # of after it.
         python-version: ["3.10", "3.11", "3.12"]
 
+    env:
+      # A self-hosted runner inherits the service environment of a machine that
+      # holds real credentials, so every variable this package reads is pinned
+      # to an inert value. AgentCheck's environment surface is small: a grep for
+      # os.environ/os.getenv across the package and tests finds only the name
+      # below, plus OPENAI_API_KEY.
+      #
+      # Deliberately absent: OPENAI_API_KEY. agentcheck/inspect/extractor.py
+      # branches on whether that name is *present*, and `FOO: ""` makes it
+      # present. Pinning it here would change what those tests observe. The
+      # runner environment is verified credential-free by a step below instead.
+      AGENTCHECK_ALLOWED_TEST: ""
+
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        # The default clean: true runs git clean -ffdx, which clears the
+        # editable-install egg-info, __pycache__, and anything else a previous
+        # job left in this persistent workspace.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install uv
+        # Not actions/setup-python. The interpreters it downloads record the
+        # absolute path of their own libpython as
+        # /opt/hostedtoolcache/Python/<version>/x64/lib, which exists only on a
+        # GitHub-hosted VM. This runner keeps its tool cache elsewhere, so the
+        # loader substitutes the host's libpython and the job ends up running a
+        # standard library and a core from different releases. uv's
+        # interpreters resolve libpython relative to the executable, so they
+        # stay correct wherever they are unpacked.
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          version: "0.9.18"
+          # This runner keeps uv's cache on local disk between jobs, so a
+          # GitHub cache round-trip would be pure overhead.
+          enable-cache: false
+
+      - name: Verify no provider credential reached this job
+        # The suite asserts on how AgentCheck behaves when a provider
+        # credential is absent, and extractor.py takes a different branch when
+        # OPENAI_API_KEY is present. A key exported into the runner service
+        # would not fail loudly -- it would quietly change what several tests
+        # observe. Names only; no value is read or printed.
+        run: |
+          for name in OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY; do
+            if printenv "$name" >/dev/null 2>&1; then
+              echo "$name is present in this job's environment; the suite expects it absent" >&2
+              exit 1
+            fi
+          done
+          echo "PASS: no provider credential is visible to this job"
+
+      - name: Create an isolated virtual environment
+        # only-managed rather than whatever Python the host publishes: the job
+        # should test the version the matrix names, not a host build that
+        # merely shares its minor number. RUNNER_TEMP is recreated per job.
+        run: |
+          uv venv --python "${{ matrix.python-version }}" \
+            --python-preference only-managed "$RUNNER_TEMP/venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+
+      - name: Verify interpreter integrity
+        # Seconds, before anything expensive. A mismatched interpreter does not
+        # fail honestly: it segfaults the worker subprocesses and arrives as a
+        # wall of behavioural failures with no diagnostics -- exactly the
+        # infrastructure-as-product-failure confusion AgentCheck exists to
+        # prevent.
+        run: python scripts/check_interpreter_integrity.py "${{ matrix.python-version }}"
+
+      - name: Install
+        run: uv pip install --python "$RUNNER_TEMP/venv/bin/python" -e ".[dev]"
+
+      - name: Compile Python sources
+        run: python -m compileall -q agentcheck scripts examples tests
+
+      - name: Test
+        # -n 2, measured rather than guessed, and not a knob to turn up.
+        #
+        # Every scenario runs in its own child process under a 10s wall-clock
+        # budget. That budget is a product default and the suite's ability to
+        # notice a starved scenario depends on it, so it is never raised to buy
+        # CI headroom. pytest-xdist workers each spawn their own scenario
+        # children, so the worker count decides whether those children get
+        # their budget. On this 14-core machine -n 2 has a green history; -n 3
+        # and -n 4 were benchmarked and starved scenarios, turning real
+        # verdicts into worker_timeout.
+        run: python -m pytest -p no:cacheprovider tests -q -n 2
+
+  checks:
+    # One job, not five. There is a single self-hosted runner, so every extra
+    # job is another slot in a serial queue: as separate jobs these checks cost
+    # a few minutes of work but five job setups and five checkouts, all waiting
+    # behind each other. Merged into one job they stay individually named
+    # steps, so each result is still visible, and `!cancelled()` keeps a
+    # failure in one check from hiding the outcome of the rest.
+    name: Quality, packaging, extras, and runner trust
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
+
+    env:
+      AGENTCHECK_ALLOWED_TEST: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.9.18"
+          enable-cache: false
 
       - name: Verify no provider credential reached this job
         run: |
           for name in OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY; do
-            if [ -n "${!name:-}" ]; then
-              echo "$name is set in CI; evaluation tests must never spend money"
+            if printenv "$name" >/dev/null 2>&1; then
+              echo "$name is present in this job's environment" >&2
               exit 1
             fi
           done
-          echo "no provider credentials present"
+          echo "PASS: no provider credential is visible to this job"
+
+      - name: Create isolated virtual environments
+        run: |
+          uv venv --python 3.12 --python-preference only-managed "$RUNNER_TEMP/venv"
+          uv venv --python 3.12 --python-preference only-managed "$RUNNER_TEMP/base-venv"
+          uv venv --python 3.12 --python-preference only-managed "$RUNNER_TEMP/openai-venv"
+          uv venv --python 3.12 --python-preference only-managed "$RUNNER_TEMP/pydantic-venv"
+          uv venv --python 3.12 --python-preference only-managed "$RUNNER_TEMP/wheel-venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+
+      - name: Verify interpreter integrity
+        run: python scripts/check_interpreter_integrity.py "3.12"
 
       - name: Install
-        run: python -m pip install -e ".[dev]"
+        run: uv pip install --python "$RUNNER_TEMP/venv/bin/python" -e ".[dev]"
 
-      - name: Test
-        run: python -m pytest tests -q -n 2
+      - name: Verify no untrusted context can reach this runner
+        # Every job here runs on a personal machine, and a job-level `if` is not
+        # inherited, so the guards are the only thing between a fork's branch
+        # and this host. They are checked by evaluating them against synthetic
+        # push, same-repo, fork, pull_request_target, workflow_run,
+        # workflow_dispatch, and issue_comment contexts rather than by matching
+        # their text, because the mistakes worth catching are logical ones.
+        if: ${{ !cancelled() }}
+        run: python scripts/check_workflow_safety.py
 
-  base-install:
-    name: Base install has no framework
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
+      - name: Ruff
+        if: ${{ !cancelled() }}
+        run: python -m ruff check agentcheck tests scripts
 
-      - name: Install base only
-        run: python -m pip install .
+      - name: Mypy
+        if: ${{ !cancelled() }}
+        run: python -m mypy agentcheck
 
-      - name: A base install must import and run without any framework
+      - name: Secret scan
+        if: ${{ !cancelled() }}
+        run: python scripts/check_no_secrets.py
+
+      - name: Base install has no framework
+        # A base install must import and run with neither framework present.
+        if: ${{ !cancelled() }}
         run: |
-          python - <<'PY'
-          import importlib.util, subprocess, sys
+          uv pip install --python "$RUNNER_TEMP/base-venv/bin/python" .
+          "$RUNNER_TEMP/base-venv/bin/python" - <<'PY'
+          import importlib.util, subprocess
           for framework in ("agents", "pydantic_ai"):
               assert importlib.util.find_spec(framework) is None, (
                   f"{framework} must not be a base dependency"
               )
           import agentcheck
-          subprocess.run(["agentcheck", "--help"], check=True)
+          print("base import ok:", agentcheck.__version__)
           PY
+          "$RUNNER_TEMP/base-venv/bin/agentcheck" --help > /dev/null
 
-      - name: A missing extra must be actionable, not a traceback
+      - name: A missing extra is actionable, not a traceback
+        if: ${{ !cancelled() }}
         run: |
-          python - <<'PY'
+          "$RUNNER_TEMP/base-venv/bin/python" - <<'PY'
           from agentcheck.adapters import AdapterDependencyError
-          from agentcheck.adapters.openai_agents import _require_sdk as openai_sdk
-          from agentcheck.adapters.pydantic_ai import _require_sdk as pydantic_sdk
+          from agentcheck.adapters.openai_agents import _require_sdk as need_openai
+          from agentcheck.adapters.pydantic_ai import _require_sdk as need_pydantic
 
-          for require in (openai_sdk, pydantic_sdk):
+          for require in (need_openai, need_pydantic):
               try:
                   require()
               except AdapterDependencyError as exc:
@@ -112,69 +275,45 @@ jobs:
                   raise AssertionError(f"{require} should have refused")
           PY
 
-  extras:
-    name: Extra ${{ matrix.extra }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        extra: ["openai-agents", "pydantic-ai", "all"]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install extra
-        run: python -m pip install ".[${{ matrix.extra }}]" pytest pytest-xdist
-
-      - name: Adapter tests for this extra
+      - name: Extra openai-agents in isolation
+        # Installed alone, so a leak from the other extra shows up here rather
+        # than being masked by a combined environment.
+        if: ${{ !cancelled() }}
         run: |
-          case "${{ matrix.extra }}" in
-            openai-agents) python -m pytest tests/agentcheck/test_openai_adapter.py -q ;;
-            pydantic-ai)   python -m pytest tests/agentcheck/test_pydantic_ai_adapter.py -q ;;
-            all)           python -m pytest tests/agentcheck/test_openai_adapter.py \
-                                            tests/agentcheck/test_pydantic_ai_adapter.py -q ;;
-          esac
+          uv pip install --python "$RUNNER_TEMP/openai-venv/bin/python" ".[openai-agents]" pytest
+          "$RUNNER_TEMP/openai-venv/bin/python" -c "
+          import importlib.util
+          assert importlib.util.find_spec('agents') is not None
+          assert importlib.util.find_spec('pydantic_ai') is None, 'pydantic-ai leaked'
+          "
+          "$RUNNER_TEMP/openai-venv/bin/python" -m pytest tests/agentcheck/test_openai_adapter.py -q
 
-  quality:
-    name: Quality, packaging, and secrets
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install
-        run: python -m pip install -e ".[dev]"
-
-      - name: Ruff
-        run: python -m ruff check agentcheck tests
-
-      - name: Mypy
-        run: python -m mypy agentcheck
-
-      - name: Secret scan
-        run: python scripts/check_no_secrets.py
+      - name: Extra pydantic-ai in isolation
+        if: ${{ !cancelled() }}
+        run: |
+          uv pip install --python "$RUNNER_TEMP/pydantic-venv/bin/python" ".[pydantic-ai]" pytest
+          "$RUNNER_TEMP/pydantic-venv/bin/python" -c "
+          import importlib.util
+          assert importlib.util.find_spec('pydantic_ai') is not None
+          assert importlib.util.find_spec('agents') is None, 'openai-agents leaked'
+          "
+          "$RUNNER_TEMP/pydantic-venv/bin/python" -m pytest tests/agentcheck/test_pydantic_ai_adapter.py -q
 
       - name: Build wheel and sdist
-        run: python -m build
+        if: ${{ !cancelled() }}
+        run: python -m build --outdir "$RUNNER_TEMP/dist"
 
       - name: Audit artifact contents
-        run: python scripts/check_distribution.py
+        if: ${{ !cancelled() }}
+        run: |
+          rm -rf dist && cp -r "$RUNNER_TEMP/dist" dist
+          python scripts/check_distribution.py
 
       - name: Wheel install smoke test
+        if: ${{ !cancelled() }}
         run: |
-          python -m venv /tmp/smoke
-          /tmp/smoke/bin/python -m pip install --quiet dist/*.whl
-          cd /tmp
-          /tmp/smoke/bin/python -c "import agentcheck; print(agentcheck.__version__)"
-          /tmp/smoke/bin/agentcheck --help > /dev/null
+          uv pip install --python "$RUNNER_TEMP/wheel-venv/bin/python" "$RUNNER_TEMP"/dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/wheel-venv/bin/python" -c "import agentcheck; print(agentcheck.__version__)"
+          "$RUNNER_TEMP/wheel-venv/bin/agentcheck" --help > /dev/null
           echo "wheel install smoke passed"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include AGENTS.md
 recursive-include tests *.py
 recursive-include examples *.py *.json *.md
 recursive-include scripts *.py
+recursive-include docs *.md
 recursive-include .github *.yml
 
 # Evaluation runs write under .agentcheck/ next to the target. Those are local

--- a/docs/ci-trust-model.md
+++ b/docs/ci-trust-model.md
@@ -1,0 +1,99 @@
+# CI trust model
+
+> **If you are about to make this repository public, read this first.**
+> Normal CI currently runs on a self-hosted runner that is a maintainer's
+> personal workstation. That is safe while this repository is private. It stops
+> being safe the moment anyone can open a pull request.
+
+## Where CI runs today
+
+| Workflow | Runner | Trigger | Why |
+|---|---|---|---|
+| `ci.yml` | `[self-hosted, Linux, X64]` (`agentlens-local`) | `push`, `pull_request` | Every branch here is written by the owner, and GitHub-hosted minutes are billed against the account while the repository is private. |
+| `agentcheck-example.yml` | `ubuntu-latest` | `workflow_dispatch` | Deliberately GitHub-hosted — see below. |
+
+## Why the example workflow stays GitHub-hosted
+
+`agentcheck-example.yml` is not this repository's CI. It is a template meant to
+be copied into a project that uses AgentCheck. Pointing it at `self-hosted`
+would hand every reader a workflow that cannot run anywhere but one specific
+machine, which defeats its only purpose.
+
+It also costs nothing: it is `workflow_dispatch` only, so it never runs unless
+someone triggers it by hand.
+
+Do not "fix" it to match `ci.yml`.
+
+## What makes the self-hosted arrangement safe right now
+
+Two things, and only two:
+
+1. **The repository is private.** Only the owner can push a branch or open a
+   pull request, so all executed code is trusted.
+2. **Each self-hosted job carries a trusted-context guard:**
+
+   ```yaml
+   if: >-
+     github.event_name == 'push'
+     || (github.event_name == 'pull_request'
+         && github.event.pull_request.head.repo.full_name == github.repository)
+   ```
+
+   It is an allowlist, not `event_name != 'pull_request'`. A deny-list would
+   admit any trigger added to `on:` later without anyone noticing.
+
+   The guard is on **every** job, because a job-level `if` is not inherited and
+   one unguarded job is enough to undo the whole arrangement.
+
+`scripts/check_workflow_safety.py` proves this holds by evaluating each guard
+against synthetic push, same-repository, fork, `pull_request_target`,
+`workflow_run`, `workflow_dispatch`, and `issue_comment` contexts. It runs in
+CI and in the test suite. It also fails if a `ci.yml` job drifts *back* to a
+GitHub-hosted label, because that spends billed minutes silently — nothing
+breaks, the bill just grows.
+
+## What must change before this repository becomes public
+
+The guard does not fail open, so publication would not instantly expose the
+runner: a fork's pull request is **skipped**, not executed.
+
+That is the problem. A public project where external pull requests get no CI at
+all is not a working open-source project, and the obvious "fix" — relaxing the
+guard so contributor PRs run — is exactly the change that turns a workstation
+into a public code-execution surface.
+
+So, before publication:
+
+1. **Move `ci.yml`'s `tests` and `checks` jobs back to GitHub-hosted runners**
+   (`runs-on: ubuntu-latest`), or to properly isolated ephemeral self-hosted
+   runners that are destroyed after each job.
+2. **Remove the `if:` guards** once no job targets `agentlens-local`, since they
+   exist only to protect that runner.
+3. **Restore `actions/setup-python`** in place of the `uv`-provisioned
+   interpreters if hosted runners are used. The `uv` approach exists because
+   `actions/setup-python`'s interpreters hard-code
+   `/opt/hostedtoolcache/...` libpython paths that do not exist on a
+   self-hosted runner. On a hosted runner that constraint disappears.
+4. **Re-check pytest concurrency.** `-n 2` is measured for a 14-core
+   workstation. A hosted runner has far fewer cores, and at `-n 2` there the
+   suite starved its own scenario budget: 10 failed / 920 passed on Python 3.11
+   and 3.12 while 3.10 passed, from a commit that passes 924/924 locally.
+   Scenarios came back `INFRA_ERROR` instead of real verdicts. The fix is fewer
+   pytest workers or sharding across jobs — **never** a larger scenario budget,
+   which would trade away the signal that detects a starved run.
+5. **Do not attach `agentlens-local` to this repository's runner list**, and do
+   not use `pull_request_target` anywhere.
+6. **Budget for the minutes.** Actions minutes are free on public
+   repositories, which is what makes step 1 affordable. While this repository
+   is private they are billed: the single bootstrap CI run consumed roughly 84
+   minutes of job time, most of it three full-suite jobs at 23–29 minutes each,
+   and the account then declined to start further hosted jobs.
+
+`tests/agentcheck/test_workflow_safety.py::test_publication_checklist_is_discoverable`
+asserts this document exists and that `ci.yml` carries the warning inline, so
+the decision cannot quietly disappear.
+
+## The rule that does not change
+
+**Arbitrary code from a public pull request must never execute on
+`agentlens-local`,** whatever else is convenient.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ dev = [
     "mypy>=1.17,<1.18",
     "pytest>=8.0,<10.0",
     "pytest-xdist>=3.6,<4",
+    # scripts/check_workflow_safety.py parses the workflows it audits.
+    "pyyaml>=6.0,<7",
     "ruff>=0.12,<0.13",
     "types-requests>=2.32,<3",
 ]

--- a/scripts/check_interpreter_integrity.py
+++ b/scripts/check_interpreter_integrity.py
@@ -1,0 +1,109 @@
+"""Fail fast when the interpreter chosen for a job is not self-consistent.
+
+A relocatable CPython records where its own ``libpython`` lives. The prebuilt
+interpreters ``actions/setup-python`` downloads hard-code that location as
+``/opt/hostedtoolcache/Python/<version>/x64/lib``, a path that exists only on a
+GitHub-hosted VM. A self-hosted runner keeps its tool cache somewhere else, so
+the loader never finds the bundled library, falls back to whatever ``libpython``
+the host publishes, and produces an interpreter whose core and standard library
+come from different releases.
+
+That mismatch is invisible to most pure-Python work and fatal to anything that
+touches an affected C extension, so it reached AgentCheck as SIGSEGV inside the
+worker subprocesses: twenty-one behavioural failures that were one
+infrastructure fault. AgentCheck refuses to report an infrastructure fault as a
+product failure, and its own CI owes the suite the same guarantee -- before the
+suite spends thirteen minutes producing verdicts nobody should trust.
+
+The check has to run in a child process, not just in-process. Workers inherit a
+deliberately minimal environment that drops ``LD_LIBRARY_PATH`` (see
+``agentcheck.config.child_environment``), so a loader override set at the job
+level would hide the fault from the only process whose health matters. The
+child below is therefore spawned without loader overrides, exactly as a worker
+is.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+# Extensions whose ABI moves between patch releases, so a core/stdlib mismatch
+# shows up here as an unresolved symbol rather than as a later crash.
+_PROBE_MODULES = ("ctypes", "ssl", "hashlib", "sqlite3", "socket", "decimal")
+
+# Variables that let a caller redirect the dynamic loader. A worker never sees
+# them, so neither does this check.
+_LOADER_OVERRIDES = ("LD_LIBRARY_PATH", "LD_PRELOAD", "PYTHONHOME", "PYTHONPATH")
+
+_CHILD_PROGRAM = (
+    "import json, sys\n"
+    f"for name in {_PROBE_MODULES!r}:\n"
+    "    __import__(name)\n"
+    "print(json.dumps(list(sys.version_info[:3])))\n"
+)
+
+
+def _expected_version(argument: str) -> tuple[int, int]:
+    parts = argument.split(".")
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        raise SystemExit(f"expected a MAJOR.MINOR version, got {argument!r}")
+    return int(parts[0]), int(parts[1])
+
+
+def _child_version() -> tuple[int, int, int]:
+    """Report the version a worker-shaped child actually runs."""
+
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if name not in _LOADER_OVERRIDES
+    }
+    completed = subprocess.run(
+        [sys.executable, "-c", _CHILD_PROGRAM],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"{sys.executable} cannot start a working child process "
+            f"(exit {completed.returncode}). This interpreter is not usable:\n"
+            f"{completed.stderr.strip() or '<no diagnostics>'}"
+        )
+    major, minor, micro = json.loads(completed.stdout)
+    return int(major), int(minor), int(micro)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: check_interpreter_integrity.py MAJOR.MINOR")
+    expected = _expected_version(sys.argv[1])
+
+    running = sys.version_info[:3]
+    if running[:2] != expected:
+        raise SystemExit(
+            f"{sys.executable} reports {'.'.join(map(str, running))}, "
+            f"but this job asked for {sys.argv[1]}. The interpreter is loading "
+            "a standard library and a core from different installations."
+        )
+
+    child = _child_version()
+    if child != running:
+        raise SystemExit(
+            f"{sys.executable} reports {'.'.join(map(str, running))} in process "
+            f"but {'.'.join(map(str, child))} in a child that has no loader "
+            "overrides. AgentCheck workers run with that same minimal "
+            "environment, so this interpreter would crash them."
+        )
+
+    print(f"interpreter {'.'.join(map(str, running))} is self-consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_workflow_safety.py
+++ b/scripts/check_workflow_safety.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Prove that no untrusted context can reach the self-hosted runner.
+
+It also holds normal CI on that runner. Moving a job back to a GitHub-hosted
+label costs billed minutes silently -- nothing fails, the bill just grows -- so
+the placement is asserted here rather than left to review.
+
+The self-hosted runner is a personal machine, so a job that runs on it must
+execute only repository-controlled code. GitHub does not enforce that: a
+job-level ``if`` is not inherited, so one unguarded job is enough to run a
+fork's branch here. This script reads the workflows and fails when a
+self-hosted job would be reachable from an untrusted context.
+
+It evaluates the guard expressions rather than pattern-matching them, because
+the interesting mistakes are logical -- an ``||`` that should be ``&&``, a
+deny-list that admits a trigger nobody thought about -- and a substring check
+cannot see those.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+
+WORKFLOW_DIRECTORY = Path(".github/workflows")
+SELF_HOSTED_LABEL = "self-hosted"
+
+# Workflows whose jobs must run on the self-hosted runner. Anything else in the
+# directory is an example or an on-demand workflow and is exempt; see the
+# module docstring in each.
+NORMAL_CI_WORKFLOWS = frozenset({"ci.yml"})
+
+# Contexts a workflow can be triggered from. ``trusted`` means the ref being
+# checked out is controlled by this repository.
+CONTEXTS: dict[str, dict[str, Any]] = {
+    "push to main": {
+        "trusted": True,
+        "github": {
+            "event_name": "push",
+            "repository": "owner/repo",
+            "event": {},
+        },
+    },
+    "pull_request from a branch in this repository": {
+        "trusted": True,
+        "github": {
+            "event_name": "pull_request",
+            "repository": "owner/repo",
+            "event": {"pull_request": {"head": {"repo": {"full_name": "owner/repo"}}}},
+        },
+    },
+    "pull_request from a fork": {
+        "trusted": False,
+        "github": {
+            "event_name": "pull_request",
+            "repository": "owner/repo",
+            "event": {
+                "pull_request": {"head": {"repo": {"full_name": "attacker/repo"}}}
+            },
+        },
+    },
+    "pull_request_target from a fork": {
+        "trusted": False,
+        "github": {
+            "event_name": "pull_request_target",
+            "repository": "owner/repo",
+            "event": {
+                "pull_request": {"head": {"repo": {"full_name": "attacker/repo"}}}
+            },
+        },
+    },
+    "workflow_dispatch": {
+        "trusted": False,
+        "github": {
+            "event_name": "workflow_dispatch",
+            "repository": "owner/repo",
+            "event": {},
+        },
+    },
+    "workflow_run": {
+        "trusted": False,
+        "github": {
+            "event_name": "workflow_run",
+            "repository": "owner/repo",
+            "event": {},
+        },
+    },
+    "issue_comment": {
+        "trusted": False,
+        "github": {
+            "event_name": "issue_comment",
+            "repository": "owner/repo",
+            "event": {},
+        },
+    },
+}
+
+
+class ExpressionError(RuntimeError):
+    """The guard uses syntax this checker does not model."""
+
+
+def _tokenize(source: str) -> list[str]:
+    tokens: list[str] = []
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char.isspace():
+            index += 1
+            continue
+        if source.startswith("&&", index) or source.startswith("||", index):
+            tokens.append(source[index : index + 2])
+            index += 2
+            continue
+        if source.startswith("==", index) or source.startswith("!=", index):
+            tokens.append(source[index : index + 2])
+            index += 2
+            continue
+        if char in "()":
+            tokens.append(char)
+            index += 1
+            continue
+        if char == "!":
+            tokens.append(char)
+            index += 1
+            continue
+        if char == "'":
+            end = source.index("'", index + 1)
+            tokens.append(source[index : end + 1])
+            index = end + 1
+            continue
+        start = index
+        while index < len(source) and (source[index].isalnum() or source[index] in "._-"):
+            index += 1
+        if index == start:
+            raise ExpressionError(f"unexpected character {char!r} in guard")
+        tokens.append(source[start:index])
+    return tokens
+
+
+class _Parser:
+    """Recursive descent over the subset of expressions these guards use."""
+
+    def __init__(self, tokens: list[str], context: dict[str, Any]) -> None:
+        self.tokens = tokens
+        self.position = 0
+        self.context = context
+
+    def peek(self) -> str | None:
+        return self.tokens[self.position] if self.position < len(self.tokens) else None
+
+    def take(self) -> str:
+        token = self.tokens[self.position]
+        self.position += 1
+        return token
+
+    def parse(self) -> Any:
+        value = self.parse_or()
+        if self.position != len(self.tokens):
+            raise ExpressionError("trailing tokens in guard")
+        return value
+
+    def parse_or(self) -> Any:
+        left = self.parse_and()
+        while self.peek() == "||":
+            self.take()
+            right = self.parse_and()
+            left = bool(left) or bool(right)
+        return left
+
+    def parse_and(self) -> Any:
+        left = self.parse_equality()
+        while self.peek() == "&&":
+            self.take()
+            right = self.parse_equality()
+            left = bool(left) and bool(right)
+        return left
+
+    def parse_equality(self) -> Any:
+        left = self.parse_unary()
+        while self.peek() in ("==", "!="):
+            operator = self.take()
+            right = self.parse_unary()
+            left = (left == right) if operator == "==" else (left != right)
+        return left
+
+    def parse_unary(self) -> Any:
+        if self.peek() == "!":
+            self.take()
+            return not bool(self.parse_unary())
+        return self.parse_primary()
+
+    def parse_primary(self) -> Any:
+        token = self.peek()
+        if token is None:
+            raise ExpressionError("guard ended unexpectedly")
+        if token == "(":
+            self.take()
+            value = self.parse_or()
+            if self.take() != ")":
+                raise ExpressionError("unbalanced parenthesis in guard")
+            return value
+        token = self.take()
+        if token.startswith("'"):
+            return token[1:-1]
+        if token in ("true", "false"):
+            return token == "true"
+        return self._lookup(token)
+
+    def _lookup(self, path: str) -> Any:
+        # An absent property is the empty string in GitHub expressions, which is
+        # falsy and never equal to a non-empty literal. Modelling it any other
+        # way would make a guard look safer than it is.
+        current: Any = self.context
+        for part in path.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                return ""
+        return current
+
+
+def evaluate(expression: str, context: dict[str, Any]) -> bool:
+    text = expression.strip()
+    if text.startswith("${{") and text.endswith("}}"):
+        text = text[3:-2]
+    return bool(_Parser(_tokenize(text), context).parse())
+
+
+def _is_self_hosted(runs_on: Any) -> bool:
+    if isinstance(runs_on, str):
+        return runs_on == SELF_HOSTED_LABEL
+    if isinstance(runs_on, list):
+        return SELF_HOSTED_LABEL in runs_on
+    if isinstance(runs_on, dict):
+        labels = runs_on.get("labels", [])
+        if isinstance(labels, str):
+            return labels == SELF_HOSTED_LABEL
+        return SELF_HOSTED_LABEL in (labels or [])
+    return False
+
+
+def _triggers(workflow: Mapping[Any, Any]) -> set[str]:
+    # PyYAML resolves an unquoted `on:` key to the boolean True.
+    raw = workflow.get("on", workflow.get(True))
+    if isinstance(raw, str):
+        return {raw}
+    if isinstance(raw, list):
+        return set(raw)
+    if isinstance(raw, dict):
+        return set(raw)
+    return set()
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+
+    for path in sorted(WORKFLOW_DIRECTORY.glob("*.yml")) + sorted(
+        WORKFLOW_DIRECTORY.glob("*.yaml")
+    ):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        triggers = _triggers(workflow)
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            if not _is_self_hosted(job.get("runs-on")):
+                continue
+            checked += 1
+            guard = job.get("if")
+            if guard is None:
+                failures.append(
+                    f"{path.name}:{job_name} runs self-hosted with no trusted-context guard"
+                )
+                continue
+            for label, context in CONTEXTS.items():
+                event = context["github"]["event_name"]
+                # Only contexts the workflow can actually be triggered from can
+                # reach a job, but an untrusted trigger that is not declared is
+                # still worth reporting if the guard would admit it.
+                try:
+                    allowed = evaluate(str(guard), {"github": context["github"]})
+                except ExpressionError as error:
+                    failures.append(f"{path.name}:{job_name} guard not understood: {error}")
+                    break
+                if allowed and not context["trusted"]:
+                    reachable = event in triggers
+                    detail = "declared trigger" if reachable else "undeclared trigger"
+                    failures.append(
+                        f"{path.name}:{job_name} would run for {label} ({detail})"
+                    )
+            if "pull_request_target" in triggers:
+                failures.append(
+                    f"{path.name}:{job_name} is self-hosted in a workflow that uses "
+                    "pull_request_target"
+                )
+
+    for name in sorted(NORMAL_CI_WORKFLOWS):
+        path = WORKFLOW_DIRECTORY / name
+        if not path.exists():
+            failures.append(f"{name} is missing; normal CI placement cannot be checked")
+            continue
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            if not _is_self_hosted(job.get("runs-on")):
+                failures.append(
+                    f"{name}:{job_name} runs on {job.get('runs-on')!r} rather than the "
+                    "self-hosted runner, which spends billed GitHub minutes"
+                )
+
+    if not checked:
+        print("FAIL: no self-hosted job found; this checker would pass vacuously")
+        return 1
+    if failures:
+        print("FAIL: workflow trust or runner placement is wrong")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(
+        f"PASS: {checked} self-hosted job(s) reject every untrusted context, "
+        "and normal CI stays off GitHub-hosted runners"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agentcheck/test_workflow_safety.py
+++ b/tests/agentcheck/test_workflow_safety.py
@@ -1,27 +1,37 @@
-"""A public repository must not run contributor code on a trusted machine.
+"""CI must not become a way to run other people's code on someone's computer.
 
-This is the one CI mistake in an open-source project that costs more than a red
-build. `pull_request` runs code from a fork. If such a workflow is ever pointed
-at a self-hosted runner -- someone's workstation, with their filesystem, their
-network, and their credentials -- then opening a pull request is remote code
-execution on that machine.
+While this repository is private, normal CI runs on a self-hosted runner --
+a maintainer's own workstation -- because every branch here is written by the
+owner and GitHub-hosted minutes are billed against the account.
 
-`pull_request_target` is the same hazard by a different route: it runs with the
-base repository's token and secrets, so checking out and executing the fork's
-code under it hands those over.
+That arrangement is safe only because of the `if:` guard on each self-hosted
+job, which admits pushes and same-repository pull requests and nothing else.
+A job-level `if` is not inherited, so one unguarded job is enough to undo it.
 
-Neither is something to catch in review. This test reads the workflows.
+These tests check the guard rather than trusting review, and they check it by
+evaluating the expression against synthetic trigger contexts, because the
+mistakes worth catching are logical: an `||` that should be `&&`, a deny-list
+that admits a trigger nobody thought about.
+
+`test_publication_checklist_is_discoverable` is the one that matters most and
+tests the least code. The guard makes a fork's pull request *skip*, which is
+safe but leaves external contributors with no CI -- so this configuration has
+to be revisited before the repository goes public. That is precisely the kind
+of decision that gets forgotten, so the reminder is asserted to exist.
 """
 
 from __future__ import annotations
 
 import pathlib
-import re
+import subprocess
+import sys
 
 import pytest
 
 
-WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPOSITORY_ROOT / ".github" / "workflows"
+TRUST_MODEL_DOC = REPOSITORY_ROOT / "docs" / "ci-trust-model.md"
 
 
 def _workflow_files() -> list[pathlib.Path]:
@@ -30,43 +40,63 @@ def _workflow_files() -> list[pathlib.Path]:
     return files
 
 
-@pytest.mark.parametrize("workflow", _workflow_files(), ids=lambda path: path.name)
-def test_no_workflow_uses_a_self_hosted_runner(workflow: pathlib.Path) -> None:
-    text = workflow.read_text(encoding="utf-8")
-    offending = [
-        f"{number}: {line.strip()}"
-        for number, line in enumerate(text.splitlines(), start=1)
-        # Match the runner label wherever it appears in a runs-on value, including
-        # the list form `runs-on: [self-hosted, Linux, X64]`.
-        if re.search(r"self-hosted", line) and not line.lstrip().startswith("#")
-    ]
-    assert not offending, (
-        f"{workflow.name} references a self-hosted runner: {offending}. "
-        "Public pull requests execute untrusted code; they must run on "
-        "GitHub-hosted ephemeral runners only."
+def test_no_self_hosted_job_is_reachable_from_an_untrusted_context() -> None:
+    """Delegates to the checker CI runs, so both see the same verdict."""
+
+    result = subprocess.run(
+        [sys.executable, "scripts/check_workflow_safety.py"],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 @pytest.mark.parametrize("workflow", _workflow_files(), ids=lambda path: path.name)
 def test_no_workflow_uses_pull_request_target(workflow: pathlib.Path) -> None:
-    text = workflow.read_text(encoding="utf-8")
+    """The trigger that runs a fork's code with the base repository's secrets."""
+
     offending = [
         number
-        for number, line in enumerate(text.splitlines(), start=1)
+        for number, line in enumerate(workflow.read_text().splitlines(), start=1)
         if "pull_request_target" in line and not line.lstrip().startswith("#")
     ]
     assert not offending, (
         f"{workflow.name} uses pull_request_target at line(s) {offending}. "
-        "That trigger runs with the base repository's token and secrets, so it "
-        "must never be combined with checking out a fork's code."
+        "It runs with the base repository's token and secrets, so it must never "
+        "be combined with checking out a fork's code -- and never at all on a "
+        "self-hosted runner."
     )
 
 
 @pytest.mark.parametrize("workflow", _workflow_files(), ids=lambda path: path.name)
 def test_workflows_declare_least_privilege_token(workflow: pathlib.Path) -> None:
-    text = workflow.read_text(encoding="utf-8")
+    import re
+
+    text = workflow.read_text()
     assert re.search(r"^permissions:", text, re.MULTILINE), (
         f"{workflow.name} does not declare a top-level `permissions:` block. "
-        "Without one the workflow inherits the repository default, which may be "
-        "write. State the minimum explicitly."
+        "Without one it inherits the repository default, which may be write."
+    )
+
+
+def test_publication_checklist_is_discoverable() -> None:
+    """A self-hosted runner plus a public repository is the mistake to prevent."""
+
+    assert TRUST_MODEL_DOC.exists(), (
+        f"{TRUST_MODEL_DOC.relative_to(REPOSITORY_ROOT)} is missing. It records why "
+        "CI is self-hosted while this repository is private and what has to change "
+        "before it goes public; without it that decision is only in someone's head."
+    )
+    doc = TRUST_MODEL_DOC.read_text()
+    for required in ("private", "public", "self-hosted", "fork"):
+        assert required in doc.lower(), f"trust-model doc never mentions {required!r}"
+
+    # The workflow itself must carry the warning too. Someone changing runner
+    # labels is reading the YAML, not the docs directory.
+    ci = (WORKFLOWS / "ci.yml").read_text()
+    assert "BEFORE MAKING THIS REPOSITORY PUBLIC" in ci, (
+        "ci.yml must carry the pre-publication warning where a maintainer "
+        "editing runner labels will actually see it"
     )


### PR DESCRIPTION
## Why

The bootstrap CI run spent roughly **84 minutes** of billed GitHub-hosted time
in one go, and the account then declined to start any further hosted job
("The job was not started because recent account payments have failed or your
spending limit needs to be increased"). Every job on the follow-up PR was
refused in under 4 seconds.

Where it went:

| Job | Minutes |
|---|---|
| Tests (Python 3.11) | 29.1 |
| Tests (Python 3.12) | 28.9 |
| Tests (Python 3.10) | 23.1 |
| Quality, packaging, and secrets | 1.5 |
| Extra all / openai-agents / pydantic-ai | 1.5 combined |
| Base install | 0.2 |

AgentLens already solved this by moving to `agentlens-local`. This repository
can use the same runner, and while it is **private** every branch here is
written by the owner, so the executing code is trusted.

## What makes it safe

The guard, copied from AgentLens rather than reinvented, on **every** job:

```yaml
if: >-
  github.event_name == 'push'
  || (github.event_name == 'pull_request'
      && github.event.pull_request.head.repo.full_name == github.repository)
```

An allowlist, not `!= 'pull_request'` — a deny-list admits any trigger added to
`on:` later. On every job, because a job-level `if` is not inherited.

`scripts/check_workflow_safety.py` evaluates each guard against synthetic push,
same-repo, fork, `pull_request_target`, `workflow_run`, `workflow_dispatch`, and
`issue_comment` contexts, and also fails if a `ci.yml` job drifts *back* to a
hosted label (which would spend minutes silently). Verified in both directions
by breaking the guard on purpose:

- deny-list variant → `ci.yml:tests would run for pull_request from a fork`
- one job unguarded → `ci.yml:checks runs self-hosted with no trusted-context guard`
- restored → `PASS: 2 self-hosted job(s) reject every untrusted context`

## Runner details that are not just labels

- **`actions/setup-python` → `uv`.** Its interpreters hard-code
  `/opt/hostedtoolcache/.../lib` for libpython, which does not exist here; the
  loader then mixes a host libpython with a downloaded stdlib and it arrives as
  SIGSEGV inside worker subprocesses rather than an honest failure.
  `check_interpreter_integrity.py` catches it in seconds.
- **Inherited environment blanked.** `OPENAI_API_KEY` is deliberately left
  *unset* rather than pinned to `""`, because `extractor.py` branches on the
  name being present and `FOO: ""` makes it present. A separate step verifies
  no provider credential is visible.
- **`-n 2`, unchanged.** Measured for this 14-core machine. Scenario wall-clock
  budgets are untouched.
- **8 jobs → 2.** One runner means every extra job is another serial queue slot.
  Checks remain individually named steps under `!cancelled()`, so per-check
  results stay visible. No check was dropped.

## Intentionally still GitHub-hosted

`agentcheck-example.yml`. It is a template for users to copy into their own
projects, so a self-hosted label would give every reader a workflow that runs on
exactly one machine. It is `workflow_dispatch` only, so it costs nothing. A
comment in the file explains this.

## ⚠️ This expires when the repository goes public

The guard makes a fork's PR **skip**, not execute — safe, but it leaves external
contributors with no CI. The obvious fix, relaxing the guard, is exactly what
turns a workstation into a public code-execution surface.

`docs/ci-trust-model.md` records the argument and the specific steps to undo
this before publication. `ci.yml` carries the warning inline where someone
editing runner labels will see it, and
`test_publication_checklist_is_discoverable` asserts both still exist.

**Arbitrary code from a public pull request must never execute on
`agentlens-local`.**

## Verification

- `check_workflow_safety.py`: PASS, plus two deliberate-break negative tests
- `test_workflow_safety.py`: 6 passed
- `ruff check agentcheck tests scripts`: clean
- `mypy agentcheck`: clean, 83 files
- No secrets added, no provider credentials, provider spend $0