### PR TITLE
Public release prep: publishable package name, runner-name fix, prepared public CI

### DIFF
--- a/.github/workflows/ci-public.yml.disabled
+++ b/.github/workflows/ci-public.yml.disabled
@@ -1,0 +1,146 @@
+# The public CI workflow. NOT ACTIVE — the .disabled suffix keeps GitHub from
+# seeing it, because hosted minutes are billed while this repository is private.
+#
+# To activate at publication (see docs/ci-trust-model.md):
+#   git rm .github/workflows/ci.yml
+#   git mv .github/workflows/ci-public.yml.disabled .github/workflows/ci.yml
+#
+# What changed from the private workflow, and why:
+#
+#   * runs-on is ubuntu-latest everywhere. GitHub: "self-hosted runners should
+#     almost never be used for public repositories", because anyone who can fork
+#     and open a pull request can compromise the runner, its secrets and its
+#     GITHUB_TOKEN. Standard hosted runners are free for public repositories, so
+#     this costs nothing.
+#   * The trusted-context `if:` guards are gone. They existed only to keep fork
+#     pull requests off a workstation; with no self-hosted runner there is
+#     nothing to guard, and keeping them would silently skip every external
+#     contributor's CI.
+#   * actions/setup-python replaces uv. The uv indirection existed because
+#     setup-python's interpreters hard-code /opt/hostedtoolcache libpython paths
+#     that do not exist on a self-hosted runner. On a hosted runner that is the
+#     correct path.
+#   * pytest runs serially. -n 2 is measured for a 14-core workstation; a hosted
+#     runner has far fewer cores, and at -n 2 there the suite starved its own 10s
+#     scenario budget (10 failed / 920 passed on 3.11 and 3.12 while 3.10 passed,
+#     scenarios returning INFRA_ERROR). The budget is a product default and is
+#     never raised to buy CI headroom, so the worker count gives way instead.
+#
+# `pull_request` is used, never `pull_request_target`: fork pull requests must
+# not run with the base repository's token or secrets.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  PRIMARY_PYTHON: "3.12"
+
+jobs:
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # Hosted runners are free and run in parallel here, so every supported
+        # version runs on both triggers -- there is no serial queue to ration.
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Verify no provider credential reached this job
+        run: |
+          for name in OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY; do
+            if printenv "$name" >/dev/null 2>&1; then
+              echo "$name is present; the suite expects it absent" >&2
+              exit 1
+            fi
+          done
+          echo "PASS: no provider credential is visible to this job"
+
+      - name: Install
+        run: python -m pip install -e ".[dev]"
+
+      - name: Test
+        # Serial: see the header. Do not raise this to speed the build up.
+        run: |
+          if [ "${{ matrix.python-version }}" = "$PRIMARY_PYTHON" ]; then
+            python -m pytest -p no:cacheprovider tests -q
+          else
+            mapfile -t compat < <(python tests/compat_manifest.py)
+            echo "cross-version suite: ${#compat[@]} files"
+            python -m pytest -p no:cacheprovider "${compat[@]}" -q
+          fi
+
+  checks:
+    name: Quality, packaging, extras, and trust
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: python -m pip install -e ".[dev]"
+
+      - name: Workflow trust model
+        if: ${{ !cancelled() }}
+        run: python scripts/check_workflow_safety.py
+
+      - name: Ruff
+        if: ${{ !cancelled() }}
+        run: python -m ruff check agentcheck tests scripts
+
+      - name: Mypy
+        if: ${{ !cancelled() }}
+        run: python -m mypy agentcheck
+
+      - name: Secret scan
+        if: ${{ !cancelled() }}
+        run: python scripts/check_no_secrets.py
+
+      - name: Base install has no framework
+        if: ${{ !cancelled() }}
+        run: |
+          python -m venv /tmp/base && /tmp/base/bin/python -m pip install --quiet .
+          /tmp/base/bin/python - <<'PY'
+          import importlib.util
+          for framework in ("agents", "pydantic_ai"):
+              assert importlib.util.find_spec(framework) is None, framework
+          import agentcheck; print("base import ok:", agentcheck.__version__)
+          PY
+          /tmp/base/bin/agentcheck --help > /dev/null
+
+      - name: Build and audit artifacts
+        if: ${{ !cancelled() }}
+        run: |
+          python -m build
+          python scripts/check_distribution.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 # ============================================================================
 # READ BEFORE MAKING THIS REPOSITORY PUBLIC
 # ============================================================================
-# Every job below runs on `agentlens-local`, a self-hosted runner that is a
+# Every job below runs on `agentcheck-local`, a self-hosted runner that is a
 # maintainer's own workstation. That is acceptable *only* while this repository
 # is private and every branch in it is written by the owner.
 #

