### PR TITLE
Add the framework-neutral custom-agent runtime contracts without enabling custom-agent execution

### DIFF
--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -1,6 +1,13 @@
 """AgentCheck: deterministic, local evaluation for AI agents."""
 
 from .config import AgentCheckConfig, load_config
+from .custom import CustomAgentProtocol, ToolRuntime, TurnResult
 
-__all__ = ["AgentCheckConfig", "load_config"]
+__all__ = [
+    "AgentCheckConfig",
+    "CustomAgentProtocol",
+    "ToolRuntime",
+    "TurnResult",
+    "load_config",
+]
 __version__ = "0.1.0"

--- a/agentcheck/custom.py
+++ b/agentcheck/custom.py
@@ -1,0 +1,99 @@
+"""Contracts a custom agent implements to be evaluated by AgentCheck.
+
+AgentCheck supports the OpenAI Agents SDK and PydanticAI by rebuilding the
+target from its declared surface, so the original tool handlers are never
+reachable. An agent written directly against a model API has no framework
+surface to rebuild from, so the same guarantee has to come from somewhere else.
+
+It comes from what AgentCheck is *given*. A custom agent declares its tools as
+``ToolDefinition`` -- a name, a schema and risk flags, with no callable
+anywhere -- and receives a ``ToolRuntime`` to call them through. AgentCheck
+therefore never holds a reference to ``cancel_order``, which is why it cannot
+execute it. That is a structural property, not a promise to be careful.
+
+What this does *not* cover is a side effect written directly into the
+orchestration loop rather than behind a declared tool. That code is the agent,
+so it has to run. Process isolation, an empty environment allowlist and
+socket-level network denial catch the common escapes; a local filesystem write
+inside reasoning code is not preventable, and the documentation says so rather
+than implying a sandbox.
+
+These types are contracts only. Nothing here executes a custom agent yet: the
+adapter, the configuration surface and the CLI wiring are separate work, and
+landing the shape first keeps that work reviewable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+from agentcheck.domain.agent_spec import ToolDefinition
+from agentcheck.domain.run import ToolOutcome
+
+
+__all__ = ["CustomAgentProtocol", "ToolRuntime", "TurnResult"]
+
+
+@runtime_checkable
+class ToolRuntime(Protocol):
+    """The only way a custom agent is allowed to reach a tool.
+
+    Implemented by AgentCheck over the existing ``ToolGateway``, so a call is
+    matched against the scenario's fixtures, validated against the declared
+    schema, and refused if the tool was never declared. The agent's own
+    handlers are not involved at any point.
+
+    Synchronous because ``ToolGateway.invoke`` is synchronous, and because a
+    custom loop should not have to become async to be testable.
+    """
+
+    def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
+        """Simulate one tool call and return its canonical outcome.
+
+        The returned ``ToolOutcome`` carries ``status`` and ``error`` as well as
+        ``result``, so a loop can react to a simulated failure or an ambiguous
+        outcome the way it would react to a real one. Raises rather than
+        returning a plausible value when the tool is unknown or the arguments do
+        not satisfy the declared schema: a harness that invents tool output
+        invents passing runs.
+        """
+        ...
+
+
+@dataclass
+class TurnResult:
+    """What one turn of a custom agent produced.
+
+    ``state`` is opaque to AgentCheck and is handed straight back to ``resume``
+    on the next turn. It stays in the worker process and is never serialized,
+    which keeps arbitrary user objects out of any wire format and keeps pickle
+    out of the design entirely.
+    """
+
+    output: Any
+    state: Any = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class CustomAgentProtocol(Protocol):
+    """The minimum a custom agent implements to be evaluated.
+
+    AgentCheck drives *turns*; the agent drives its own tool loop within a turn.
+    A scenario's opening request becomes ``start``, and each ``followup_turn``
+    becomes a ``resume`` -- which is what makes a confirmation flow expressible:
+    the agent asks, the scenario answers, and the destructive call happens
+    afterwards or not at all.
+    """
+
+    tools: Sequence[ToolDefinition]
+    """Declared tools. Names, schemas and risk flags -- never callables."""
+
+    def start(self, message: str, tools: ToolRuntime) -> TurnResult:
+        """Handle the scenario's opening user message."""
+        ...
+
+    def resume(self, state: Any, message: str, tools: ToolRuntime) -> TurnResult:
+        """Continue from a previous turn's state with a follow-up message."""
+        ...

