### PR TITLE
Run the full suite once and the interpreter-facing half everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ concurrency:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONDONTWRITEBYTECODE: "1"
+  # The interpreter that runs the whole suite. Every other supported version
+  # runs the cross-version suite from tests/compat_manifest.py.
+  PRIMARY_PYTHON: "3.12"
 
 jobs:
   tests:
@@ -69,11 +72,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # All three supported versions, on both triggers. There is one runner,
-        # so these queue serially rather than running side by side; that is the
-        # cost of keeping every supported version covered before merge instead
-        # of after it.
-        python-version: ["3.10", "3.11", "3.12"]
+        # One runner means these queue serially, so every entry is wall-clock a
+        # pull request waits. On a pull request all three supported versions run;
+        # after merge only the primary does, because the merge-race this second
+        # run exists to catch would show up on any interpreter. See the Test step.
+        python-version: ${{ github.event_name == 'push' && fromJSON('["3.12"]') || fromJSON('["3.10", "3.11", "3.12"]') }}
 
     env:
       # A self-hosted runner inherits the service environment of a machine that
@@ -162,7 +165,26 @@ jobs:
         # their budget. On this 14-core machine -n 2 has a green history; -n 3
         # and -n 4 were benchmarked and starved scenarios, turning real
         # verdicts into worker_timeout.
-        run: python -m pytest -p no:cacheprovider tests -q -n 2
+        #
+        # The primary interpreter runs everything. The others run the
+        # cross-version suite, whose contents and rationale live in
+        # tests/compat_manifest.py and are enforced by
+        # tests/agentcheck/test_compat_manifest.py -- the list is read from the
+        # manifest here rather than duplicated, so the two cannot drift.
+        #
+        # The package has no sys.version_info branching, so what differs between
+        # interpreters is where it meets one: recursive TypeAliasType models,
+        # subprocess workers, import machinery, SDK internals and the CLI entry
+        # point. Those all run on every version. Pure logic over already-built
+        # objects runs once.
+        run: |
+          if [ "${{ matrix.python-version }}" = "$PRIMARY_PYTHON" ]; then
+            python -m pytest -p no:cacheprovider tests -q -n 2
+          else
+            mapfile -t compat < <(python tests/compat_manifest.py)
+            echo "cross-version suite: ${#compat[@]} files"
+            python -m pytest -p no:cacheprovider "${compat[@]}" -q -n 2
+          fi
 
   checks:
     # One job, not five. There is a single self-hosted runner, so every extra

--- a/docs/ci-trust-model.md
+++ b/docs/ci-trust-model.md
@@ -5,6 +5,54 @@
 > personal workstation. That is safe while this repository is private. It stops
 > being safe the moment anyone can open a pull request.
 
+## What runs, and on which interpreter
+
+The full suite runs once, on the primary interpreter. Every other supported
+version runs the cross-version suite defined in `tests/compat_manifest.py`.
+
+| | Py3.10 | Py3.11 | Py3.12 |
+|---|---|---|---|
+| Full behavioural suite (930 tests) | | | ✅ |
+| Domain models, serialization, fingerprints | ✅ | ✅ | ✅ |
+| Worker / process isolation | ✅ | ✅ | ✅ |
+| ToolGateway, fail-closed, unknown tools | ✅ | ✅ | ✅ |
+| Prerequisites, confirmation, `followup_turns` | ✅ | ✅ | ✅ |
+| Replay, source integrity | ✅ | ✅ | ✅ |
+| OpenAI Agents adapter | ✅ | ✅ | ✅ |
+| PydanticAI adapter | ✅ | ✅ | ✅ |
+| CLI end-to-end, target import, package boundary | ✅ | ✅ | ✅ |
+| Network containment | ✅ | ✅ | ✅ |
+| Packaging, extras, clean install | | | ✅ (checks job) |
+| Capability inference, generation, selection, shrink, reporting logic | | | ✅ |
+
+The split is by **where the interpreter can reach**, not by how slow a file is.
+The package contains no `sys.version_info` branching, so what differs between
+3.10 and 3.12 is the boundary with the interpreter: the recursive
+`TypeAliasType` models in `agentcheck/domain/base.py` that every contract sits
+on, subprocess worker launch, import machinery, third-party SDK internals, and
+the `argparse` console entry point. All of those run everywhere. Pure logic over
+already-constructed objects runs once.
+
+The cross-version suite is 381 of 930 tests across 18 files and takes about six
+minutes, against roughly 22-26 for the full suite. It is not a smoke test.
+
+`tests/agentcheck/test_compat_manifest.py` fails if a category loses its files,
+if a listed file disappears, or if a listed file stops containing the symbols
+that made it evidence — and if `ci.yml` stops reading the list from the manifest.
+
+## Post-merge
+
+A pull request runs all three interpreters. A push to `main` runs only the
+primary, plus the full checks job.
+
+`pull_request` events already build and test the **merge result**, not the
+branch tip, so post-merge CI is not re-testing an untested tree. What it still
+catches is a merge race: `main` advancing between the moment PR CI ran and the
+moment the merge landed. That risk is real but interpreter-independent — a
+semantic conflict breaks on 3.12 exactly as it breaks on 3.10 — so re-running
+the other two versions after merge buys nothing and costs about 45 minutes of a
+serial queue.
+
 ## Where CI runs today
 
 | Workflow | Runner | Trigger | Why |