--- a/README.md
+++ b/README.md
@@ -72,16 +72,27 @@ ambiguous account to the wrong ID, retries a destructive call after a timeout,
 claims an email update succeeded when the tool errored, applies the same side
 effect twice). That is the demonstration, not a bug.
 
-Once a release is published the install will be
-`pip install "agentcheck[openai-agents]"`. **That does not work today** — the
-name is not ours on PyPI yet, and the package is unpublished.
+### Once published
+
+The distribution will be **`agentcheck-ai`**, so the install will be:
+
+```bash
+pip install "agentcheck-ai[openai-agents]"
+```
+
+The import package and the command stay `agentcheck` either way —
+`import agentcheck`, `agentcheck --help`. Only the name you `pip install`
+differs, the way `scikit-learn` installs `sklearn`.
+
+**Do not `pip install agentcheck`.** That name on PyPI belongs to an unrelated
+project, and nothing here has been published yet. Use the source install above.
 
 ## Supported frameworks
 
 | Framework | Extra | Supported versions |
 |---|---|---|
-| OpenAI Agents SDK | `agentcheck[openai-agents]` | `openai-agents >=0.20,<0.21` |
-| PydanticAI | `agentcheck[pydantic-ai]` | `pydantic-ai-slim >=2.32,<2.33` |
+| OpenAI Agents SDK | `agentcheck-ai[openai-agents]` | `openai-agents >=0.20,<0.21` |
+| PydanticAI | `agentcheck-ai[pydantic-ai]` | `pydantic-ai-slim >=2.32,<2.33` |
 
 No other framework is supported. There is no partial or best-effort mode, and
 LangGraph, CrewAI, AutoGen and others are **not** supported.

--- a/docs/ci-trust-model.md
+++ b/docs/ci-trust-model.md
@@ -12,7 +12,7 @@ version runs the cross-version suite defined in `tests/compat_manifest.py`.
 
 | | Py3.10 | Py3.11 | Py3.12 |
 |---|---|---|---|
-| Full behavioural suite (930 tests) | | | ✅ |
+| Full behavioural suite (964 tests) | | | ✅ |
 | Domain models, serialization, fingerprints | ✅ | ✅ | ✅ |
 | Worker / process isolation | ✅ | ✅ | ✅ |
 | ToolGateway, fail-closed, unknown tools | ✅ | ✅ | ✅ |
@@ -33,8 +33,9 @@ on, subprocess worker launch, import machinery, third-party SDK internals, and
 the `argparse` console entry point. All of those run everywhere. Pure logic over
 already-constructed objects runs once.
 
-The cross-version suite is 381 of 930 tests across 18 files and takes about six
-minutes, against roughly 22-26 for the full suite. It is not a smoke test.
+The cross-version suite is 381 of 964 tests across 18 files. Measured on the
+self-hosted runner it takes about 8 minutes per interpreter, against 21 for the
+full suite. It is not a smoke test.
 
 `tests/agentcheck/test_compat_manifest.py` fails if a category loses its files,
 if a listed file disappears, or if a listed file stops containing the symbols
@@ -57,7 +58,7 @@ serial queue.
 
 | Workflow | Runner | Trigger | Why |
 |---|---|---|---|
-| `ci.yml` | `[self-hosted, Linux, X64]` (`agentlens-local`) | `push`, `pull_request` | Every branch here is written by the owner, and GitHub-hosted minutes are billed against the account while the repository is private. |
+| `ci.yml` | `[self-hosted, Linux, X64]` (`agentcheck-local`) | `push`, `pull_request` | Every branch here is written by the owner, and GitHub-hosted minutes are billed against the account while the repository is private. |
 | `agentcheck-example.yml` | `ubuntu-latest` | `workflow_dispatch` | Deliberately GitHub-hosted — see below. |
 
 ## Why the example workflow stays GitHub-hosted
@@ -100,6 +101,33 @@ CI and in the test suite. It also fails if a `ci.yml` job drifts *back* to a
 GitHub-hosted label, because that spends billed minutes silently — nothing
 breaks, the bill just grows.
 