--- a/tests/agentcheck/test_custom_agent_contract.py
+++ b/tests/agentcheck/test_custom_agent_contract.py
@@ -1,0 +1,223 @@
+"""The custom-agent contracts, and what they deliberately do not contain.
+
+These are typing tests, and typing tests earn their place here for one reason:
+the safety argument for custom agents is a property of the *shape* of the
+contract. AgentCheck cannot execute ``cancel_order`` because it is never handed
+``cancel_order``. If a future change adds a handler field for convenience, that
+argument silently becomes "we promise not to call it", and nothing else in the
+suite would notice. `test_contract_never_accepts_a_callable_handler` is the one
+that would.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import fields, is_dataclass
+from typing import Any, Mapping, Sequence, get_type_hints
+
+import pytest
+
+from agentcheck import CustomAgentProtocol, ToolRuntime, TurnResult
+from agentcheck.adapters import FrameworkAdapter, OpenAIAgentsAdapter, PydanticAIAdapter
+from agentcheck.domain.agent_spec import ToolDefinition
+from agentcheck.domain.run import ToolOutcome, ToolOutcomeStatus
+
+
+# --------------------------------------------------------------------------
+# The common runtime contract
+# --------------------------------------------------------------------------
+
+
+def test_framework_adapter_declares_the_universal_run_contract() -> None:
+    """The four-method contract a custom-agent adapter will have to satisfy.
+
+    ``run()`` is already abstract here -- this pins it, because it is the method
+    the worker calls to execute a prepared target and the reason a custom agent
+    can become a fourth adapter rather than a second execution path through the
+    runner. Nothing in this PR adds it; the test exists so a later refactor
+    cannot quietly drop it.
+    """
+
+    assert FrameworkAdapter.__abstractmethods__ == frozenset(
+        {"inspect", "preflight", "prepare", "run"}
+    )
+
+
+@pytest.mark.parametrize("adapter", [OpenAIAgentsAdapter, PydanticAIAdapter])
+def test_existing_adapters_still_satisfy_the_interface(adapter: type) -> None:
+    """Declaring run() must not have made a shipped adapter abstract."""
+
+    assert issubclass(adapter, FrameworkAdapter)
+    assert not getattr(adapter, "__abstractmethods__", frozenset()), (
+        f"{adapter.__name__} became abstract, which means the declared contract "
+        "does not match what it already implements."
+    )
+    adapter()  # constructible, so nothing was left unimplemented
+
+
+@pytest.mark.parametrize("adapter", [OpenAIAgentsAdapter, PydanticAIAdapter])
+def test_adapter_run_signature_matches_the_declared_contract(adapter: type) -> None:
+    """The declaration describes the adapters; the adapters were not reshaped."""
+
+    declared = inspect.signature(FrameworkAdapter.run)
+    actual = inspect.signature(adapter.run)
+    assert list(actual.parameters) == list(declared.parameters), (
+        f"{adapter.__name__}.run parameters drifted from the declared contract"
+    )
+    for name, parameter in declared.parameters.items():
+        assert actual.parameters[name].kind == parameter.kind, name
+        assert actual.parameters[name].default == parameter.default, name
+
+
+@pytest.mark.parametrize("adapter", [OpenAIAgentsAdapter, PydanticAIAdapter])
+def test_adapter_run_is_still_a_coroutine_function(adapter: type) -> None:
+    assert inspect.iscoroutinefunction(adapter.run)
+
+
+# --------------------------------------------------------------------------
+# The custom-agent contracts
+# --------------------------------------------------------------------------
+
+
+class _ExampleAgent:
+    """The smallest thing that satisfies the protocol.
+
+    Deliberately holds no callable for its tools: it declares them and reaches
+    them only through the supplied runtime.
+    """
+
+    tools: Sequence[ToolDefinition] = (
+        ToolDefinition(name="get_order", input_schema={"type": "object"}),
+        ToolDefinition(
+            name="cancel_order",
+            input_schema={"type": "object"},
+            state_changing=True,
+            destructive=True,
+        ),
+    )
+
+    def start(self, message: str, tools: ToolRuntime) -> TurnResult:
+        outcome = tools.call("get_order", {"order_id": "W1"})
+        return TurnResult(output=f"found {outcome.tool_name}", state={"seen": True})
+
+    def resume(self, state: Any, message: str, tools: ToolRuntime) -> TurnResult:
+        tools.call("cancel_order", {"order_id": "W1"})
+        return TurnResult(output="cancelled", state=state)
+
+
+class _RecordingRuntime:
+    """A stand-in runtime. Records calls; executes nothing."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+    def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
+        self.calls.append((name, dict(arguments)))
+        return ToolOutcome(
+            outcome_id=f"outcome-{len(self.calls)}",
+            attempt_id=f"attempt-{len(self.calls)}",
+            event_id=f"event-{len(self.calls)}",
+            tool_name=name,
+            status=ToolOutcomeStatus.SUCCESS,
+            result={"ok": True},
+        )
+
+
+def test_a_minimal_agent_satisfies_the_protocol() -> None:
+    assert isinstance(_ExampleAgent(), CustomAgentProtocol)
+
+
+def test_a_runtime_stand_in_satisfies_the_tool_runtime_protocol() -> None:
+    assert isinstance(_RecordingRuntime(), ToolRuntime)
+
+
+def test_turns_thread_state_and_reach_tools_only_through_the_runtime() -> None:
+    agent, runtime = _ExampleAgent(), _RecordingRuntime()
+
+    first = agent.start("cancel my order", runtime)
+    assert first.state == {"seen": True}
+
+    second = agent.resume(first.state, "yes, cancel it", runtime)
+    assert second.output == "cancelled"
+    assert second.state == first.state, "opaque state is handed back unchanged"
+
+    assert [name for name, _ in runtime.calls] == ["get_order", "cancel_order"]
+
+
+def test_turn_result_keeps_state_opaque_and_unserialized() -> None:
+    """State is an in-process handle, so it may be any object at all."""
+
+    sentinel = object()
+    result = TurnResult(output="done", state=sentinel)
+    assert result.state is sentinel
+    assert result.metadata == {}
+    assert is_dataclass(TurnResult)
+
+
+# --------------------------------------------------------------------------
+# The property the whole design rests on
+# --------------------------------------------------------------------------
+
+
+def test_contract_never_accepts_a_callable_handler() -> None:
+    """No path in the contract carries a real tool implementation.
+
+    AgentCheck's zero-execution guarantee for declared tools is structural: it
+    holds no reference to the function, so it cannot call it. A field named
+    `handler`, `callable`, `fn` or similar would quietly downgrade that to a
+    promise.
+    """
+
+    banned = ("handler", "callable", "func", "fn", "impl", "target", "tool_callable")
+
+    for name in [field.name for field in fields(TurnResult)]:
+        assert not any(token in name.lower() for token in banned), name
+
+    for name in ToolDefinition.model_fields:
+        assert not any(token in name.lower() for token in banned), (
+            f"ToolDefinition.{name} looks like a handler reference"
+        )
+
+    hints = get_type_hints(_ExampleAgent)
+    assert "Callable" not in str(hints.get("tools", "")), (
+        "declared tools must be data, not callables"
+    )
+
+
+def test_tool_runtime_exposes_only_simulated_calls() -> None:
+    """One method in, canonical outcome out -- no escape hatch."""
+
+    public = [
+        name
+        for name in dir(ToolRuntime)
+        if not name.startswith("_") and callable(getattr(ToolRuntime, name, None))
+    ]
+    assert public == ["call"], f"ToolRuntime grew extra surface: {public}"
+
+    returns = inspect.signature(ToolRuntime.call).return_annotation
+    assert "ToolOutcome" in str(returns), (
+        "a simulated call must return the canonical outcome, so a custom loop "
+        "sees simulated failures and ambiguity the way a real one would"
+    )
+
+
+def test_custom_contracts_are_importable_from_both_paths() -> None:
+    from agentcheck import custom
+
+    assert custom.ToolRuntime is ToolRuntime
+    assert custom.TurnResult is TurnResult
+    assert custom.CustomAgentProtocol is CustomAgentProtocol
+    assert set(custom.__all__) == {"CustomAgentProtocol", "ToolRuntime", "TurnResult"}
+
+
+def test_custom_agent_execution_is_not_wired_up_yet() -> None:
+    """PR A is contracts only; nothing may execute a custom agent."""
+
+    from agentcheck.config import AgentCheckConfig
+    from agentcheck.runner import worker
+
+    adapters = getattr(worker, "_ADAPTERS", {})
+    assert "custom" not in adapters, "a custom adapter was registered too early"
+
+    annotation = str(AgentCheckConfig.model_fields["adapter"].annotation)
+    assert "custom" not in annotation, "config gained a custom adapter option"

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -116,6 +116,10 @@ COMPATIBILITY_SUITE: dict[str, dict[str, object]] = {
             "tests/agentcheck/test_cli_e2e.py",
             "tests/agentcheck/test_target_loading.py",
             "tests/agentcheck/test_package_boundary.py",
+            # Protocol runtime-checkability and typing behaviour differ between
+            # interpreters, and this contract must hold on every version the
+            # package claims to support.
+            "tests/agentcheck/test_custom_agent_contract.py",
         ),
         "symbols": ("main", "import"),
     },