--- a/tests/agentcheck/test_compat_manifest.py
+++ b/tests/agentcheck/test_compat_manifest.py
@@ -1,0 +1,90 @@
+"""Keep the cross-version suite from quietly shrinking.
+
+The full suite runs on one interpreter; the manifest decides what still runs on
+all of them. That makes the manifest a coverage decision, and coverage decisions
+that live only in a YAML argument list get eroded by whoever is trying to make
+CI faster next.
+
+These tests fail if a category loses its files, if a listed file disappears, or
+if a listed file stops containing the symbols that made it evidence for its
+category in the first place. The last one matters most: a file can be gutted
+while keeping its name, and a manifest that only checks paths would not notice.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from tests.compat_manifest import COMPATIBILITY_SUITE, compatibility_paths
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# Losing any of these means the product's safety story stops being verified on
+# an interpreter it claims to support.
+REQUIRED_CATEGORIES = frozenset(
+    {
+        "domain-and-serialization",
+        "worker-and-isolation",
+        "tool-gateway-and-fail-closed",
+        "prerequisites-confirmation-followup",
+        "replay-and-source-integrity",
+        "adapters",
+        "cli-and-import",
+    }
+)
+
+
+def test_every_required_category_is_present() -> None:
+    missing = REQUIRED_CATEGORIES - set(COMPATIBILITY_SUITE)
+    assert not missing, (
+        f"the cross-version suite no longer covers {sorted(missing)}. Those "
+        "categories are the interpreter-facing surfaces; dropping one means "
+        "3.10 and 3.11 stop verifying it."
+    )
+
+
+@pytest.mark.parametrize("category", sorted(REQUIRED_CATEGORIES))
+def test_category_has_files_and_a_stated_reason(category: str) -> None:
+    entry = COMPATIBILITY_SUITE[category]
+    assert entry["files"], f"{category} has no test files"
+    assert str(entry["why"]).strip(), (
+        f"{category} has no stated reason. If it is not clear why the category "
+        "is interpreter-sensitive, it should not be costing two extra CI runs."
+    )
+
+
+@pytest.mark.parametrize("path", compatibility_paths())
+def test_listed_file_exists(path: str) -> None:
+    assert (REPOSITORY_ROOT / path).is_file(), (
+        f"{path} is in the cross-version manifest but does not exist. Either "
+        "restore it or move its coverage to another file in the same category."
+    )
+
+
+@pytest.mark.parametrize("category", sorted(REQUIRED_CATEGORIES))
+def test_each_file_still_evidences_its_category(category: str) -> None:
+    """A file can keep its name and lose its meaning; check the content."""
+
+    entry = COMPATIBILITY_SUITE[category]
+    symbols = tuple(entry["symbols"])  # type: ignore[arg-type]
+    for path in entry["files"]:  # type: ignore[union-attr]
+        text = (REPOSITORY_ROOT / str(path)).read_text(encoding="utf-8")
+        assert any(symbol in text for symbol in symbols), (
+            f"{path} is listed under {category} but no longer mentions any of "
+            f"{list(symbols)}. It may have been rewritten into something that "
+            "no longer provides that category's cross-version evidence."
+        )
+
+
+def test_manifest_matches_what_ci_runs() -> None:
+    """The workflow must run exactly the manifest, not a drifting copy of it."""
+
+    workflow = (REPOSITORY_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "compat_manifest" in workflow, (
+        "ci.yml no longer derives the compatibility suite from "
+        "tests/compat_manifest.py. Hard-coding the list in the workflow lets the "
+        "manifest and the matrix drift apart silently."
+    )

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -1,0 +1,136 @@
+"""The cross-version compatibility suite: what runs on every supported Python.
+
+The full suite runs once, on the newest supported interpreter. Running all 930
+tests three times costs about 70 minutes of a single self-hosted runner's
+serial queue, and most of that third and second pass re-executes pure logic that
+cannot behave differently between 3.10 and 3.12.
+
+What *can* differ is narrow and identifiable. The package contains no
+``sys.version_info`` branching at all, so cross-version risk is not in its
+control flow -- it is in the places where the package meets the interpreter:
+
+* ``agentcheck/domain/base.py`` builds its models on a **recursive**
+  ``TypeAliasType`` and an ``Annotated`` validator from ``typing_extensions``,
+  and defines ``canonical_hash``. Every contract, fingerprint and serialized
+  artifact in the product sits on top of that file.
+* Scenarios execute in **child processes** launched through ``subprocess`` with
+  an explicit interpreter and ``PYTHONPATH``. Spawn behaviour, environment
+  propagation and import bootstrapping are interpreter concerns.
+* Adapters read **framework-private attributes** from third-party SDKs, which
+  are themselves compiled against a Python version.
+* The CLI is an installed **entry point** parsed by ``argparse``.
+
+So the compatibility suite is chosen by *where the interpreter can reach*, not
+by how fast a file runs. Each category below names the property that would be
+silently lost if its files stopped running on 3.10 and 3.11.
+
+``test_compat_manifest.py`` enforces this: every file must exist, every category
+must be populated, and each file must still contain the symbols that make it
+evidence for its category. Removing coverage therefore fails a test rather than
+quietly shrinking the matrix.
+"""
+
+from __future__ import annotations
+
+
+# category -> (why it is interpreter-sensitive, test files, symbols that prove it)
+COMPATIBILITY_SUITE: dict[str, dict[str, object]] = {
+    "domain-and-serialization": {
+        "why": (
+            "Recursive TypeAliasType and Annotated validators from "
+            "typing_extensions underpin every contract; canonical_hash turns "
+            "them into fingerprints."
+        ),
+        "files": (
+            "tests/agentcheck/test_domain.py",
+            "tests/agentcheck/test_artifacts.py",
+            "tests/agentcheck/test_suite_compatibility.py",
+        ),
+        "symbols": ("fingerprint", "model_dump", "IncompatibleSuiteError", "redact"),
+    },
+    "worker-and-isolation": {
+        "why": (
+            "Scenarios run in child processes launched with an explicit "
+            "interpreter and PYTHONPATH; spawn and import bootstrap are "
+            "interpreter behaviour."
+        ),
+        "files": (
+            "tests/agentcheck/test_worker_process.py",
+            "tests/agentcheck/test_network_containment.py",
+        ),
+        "symbols": ("subprocess", "worker"),
+    },
+    "tool-gateway-and-fail-closed": {
+        "why": (
+            "Unknown tools must fail closed and original handlers must never "
+            "execute, on every interpreter the product claims to support."
+        ),
+        "files": (
+            "tests/agentcheck/test_world_gateway.py",
+            "tests/agentcheck/test_schema_safety.py",
+        ),
+        "symbols": ("ToolGateway", "unknown", "UnsafeSchema"),
+    },
+    "prerequisites-confirmation-followup": {
+        "why": (
+            "The interactive path drives a multi-stage run through the "
+            "orchestrator, so it exercises staged child-process execution end "
+            "to end."
+        ),
+        "files": (
+            "tests/agentcheck/test_prerequisite_fixtures.py",
+            "tests/agentcheck/test_interactive_scenarios.py",
+            "tests/agentcheck/test_confirmation_variant_cases.py",
+        ),
+        "symbols": ("prerequisite", "followup_turns", "confirmation"),
+    },
+    "replay-and-source-integrity": {
+        "why": (
+            "Replay reloads serialized manifests and re-binds a source "
+            "fileset, which is deserialization plus filesystem behaviour."
+        ),
+        "files": (
+            "tests/agentcheck/test_replay.py",
+            "tests/agentcheck/test_source_fileset.py",
+        ),
+        "symbols": ("manifest", "fileset"),
+    },
+    "adapters": {
+        "why": (
+            "Adapters read framework-private attributes from SDKs built "
+            "against a specific Python version."
+        ),
+        "files": (
+            "tests/agentcheck/test_openai_adapter.py",
+            "tests/agentcheck/test_pydantic_ai_adapter.py",
+            "tests/agentcheck/test_controlled_model.py",
+        ),
+        "symbols": ("adapter", "Adapter"),
+    },
+    "cli-and-import": {
+        "why": (
+            "Console entry point, argparse wiring, target import machinery and "
+            "the meta-path boundary check are all interpreter surfaces."
+        ),
+        "files": (
+            "tests/agentcheck/test_cli_e2e.py",
+            "tests/agentcheck/test_target_loading.py",
+            "tests/agentcheck/test_package_boundary.py",
+        ),
+        "symbols": ("main", "import"),
+    },
+}
+
+
+def compatibility_paths() -> list[str]:
+    """Every test file in the cross-version suite, deduplicated and ordered."""
+
+    seen: dict[str, None] = {}
+    for category in COMPATIBILITY_SUITE.values():
+        for path in category["files"]:  # type: ignore[union-attr]
+            seen.setdefault(str(path), None)
+    return list(seen)
+
+
+if __name__ == "__main__":
+    print("\n".join(compatibility_paths()))


### PR DESCRIPTION
One runner executes jobs serially, so a PR was waiting **~72 minutes**: three
full suites (22.6 / 22.1 / 25.7 min, measured on PR #3) plus checks at 1.6.

The second and third passes re-ran the same pure logic on a different
interpreter and found nothing — because there is nothing there to find.

## The evidence for splitting

**The package contains no `sys.version_info` branching at all.** Cross-version
risk is therefore not in its control flow; it is at the boundary with the
interpreter, and that boundary is small enough to name:

- `agentcheck/domain/base.py` builds every model on a **recursive
  `TypeAliasType`** plus an `Annotated` validator from `typing_extensions`, and
  defines `canonical_hash`. Every contract, fingerprint and artifact sits on it.
- Scenarios run in **child processes** launched via `subprocess` with an
  explicit interpreter and `PYTHONPATH`.
- Adapters read **framework-private attributes** from SDKs compiled against a
  Python version.
- The CLI is an installed **`argparse` entry point**.

Those run on all three versions. Capability inference, generation, selection,
shrink search and report rendering run once.

## Measured (idle machine)

| Suite | Tests | Wall |
|---|---|---|
| Cross-version | 381 | **6m11s** |
| Full | 964 | 15m25s |

The cross-version suite is 40% of the tests in 40% of the time — it is **not** a
smoke test. It runs real subprocess workers, the whole CLI pipeline end to end,
both adapters, the interactive `followup_turns` path, and the
replay/source-integrity chain. It deliberately keeps the slowest test in the
repository (a 186s end-to-end CLI workflow driving real child processes through
inspect → generate → test → replay → shrink → review), because a real entry
point driving real subprocesses is exactly what an interpreter change breaks.

## Coverage guard

The list lives in `tests/compat_manifest.py` with a stated reason per category,
and `ci.yml` **reads** it rather than repeating it.
`tests/agentcheck/test_compat_manifest.py` fails if a category loses its files,
if a listed file disappears, if a listed file stops containing the symbols that
made it evidence for its category, or if the workflow stops deriving the list
from the manifest. It caught two wrong symbol choices while being written.

## Post-merge

`pull_request` events already build and test the **merge result**, not the
branch tip — so post-merge CI is not covering an untested tree. What it still
catches is `main` advancing between PR CI and the merge landing. That risk is
**interpreter-independent**: a semantic conflict breaks on 3.12 exactly as on
3.10. So `push` now runs the primary interpreter plus full checks, and the other
two versions stop costing ~45 minutes to re-answer an answered question.

## Not done

- `-n 2` unchanged. Higher concurrency previously starved scenario budgets.
- No scenario wall-clock budget touched.
- No test deleted, no assertion weakened, no isolation bypassed.
- No job-level sharding — with one runner that would just queue.

## Verification

`test_compat_manifest.py` 34 passed · compat suite 381 passed · full suite 964
passed · ruff clean · workflow-safety PASS (2 self-hosted jobs still reject every
untrusted context). Provider requests 0, spend $0.