+## Why the answer is simply "move to GitHub-hosted"
+
+Two facts, both verified against GitHub's own documentation rather than assumed,
+decide this:
+
+**1. Self-hosted runners are the wrong tool for a public repository.** GitHub's
+security hardening guide states that "self-hosted runners should almost never be
+used for public repositories", because "anyone who can fork the repository and
+open a pull request ... are able to compromise the self-hosted runner
+environment, including gaining access to secrets and the `GITHUB_TOKEN`".
+
+**2. The cost objection disappears when the repository is public.** Standard
+GitHub-hosted runners are **free with no minute allowance to exhaust** for public
+repositories — "GitHub Actions usage is free for self-hosted runners and for
+public repositories that use standard GitHub-hosted runners". (Larger runners are
+always billed, including on public repositories; standard runners are what this
+project needs.)
+
+The only reason CI is self-hosted today is that hosted minutes *are* billed for
+**private** repositories, and this account exhausted them. Publication removes
+that constraint entirely. There is no trade-off to weigh: going public makes the
+secure option also the free one.
+
+Sources:
+- Security hardening for GitHub Actions — <https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions>
+- About billing for GitHub Actions — <https://docs.github.com/en/billing/managing-billing-for-your-products/about-billing-for-github-actions>
+
 ## What must change before this repository becomes public
 
 The guard does not fail open, so publication would not instantly expose the
@@ -115,7 +143,7 @@ So, before publication:
 1. **Move `ci.yml`'s `tests` and `checks` jobs back to GitHub-hosted runners**
    (`runs-on: ubuntu-latest`), or to properly isolated ephemeral self-hosted
    runners that are destroyed after each job.
-2. **Remove the `if:` guards** once no job targets `agentlens-local`, since they
+2. **Remove the `if:` guards** once no job targets `agentcheck-local`, since they
    exist only to protect that runner.
 3. **Restore `actions/setup-python`** in place of the `uv`-provisioned
    interpreters if hosted runners are used. The `uv` approach exists because
@@ -129,13 +157,13 @@ So, before publication:
    Scenarios came back `INFRA_ERROR` instead of real verdicts. The fix is fewer
    pytest workers or sharding across jobs — **never** a larger scenario budget,
    which would trade away the signal that detects a starved run.
-5. **Do not attach `agentlens-local` to this repository's runner list**, and do
+5. **Do not attach any self-hosted runner to this repository**, and do
    not use `pull_request_target` anywhere.
 6. **Enable private vulnerability reporting** in the repository's Security
    settings. GitHub only offers it on public repositories, so it cannot be
    turned on before publication — and `SECURITY.md` directs researchers to it.
 7. **Scrub the runner references.** This document and `ci.yml` name
-   `agentlens-local` because that is operationally accurate today. Once CI moves
+   `agentcheck-local` because that is operationally accurate today. Once CI moves
    to hosted or ephemeral runners those names are stale, and a public repository
    should not carry the label of a machine it no longer uses.
 8. **Budget for the minutes.** Actions minutes are free on public
@@ -144,6 +172,23 @@ So, before publication:
    minutes of job time, most of it three full-suite jobs at 23–29 minutes each,
    and the account then declined to start further hosted jobs.
 
+### The prepared replacement
+
+`.github/workflows/ci-public.yml.disabled` is the finished public workflow. It is
+deliberately **not** a `.yml` file, so GitHub ignores it and it cannot run while
+this repository is private and hosted minutes are billed.
+
+Publication is then two file operations:
+
+```bash
+git rm .github/workflows/ci.yml
+git mv .github/workflows/ci-public.yml.disabled .github/workflows/ci.yml
+```
+
+Everything else in the checklist above is already satisfied by that file: hosted
+runners, no self-hosted label, no trusted-context guards, `actions/setup-python`
+instead of uv, and pytest concurrency reduced for a smaller machine.
+
 `tests/agentcheck/test_workflow_safety.py::test_publication_checklist_is_discoverable`
 asserts this document exists and that `ci.yml` carries the warning inline, so
 the decision cannot quietly disappear.
@@ -151,4 +196,4 @@ the decision cannot quietly disappear.
 ## The rule that does not change
 
 **Arbitrary code from a public pull request must never execute on
-`agentlens-local`,** whatever else is convenient.
+`agentcheck-local`,** whatever else is convenient.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,17 @@ requires = ["setuptools>=83,<84", "wheel>=0.45,<1"]
 build-backend = "setuptools.build_meta"
 
 [project]
-# OWNER DECISION REQUIRED BEFORE ANY RELEASE.
-# The PyPI name `agentcheck` is already registered to an unrelated project
-# ("Trace . Replay . Test your AI agents like real software", 0.1.0, uploaded
-# 2025-07-01). This name therefore cannot be uploaded as-is. The import package
-# and the CLI can still be `agentcheck` whatever is decided; only the
-# distribution name is contested. Nothing here is published, so this stays as a
-# statement of intent until the owner picks a path.
-name = "agentcheck"
+# The distribution name is not the import name, deliberately.
+#
+# `agentcheck` on PyPI belongs to an unrelated project (one release, 2025-07-01),
+# so publishing under it is not possible and telling users to `pip install
+# agentcheck` would install somebody else's software. The distribution is
+# therefore `agentcheck-ai`, while the import package and the console command
+# both stay `agentcheck` -- the same split scikit-learn/sklearn has used for
+# years, and invisible in day-to-day use:
+#
+#     pip install agentcheck-ai      import agentcheck      agentcheck --help
+name = "agentcheck-ai"
 # This version is not only release metadata. It is recorded as
 # `provenance.generator_version` inside every frozen suite, and the suite
 # fingerprint is a hash of that document. Bumping it re-identifies every