### PR DESCRIPTION
Contracts only. **No product runtime code changed** — no adapter, runner, domain, or replay file is touched, and `config.py`/`worker.py` are untouched.

## Why these types

The two supported adapters make original tool handlers unreachable by *rebuilding the agent from its declared surface*. A custom agent has no such surface, so the guarantee has to come from what AgentCheck is handed:

- tools are declared as the existing **`ToolDefinition`** — name, schema, risk flags, **no callable**
- the agent reaches them only through an AgentCheck-supplied **`ToolRuntime`**

AgentCheck never holds a reference to `cancel_order`, which is why it cannot execute it. Structural, not a promise.

## Design choices worth reviewing

- **`ToolRuntime.call` is synchronous and returns `ToolOutcome`** — matching `ToolGateway.invoke`, and so a custom loop need not become async to be testable. Returning the canonical outcome (not a bare result) means a loop sees simulated failure and ambiguity the way it would see real ones.
- **`TurnResult.state` is opaque and never serialized.** It stays in the worker process, so arbitrary user objects never reach a wire format and **pickle stays out of the design**.
- **AgentCheck drives turns; the agent drives its tool loop within one.** That is what makes confirmation expressible: agent asks → scenario answers via `followup_turns` → destructive call happens after consent, or not at all.

## Correction to an earlier finding

`FrameworkAdapter.run()` **was already abstract on main.** My earlier inspection grepped `"    def "`, which does not match `async def`, so I reported a gap that did not exist. **`base.py` needed no change.** The test pins the four-method contract regardless, since that is what a future custom adapter must satisfy.

## Nothing executes yet

`test_custom_agent_execution_is_not_wired_up_yet` asserts there is no `custom` entry in the adapter registry and no `custom` option on the config, so the next PR has to add them deliberately.

`test_contract_never_accepts_a_callable_handler` asserts no field on the new surface looks like a handler reference — that is the property the whole design rests on, and a convenience field would downgrade it silently.

## Verification

15 contract tests · 35 manifest-guard tests · 64 schema/fingerprint/worker regression tests · ruff clean · mypy clean (84 files). Added to the cross-version manifest, since protocol runtime-checking differs between interpreters.

No schema changed: `AgentSpec`, `ToolDefinition`, `Scenario`, `ToolFixture`, worker protocol, fingerprints all untouched. `-n 2` and safety budgets unchanged. Provider requests 0, spend $0.