@@ -56,11 +59,11 @@ pydantic-ai = [
     "pydantic-ai-slim>=2.32,<2.33",
 ]
 all = [
-    "agentcheck[openai-agents]",
-    "agentcheck[pydantic-ai]",
+    "agentcheck-ai[openai-agents]",
+    "agentcheck-ai[pydantic-ai]",
 ]
 dev = [
-    "agentcheck[all]",
+    "agentcheck-ai[all]",
     "build>=1.3,<2",
     # Ruff's and mypy's default rule sets move between minors, so an unpinned
     # range means a lint failure lands on whoever installs next rather than on

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -32,7 +32,13 @@ FORBIDDEN = (
 
 # The wheel is the installed package. Tests, examples, and docs belong in the
 # sdist and the repository, not in every user's site-packages.
-WHEEL_ALLOWED = re.compile(r"^(agentcheck/|agentcheck-[^/]*\.dist-info/)")
+#
+# The import package and the distribution have different names on purpose --
+# `agentcheck` is imported, `agentcheck-ai` is installed -- and a wheel's
+# dist-info directory is named after the distribution, with dashes normalised to
+# underscores. Matching that shape rather than a literal keeps this check honest
+# if either name changes again.
+WHEEL_ALLOWED = re.compile(r"^(agentcheck/|[A-Za-z0-9_.]+-[^/]*\.dist-info/)")
 
 
 def _members(path: pathlib.Path) -> list[str]:


### PR DESCRIPTION
Release preparation only. **No product source changed** — `agentcheck/` is untouched, `-n 2` unchanged, no safety budget touched.

## Blocker fixed: the documented install would have installed the wrong project

The README said the future install is `pip install "agentcheck[openai-agents]"`. **`agentcheck` on PyPI belongs to an unrelated project** (one release, 2025-07-01) — re-verified live, not taken from earlier notes.

Distribution becomes **`agentcheck-ai`** (verified available). Import package and CLI stay `agentcheck`:

```
pip install agentcheck-ai      import agentcheck      agentcheck --help
```

Same split `scikit-learn`/`sklearn` uses. It costs nothing here because the adapters already resolve their providing distribution at runtime — the missing-extra message now reads ``pip install 'agentcheck-ai[pydantic-ai]'`` with no string to keep in sync.

Verified from a clean venv against the built wheel: `agentcheck-ai 0.1.0` installs, `import agentcheck` resolves to site-packages, `agentcheck --version` works, `packages_distributions()['agentcheck'] == ['agentcheck-ai']`, console script `agentcheck` present, no AgentLens module importable.

## Correction: the docs named the wrong machine

`ci.yml` and `docs/ci-trust-model.md` both said jobs run on **`agentlens-local`**. They run on **`agentcheck-local`** — the wrong name was carried over when the workflow was ported from AgentLens. Naming the wrong machine in a security document is the kind of error someone acts on.

Also corrected: the trust model still quoted *930 tests / 22–26 min*. It is **964 / 21**.

## Prepared public CI (inert)

`.github/workflows/ci-public.yml.disabled` — GitHub cannot see it, so it cannot run or spend minutes while this repo is private. Publication becomes one `git mv`.

Grounded in two facts now cited with sources in the trust model:

- GitHub: *"self-hosted runners should almost never be used for public repositories"*, because anyone who can fork and open a PR *"[is] able to compromise the self-hosted runner environment, including gaining access to secrets and the `GITHUB_TOKEN`"*.
- Standard hosted runners are **free with no minute allowance** for public repositories.

So the cost argument that put CI on a workstation disappears at publication — the secure option is also the free one. The prepared workflow uses `pull_request` (never `pull_request_target`), hosted runners, no trust guards (nothing to guard), `actions/setup-python`, and serial pytest (hosted runners starved the 10s scenario budget at `-n 2`).

## Verification

ruff clean · mypy clean (83 files) · workflow-trust PASS · secret scan PASS · 145 focused tests passed · wheel 83 modules + metadata only · sdist clean · **full README walkthrough from a fresh clone**: install → inspect → generate → test (30 passed / 5 failed, as documented) → report, all exit 0.

Provider requests 0, spend $0. Repository remains private; nothing published.