### PR TITLE
Improve developer experience for public alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ tests the wrong thing. AgentCheck refuses the version instead of guessing. The
 custom integration has no framework version to widen: preflight validates its
 small public contract directly.
 
+### SDK setup and offline runs
+
+For PydanticAI, follow the
+[self-contained setup guide](docs/pydantic-ai.md) or run the
+[credential-free worked example](examples/evaluation/pydantic_agent/README.md).
+It covers the exact supported extra, target export, fixtures and prerequisites,
+`inspect` / `generate` / `test`, and the difference between a local scripted
+model and ControlledModel.
+
+For OpenAI Agents SDK, install the verified
+`agentcheck-ai[openai-agents]` extra (`openai-agents >=0.20,<0.21`). Set
+`"controlled_model": true` in `agentcheck.json` to substitute AgentCheck's
+deterministic, neutral offline model during evaluation. It makes no provider
+request and never chooses a tool, so check the CLI's action-path coverage before
+treating a passing action case as exercised. The bundled
+[account-support example](examples/evaluation/account_agent/README.md) instead
+uses a local scripted SDK model to exercise tool calls without a provider.
+
 ## How evaluation works
 
 ```text
@@ -270,6 +288,9 @@ there is outside the declared-tool guarantee. Isolation and denied egress remain
 active, but AgentCheck does not claim they sandbox arbitrary local Python side
 effects.
 
+Network denial is not a general operating-system sandbox and does not stop
+those local effects.
+
 These are the properties the test suite is built around; see
 [CONTRIBUTING.md](CONTRIBUTING.md) for the invariants contributors must preserve.
 
@@ -313,7 +334,7 @@ These are the properties the test suite is built around; see
 ```bash
 python -m pip install -e ".[dev]"  # agentcheck-ai[dev] from this checkout
 
-python -m pytest tests -q                                   # full suite
+python -m pytest tests -q -n 2                              # full suite
 python -m pytest tests/agentcheck/test_openai_adapter.py -q  # focused
 python -m ruff check agentcheck tests scripts
 python -m mypy agentcheck

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,10 @@ Understand the boundary before relying on it:
   passed to a worker unless you explicitly add them.
 - **Network is denied by default.** Reaching a non-allowlisted destination is
   reported as a containment failure rather than silently permitted.
+- **The declared-tool guarantee is not a general Python sandbox.** Target
+  imports execute. Direct filesystem writes, subprocess execution, and direct
+  local-database access performed by imports or custom orchestration are outside
+  the guarantee; network denial does not prevent those local effects.
 - **Artifacts are redacted** with bounded credential redaction before being
   written or printed. Redaction is best-effort pattern matching: it is not a
   guarantee that a novel secret format will be caught. Treat run artifacts as

--- a/agentcheck/cli.py
+++ b/agentcheck/cli.py
@@ -28,7 +28,13 @@ from agentcheck.fixtures import (
     FIXTURE_PACK_CONTRACT_VERSION,
     load_representative_inputs,
 )
-from agentcheck.domain import AgentSpec, Severity, Verdict, action_path_exercise
+from agentcheck.domain import (
+    AgentSpec,
+    CaseEvaluation,
+    Severity,
+    Verdict,
+    action_path_exercise,
+)
 from agentcheck.errors import ConfigurationError, ScenarioValidationError
 from agentcheck.generate.boundaries import (
     AUTHORED_REQUEST_TAG,
@@ -51,6 +57,9 @@ from agentcheck.shrink import (
 
 
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$")
+_CONSOLE_ERROR_CODE_CHARS = 80
+_CONSOLE_ERROR_MESSAGE_CHARS = 320
+_TRUNCATION_MARKER = "...[TRUNCATED]"
 
 
 def _run_id(value: str) -> str:
@@ -147,7 +156,8 @@ def _parser() -> argparse.ArgumentParser:
         description=(
             "Write an explicit local AgentCheck configuration. This command never "
             "imports or executes the target, so it is safe to run against code that "
-            "has not been reviewed yet."
+            "has not been reviewed yet. TARGET must already be an existing directory; "
+            "init does not create it."
         ),
     )
     init_parser.add_argument("target", nargs="?", default=".")
@@ -271,10 +281,13 @@ def _parser() -> argparse.ArgumentParser:
             "run a compatible frozen suite or the matching built-in suite. "
             "account_support_v1 is used only when the spec declares that suite's "
             "required tools. A supported target with no compatible suite is not "
-            "PASS; run generate or provide a frozen suite. Network access is "
-            "disabled during evaluation so a target cannot cause external side "
-            'effects; set "allow_network": true in agentcheck.json to reach a '
-            "real provider."
+            "PASS; run generate or provide a frozen suite. Declared tool calls are "
+            "simulated by AgentCheck and never reach their original handlers. "
+            "Network is denied by default, but the target remains trusted code: "
+            "direct filesystem writes, subprocess execution, and local database "
+            "access in imports or orchestration are outside the declared-tool "
+            'guarantee. Set "allow_network": true in agentcheck.json only when a '
+            "real provider is intentionally required."
         ),
     )
     test_parser.add_argument("target", nargs="?", default=".")
@@ -899,6 +912,42 @@ def _print_custom_integration_hint(source: Path) -> None:
         "Call your model inside start()/resume(), and route every declared tool "
         "request through tools.call(...), which AgentCheck simulates."
     )
+    print(
+        "This starter demonstrates the integration shape, not a finished policy. "
+        "Because start() always looks up A-1, its first generated evaluation may "
+        "contain behavioral FAIL results until you adapt the decision logic and "
+        "representative fixtures."
+    )
+
+
+def _bounded_console_diagnostic(value: str, *, max_chars: int) -> str:
+    redacted = redact_log_text(value)
+    printable = "".join(
+        character if character.isprintable() else " " for character in redacted
+    )
+    normalized = " ".join(printable.split()) or "(no diagnostic text)"
+    if len(normalized) <= max_chars:
+        return normalized
+    prefix_chars = max_chars - len(_TRUNCATION_MARKER)
+    return f"{normalized[:prefix_chars].rstrip()}{_TRUNCATION_MARKER}"
+
+
+def _print_case_evaluation(evaluation: CaseEvaluation, *, title: str) -> None:
+    print(f"{evaluation.verdict.value:<12} {title}")
+    if evaluation.verdict != Verdict.INFRA_ERROR:
+        return
+    error = evaluation.infrastructure_error
+    if error is None:
+        return
+    code = _bounded_console_diagnostic(
+        error.code,
+        max_chars=_CONSOLE_ERROR_CODE_CHARS,
+    )
+    message = _bounded_console_diagnostic(
+        error.message,
+        max_chars=_CONSOLE_ERROR_MESSAGE_CHARS,
+    )
+    print(f"{'':12} INFRA_ERROR — {code}: {message}")
 
 
 def _init_command(target: str, *, entrypoint: str, adapter: str, force: bool) -> int:
@@ -1063,7 +1112,7 @@ def _test_command(
     evaluation_by_id = {item.scenario_id: item for item in execution.evaluations}
     for scenario in execution.scenarios:
         evaluation = evaluation_by_id[scenario.scenario_id]
-        print(f"{evaluation.verdict.value:<12} {scenario.title}")
+        _print_case_evaluation(evaluation, title=scenario.title)
 
     counts: Counter[Verdict] = execution.counts
     pass_rate = execution.observed_pass_rate
@@ -1144,7 +1193,7 @@ def _replay_command(
     evaluation_by_id = {item.scenario_id: item for item in execution.evaluations}
     for scenario in execution.scenarios:
         evaluation = evaluation_by_id[scenario.scenario_id]
-        print(f"{evaluation.verdict.value:<12} {scenario.title}")
+        _print_case_evaluation(evaluation, title=scenario.title)
 
     counts: Counter[Verdict] = execution.counts
     pass_rate = execution.observed_pass_rate

--- a/agentcheck/initialize.py
+++ b/agentcheck/initialize.py
@@ -40,7 +40,10 @@ def resolve_initialization_root(target: str | os.PathLike[str]) -> Path:
     except (OSError, RuntimeError) as exc:
         raise ConfigurationError(f"target path cannot be resolved: {exc}") from exc
     if not resolved.is_dir():
-        raise ConfigurationError(f"target must be an existing directory: {resolved}")
+        raise ConfigurationError(
+            f"target must be an existing directory: {resolved}; "
+            "create the directory first, then run agentcheck init again"
+        )
     return resolved
 
 

--- a/docs/ci-trust-model.md
+++ b/docs/ci-trust-model.md
@@ -12,7 +12,7 @@ version runs the cross-version suite defined in `tests/compat_manifest.py`.
 
 | | Py3.10 | Py3.11 | Py3.12 |
 |---|---|---|---|
-| Full behavioural suite (964 tests) | | | ✅ |
+| Full behavioural suite | | | ✅ |
 | Domain models, serialization, fingerprints | ✅ | ✅ | ✅ |
 | Worker / process isolation | ✅ | ✅ | ✅ |
 | ToolGateway, fail-closed, unknown tools | ✅ | ✅ | ✅ |
@@ -33,7 +33,7 @@ on, subprocess worker launch, import machinery, third-party SDK internals, and
 the `argparse` console entry point. All of those run everywhere. Pure logic over
 already-constructed objects runs once.
 
-The cross-version suite is 381 of 964 tests across 18 files. Measured on the
+The cross-version suite is selected by the compatibility manifest. Measured on the
 self-hosted runner it takes about 8 minutes per interpreter, against 21 for the
 full suite. It is not a smoke test.
 

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -12,10 +12,10 @@ tools during evaluation.
 
 ## Minimal contract
 
-Run `agentcheck init TARGET --adapter custom`. If the configured entrypoint does
-not exist, the command prints the following working skeleton without writing
-target source for you. This block is tested against the CLI text so the two
-cannot drift.
+Run `agentcheck init TARGET --adapter custom` (TARGET must already
+exist; `init` does not create it). If the configured entrypoint does not exist,
+the command prints the following working skeleton without writing target source
+for you. This block is tested against the CLI text so the two cannot drift.
 
 <!-- custom-agent-cli-skeleton:start -->
 ```python
@@ -50,6 +50,12 @@ class MyAgent:
 agent = MyAgent()
 ```
 <!-- custom-agent-cli-skeleton:end -->
+
+The printed starter demonstrates the integration shape, not a finished agent
+policy. Its `start()` method always calls `lookup_account` with `A-1`, so the
+first generated evaluation can contain behavioral `FAIL` results until you
+adapt the decision logic and add representative fixtures. Those results describe
+the starter's behavior; they do not mean installation failed.
 
 The configured object must expose:
 
@@ -167,6 +173,9 @@ write in that code is not converted into a fixture-backed tool call. Process
 isolation, credential removal, and socket-level egress denial contain common
 escapes, but they do not prevent arbitrary local filesystem mutations. Use this
 adapter only for trusted local code and keep side effects behind declared tools.
+
+Network denial is not a general operating-system sandbox; it does not stop
+those local effects.
 
 ## ControlledModel is unsupported
 

--- a/docs/pydantic-ai.md
+++ b/docs/pydantic-ai.md
@@ -1,0 +1,196 @@
+# PydanticAI agents
+
+AgentCheck supports an exact `pydantic_ai.Agent` target through the
+`pydantic_ai` adapter. The adapter inspects the agent's declared function tools,
+then builds a separate runtime agent whose tools invoke AgentCheck's
+`ToolGateway`. The original target handlers remain on the source agent and are
+never called during simulated evaluation.
+
+## Install the verified version
+
+AgentCheck is not published to PyPI yet. From an AgentCheck source checkout:
+
+```bash
+python -m pip install "agentcheck-ai[pydantic-ai] @ file://$PWD"
+```
+
+The extra installs `pydantic-ai-slim >=2.32,<2.33`. AgentCheck deliberately
+supports only PydanticAI 2.32.x because inspection reads framework-private
+attributes. A missing extra produces `framework_unavailable`; another minor
+version produces `unsupported_sdk_version` with the expected and detected
+versions. AgentCheck fails preflight instead of guessing at an unverified
+object shape.
+
+The distribution is `agentcheck-ai`, the Python import is `agentcheck`, and the
+command is `agentcheck`. Do not install the unrelated PyPI distribution named
+`agentcheck`.
+
+## Export one target
+
+Use the PydanticAI `Agent` you already have and export it from a Python file.
+The smallest supported shape is:
+
+```python
+from pydantic_ai import Agent
+
+
+def lookup_order(order_id: str) -> str:
+    """Look up one order."""
+    # Your production implementation stays here. AgentCheck replaces the
+    # tool before a simulated run can reach this function.
+    ...
+
+
+agent = Agent(
+    your_model,
+    instructions="Help customers with their orders.",
+    tools=[lookup_order],
+    name="Order Support",
+)
+```
+
+`your_model` is your existing PydanticAI model object. The worked example
+uses a local `FunctionModel`, needs no API key, and is runnable without a
+provider.
+
+The V1 adapter requires:
+
+- an exact `pydantic_ai.Agent`;
+- static instructions;
+- ordinary function tools with JSON Schema;
+- no `RunContext` / `deps_type` dependency injection;
+- no output validators, target capabilities, event-stream handler, or external
+  toolsets.
+
+Those unsupported surfaces are executable target behavior that cannot be
+reconstructed safely. Preflight names each one and refuses the run.
+
+## Configure and run
+
+The target directory must exist before `agentcheck init`; the command writes
+configuration but never creates a project directory or target source:
+
+```bash
+mkdir -p path/to/order-agent
+agentcheck init path/to/order-agent \
+  --adapter pydantic_ai \
+  --entrypoint agent.py:agent
+```
+
+The relevant `agentcheck.json` fields are:
+
+```json
+{
+  "schema_version": "agentcheck.config.v1",
+  "adapter": "pydantic_ai",
+  "entrypoint": "agent.py:agent",
+  "suite": "account_support_v1",
+  "allow_network": false,
+  "controlled_model": false
+}
+```
+
+Run the ordinary flow:
+
+```bash
+agentcheck inspect  path/to/order-agent
+agentcheck fixtures init path/to/order-agent
+# Replace REPLACE_ME values and add realistic user_request text.
+agentcheck generate path/to/order-agent
+agentcheck test     path/to/order-agent
+agentcheck report   path/to/order-agent --latest
+```
+
+`inspect` imports trusted target code in a child process but does not run an
+agent turn. `generate` freezes schema-boundary and compatible behavioral cases.
+`test` runs each case in its own contained worker and prints the HTML report and
+replay-manifest locations.
+
+## Representative and prerequisite fixtures
+
+`agentcheck-fixtures.json` is committed synthetic test data. Representative
+arguments make generated calls realistic; `user_request` gives the model a
+credible reason to act:
+
+```json
+{
+  "schema_version": "agentcheck.fixtures.v1",
+  "tools": {
+    "cancel_order": {
+      "arguments": {
+        "order_id": "order_123",
+        "reason": "duplicate order"
+      },
+      "user_request": "Cancel duplicate order order_123."
+    }
+  },
+  "prerequisites": {
+    "lookup_order": {
+      "result": {
+        "order_id": "order_123",
+        "status": "pending"
+      }
+    }
+  }
+}
+```
+
+A prerequisite is a gating tool the agent may legitimately call before the
+focal action. Its declared result is included as a single-use simulated fixture;
+AgentCheck does not infer prerequisite relationships. If the agent calls a tool
+without a matching focal or prerequisite fixture, calls an undeclared tool, or
+supplies schema-invalid arguments, the scenario fails closed as `INFRA_ERROR`.
+It is never reported as a behavioral `FAIL`.
+
+Use synthetic records only. Credential-shaped fixture values are rejected, and
+fixture packs are not a place for API keys or customer data.
+
+## Offline ControlledModel
+
+For an existing provider-backed PydanticAI target, enable:
+
+```json
+{
+  "adapter": "pydantic_ai",
+  "controlled_model": true
+}
+```
+
+AgentCheck rebuilds the runtime agent with its deterministic local
+`ControlledPydanticModel`. No provider request is made during the run, no
+provider credential needs to be forwarded into the worker, and observable
+model-request/model-response events still describe real calls to that local
+replacement.
+
+The replacement is intentionally neutral: it produces a deterministic text or
+schema-shaped response and never chooses a tool. It can validate import,
+inspection, reconstruction, output handling, reports, and non-action cases, but
+a passing tool-action assertion may be vacuous because no tool was attempted.
+The CLI explicitly reports action-path coverage.
+
+To exercise model-to-tool behavior offline, keep `controlled_model` false and
+make the target select its own local scripted model, as the
+[credential-free worked example](../examples/evaluation/pydantic_agent/README.md)
+does. Its run reports `Action paths exercised: 1/1`.
+
+OpenAI Agents SDK follows the same configuration idea: set
+`controlled_model` true to replace provider execution with AgentCheck's neutral
+offline model. Install the separate verified extra
+`agentcheck-ai[openai-agents]` (`openai-agents >=0.20,<0.21`). Custom agents are
+different: AgentCheck cannot see or replace model calls owned by custom
+orchestration, so `custom` plus `controlled_model` is explicitly rejected.
+
+## Safety boundary
+
+During simulated evaluation, accepted PydanticAI function tools are rebuilt
+from their declarations with AgentCheck-owned invokers. Declared calls are
+schema-checked, fixture-backed, and controlled by `ToolGateway`; unknown tools
+and missing fixtures fail closed. Original target handlers do not execute.
+
+The target is still trusted Python. Import-time code executes, and network
+denial is not a general operating-system sandbox. Direct filesystem writes,
+subprocess execution, or direct local-database access performed by imports or
+other target orchestration are outside the declared-tool guarantee.
+
+See the complete
+[offline PydanticAI worked example](../examples/evaluation/pydantic_agent/README.md).

--- a/examples/evaluation/handoff_router/README.md
+++ b/examples/evaluation/handoff_router/README.md
@@ -25,9 +25,13 @@ agentcheck generate examples/evaluation/handoff_router
 agentcheck test examples/evaluation/handoff_router
 ```
 
+The CLI commands below verify inspection, safe reconstruction, and generated
+schema-boundary cases. They are not a CLI demonstration of the three planted
+handoff defects and may report 100% with zero action paths exercised. The
+handoff-specific behavioral scenarios live in
+`tests/agentcheck/test_example_handoff_agent.py`.
+
 `inspect` prints the reachable handoff topology. Without a frozen suite,
 `test` fails closed because the built-in `account_support_v1` suite does not
 match this target's tools; `generate` freezes schema-boundary cases for the
-merged tool surface. The handoff-specific scenarios (required/forbidden
-handoff, loop detection, fabricated success after a downstream tool error)
-are exercised by `tests/agentcheck/test_example_handoff_agent.py`.
+merged tool surface.

--- a/examples/evaluation/pydantic_agent/README.md
+++ b/examples/evaluation/pydantic_agent/README.md
@@ -1,0 +1,71 @@
+# Offline PydanticAI order lookup
+
+This worked example is a complete PydanticAI onboarding path. It uses
+PydanticAI's local `FunctionModel`, needs no API key, makes zero provider
+requests, and performs one real model-to-tool decision so the action-path result
+is not vacuous.
+
+The exported `agent` owns one declared function tool. Its original
+`lookup_order` handler is a raising tripwire: if the real handler is ever
+reached, the evaluation stops. During evaluation AgentCheck rebuilds the tool
+with an AgentCheck-owned invoker, and `ToolGateway` supplies the simulated
+result from the frozen scenario.
+
+## Install from the current source checkout
+
+AgentCheck is not published to PyPI yet. From the AgentCheck repository root:
+
+```bash
+python -m pip install "agentcheck-ai[pydantic-ai] @ file://$PWD"
+```
+
+This installs the verified PydanticAI range:
+`pydantic-ai-slim >=2.32,<2.33`. Other minor versions fail preflight with
+`unsupported_sdk_version` instead of being inspected approximately.
+
+## Run the example
+
+From the AgentCheck repository root:
+
+```bash
+agentcheck inspect  examples/evaluation/pydantic_agent
+agentcheck generate examples/evaluation/pydantic_agent
+agentcheck test     examples/evaluation/pydantic_agent
+agentcheck report   examples/evaluation/pydantic_agent --latest
+```
+
+Expected highlights are `Preflight: supported`, four generated schema/action
+cases, and:
+
+```text
+Action paths exercised: 1/1 (a tool was actually called)
+Passed:        4
+Infra errors:  0
+```
+
+The exact report location is printed at the end of the test run.
+
+## Why ControlledModel is false here
+
+The example keeps `"controlled_model": false` because its own local
+`FunctionModel` deliberately chooses `lookup_order`. There is still no provider
+request.
+
+For an ordinary provider-backed PydanticAI target, setting
+`"controlled_model": true` asks AgentCheck to substitute its deterministic
+offline model before the run. That model is intentionally neutral and never
+chooses tools, so it is useful for credential-free reconstruction and
+output-path checks but does not exercise a tool-action path. See
+[the PydanticAI guide](../../../docs/pydantic-ai.md) for the complete tradeoff.
+
+## Fixtures and prerequisites
+
+`agentcheck-fixtures.json` supplies both the representative `order_id` and the
+human-shaped `user_request` that makes calling `lookup_order` appropriate.
+Fixture values are committed test data; use synthetic records and never put
+credentials or real customer data in them.
+
+This target has no gating lookup, so its `prerequisites` object is empty. When
+one tool must run before the focal action, declare that gating tool under
+`prerequisites` with the simulated result it should return. Missing or invalid
+focal/prerequisite fixtures fail as `INFRA_ERROR`, never behavioral `FAIL`.

--- a/examples/evaluation/pydantic_agent/agent.py
+++ b/examples/evaluation/pydantic_agent/agent.py
@@ -1,0 +1,60 @@
+"""Credential-free PydanticAI target for the AgentCheck worked example."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+
+ORIGINAL_HANDLER_CALLS: list[str] = []
+_LOOKUP_REQUEST = "Look up order order_123 and tell me its current status."
+
+
+def lookup_order(order_id: str) -> str:
+    """Look up one order's current status."""
+    ORIGINAL_HANDLER_CALLS.append("lookup_order")
+    raise AssertionError("original lookup_order handler must never run")
+
+
+def _script(messages: list[Any], info: AgentInfo) -> ModelResponse:
+    del info
+    parts = [
+        part
+        for message in messages
+        for part in getattr(message, "parts", ())
+    ]
+    if any(isinstance(part, ToolCallPart) for part in parts):
+        return ModelResponse(
+            parts=[TextPart("Order order_123 is ready for pickup.")]
+        )
+    text = "\n".join(
+        content
+        for part in parts
+        if isinstance((content := getattr(part, "content", None)), str)
+    )
+    if _LOOKUP_REQUEST in text:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "lookup_order",
+                    {"order_id": "order_123"},
+                )
+            ]
+        )
+    return ModelResponse(
+        parts=[TextPart("Please provide a valid order ID to look up.")]
+    )
+
+
+agent = Agent(
+    FunctionModel(_script),
+    instructions=(
+        "Help customers look up orders. Use lookup_order only when the customer "
+        "supplies a concrete order ID."
+    ),
+    tools=[lookup_order],
+    name="Offline Order Support",
+)

--- a/examples/evaluation/pydantic_agent/agentcheck-fixtures.json
+++ b/examples/evaluation/pydantic_agent/agentcheck-fixtures.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "agentcheck.fixtures.v1",
+  "tools": {
+    "lookup_order": {
+      "arguments": {
+        "order_id": "order_123"
+      },
+      "user_request": "Look up order order_123 and tell me its current status."
+    }
+  },
+  "prerequisites": {}
+}

--- a/examples/evaluation/pydantic_agent/agentcheck.json
+++ b/examples/evaluation/pydantic_agent/agentcheck.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "agentcheck.config.v1",
+  "adapter": "pydantic_ai",
+  "entrypoint": "agent.py:agent",
+  "suite": "account_support_v1",
+  "seed": 1729,
+  "max_concurrency": 2,
+  "environment_allowlist": [],
+  "network_allowlist": [],
+  "allow_network": false,
+  "controlled_model": false,
+  "include_instructions_in_report": false,
+  "artifacts_directory": ".agentcheck"
+}

--- a/tests/agentcheck/test_cli_diagnostics.py
+++ b/tests/agentcheck/test_cli_diagnostics.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import agentcheck.cli as cli
+from agentcheck.domain import Scenario, Verdict
+from agentcheck.evaluate import infrastructure_evaluation
+from agentcheck.errors import ConfigurationError
+from agentcheck.generate import build_account_support_suite
+from agentcheck.initialize import write_initial_config
+
+
+def _infra_execution(
+    scenario: Scenario,
+    *,
+    code: str,
+    message: str,
+) -> SimpleNamespace:
+    evaluation = infrastructure_evaluation(
+        scenario,
+        code=code,
+        message=message,
+        phase="run",
+    )
+    return SimpleNamespace(
+        scenarios=(scenario,),
+        evaluations=(evaluation,),
+        spec=object(),
+        frozen_suite=None,
+        invalid_scenarios=(),
+        selection=None,
+        counts=Counter({Verdict.INFRA_ERROR: 1}),
+        observed_pass_rate=None,
+        runs=(),
+        findings=(),
+        report_path=Path("report.html"),
+        replay_manifest_path=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (
+            "fixture_not_found",
+            "No fixture declared for tool 'lookup_customer'.",
+        ),
+        (
+            "unknown_tool",
+            "Tool 'send_email' is not declared by the inspected agent.",
+        ),
+        (
+            "fixture_not_found",
+            "Prerequisite fixture for tool 'authenticate_user' is missing.",
+        ),
+    ],
+)
+def test_test_command_surfaces_actionable_infrastructure_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    code: str,
+    message: str,
+) -> None:
+    scenario = build_account_support_suite()[0]
+    execution = _infra_execution(scenario, code=code, message=message)
+    monkeypatch.setattr(cli, "execute_suite", lambda *_args, **_kwargs: execution)
+    monkeypatch.setattr(cli, "_print_inspection", lambda *_args, **_kwargs: None)
+
+    assert cli.main(["test", "."]) == 2
+
+    output = capsys.readouterr().out
+    assert f"INFRA_ERROR — {code}: {message}" in output
+    assert scenario.title in output
+    assert "Traceback" not in output
+
+
+def test_infrastructure_diagnostic_is_redacted_single_line_and_bounded(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    scenario = build_account_support_suite()[0]
+    code = "fixture_" + ("c" * 100)
+    message = (
+        "Authorization: Bearer test-secret-token-value\n"
+        "\x1b[31munsafe-control "
+        + ("x" * 500)
+    )
+    evaluation = infrastructure_evaluation(
+        scenario,
+        code=code,
+        message=message,
+        phase="run",
+    )
+
+    cli._print_case_evaluation(evaluation, title=scenario.title)
+
+    lines = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "INFRA_ERROR —" in line
+    ]
+    assert len(lines) == 1
+    diagnostic = lines[0]
+    assert "[REDACTED]" in diagnostic
+    assert "test-secret-token-value" not in diagnostic
+    assert "\x1b" not in diagnostic
+    assert "[TRUNCATED]" in diagnostic
+    assert len(diagnostic) <= 430
+
+
+def test_test_help_states_the_exact_declared_tool_safety_boundary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["test", "--help"])
+
+    assert exc_info.value.code == 0
+    normalized = " ".join(capsys.readouterr().out.split())
+    assert "Declared tool calls are simulated" in normalized
+    assert "never reach their original handlers" in normalized
+    assert "direct filesystem writes" in normalized
+    assert "subprocess execution" in normalized
+    assert "local database access" in normalized
+    assert "outside the declared-tool guarantee" in normalized
+    assert "cannot cause external side effects" not in normalized
+
+
+def test_init_help_says_the_target_directory_must_already_exist(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["init", "--help"])
+
+    assert exc_info.value.code == 0
+    normalized = " ".join(capsys.readouterr().out.split())
+    assert "TARGET must already be an existing directory" in normalized
+    assert "init does not create it" in normalized
+
+
+def test_missing_init_directory_error_tells_the_developer_what_to_do(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ConfigurationError, match="create the directory first"):
+        write_initial_config(tmp_path / "absent")
+
+
+def test_custom_init_explains_that_the_starter_may_initially_fail(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert cli.main(["init", str(tmp_path), "--adapter", "custom"]) == 0
+
+    output = capsys.readouterr().out
+    assert "integration shape, not a finished policy" in output
+    assert "first generated evaluation may contain behavioral FAIL results" in output
+    assert "representative fixtures" in output
+
+
+def test_public_safety_docs_keep_the_declared_tool_boundary_narrow() -> None:
+    root = Path(__file__).parents[2]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    security = (root / "SECURITY.md").read_text(encoding="utf-8")
+    custom = (root / "docs" / "custom-agents.md").read_text(encoding="utf-8")
+
+    assert "Declared real tool handlers never execute" in readme
+    assert "outside the declared-tool guarantee" in readme
+    assert "Network denial is not a general operating-system sandbox" in readme
+
+    assert "declared-tool guarantee is not a general Python sandbox" in security
+    assert "Direct filesystem writes, subprocess execution" in security
+    assert "direct local-database access" in " ".join(security.split())
+    assert "outside the guarantee" in " ".join(security.split())
+
+    assert "Declared real tool handlers are never supplied" in custom
+    assert "os.remove(...)" in custom
+    assert "subprocess.run(...)" in custom
+    assert "local database" in custom
+    assert "outside the declared-tool guarantee" in custom
+    assert "Network denial is not a general operating-system sandbox" in custom
+
+
+def test_allowed_public_alpha_polish_does_not_drift() -> None:
+    root = Path(__file__).parents[2]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    ci_docs = (root / "docs" / "ci-trust-model.md").read_text(encoding="utf-8")
+    custom = (root / "docs" / "custom-agents.md").read_text(encoding="utf-8")
+    handoff = (
+        root / "examples" / "evaluation" / "handoff_router" / "README.md"
+    ).read_text(encoding="utf-8")
+
+    assert "python -m pytest tests -q -n 2" in readme
+    assert "964 tests" not in ci_docs
+    assert "381 of 964" not in ci_docs
+    assert "integration shape, not a finished agent policy" in " ".join(custom.split())
+    assert "first generated evaluation can contain behavioral `FAIL`" in custom
+    assert "not a CLI demonstration of the three planted handoff defects" in " ".join(handoff.split())
+    assert "may report 100% with zero action paths exercised" in " ".join(handoff.split())

--- a/tests/agentcheck/test_example_pydantic_agent.py
+++ b/tests/agentcheck/test_example_pydantic_agent.py
@@ -1,0 +1,148 @@
+"""Credential-free end-to-end coverage for the PydanticAI worked example."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from agentcheck.adapters import PydanticAIAdapter
+from agentcheck.cli import main
+from agentcheck.config import load_config
+from agentcheck.domain import CanonicalRun, CaseEvaluation, Verdict
+from agentcheck.fixtures import load_fixture_pack
+from agentcheck.inspect import load_target
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+EXAMPLE = REPOSITORY_ROOT / "examples" / "evaluation" / "pydantic_agent"
+PYDANTIC_DOC = REPOSITORY_ROOT / "docs" / "pydantic-ai.md"
+README = REPOSITORY_ROOT / "README.md"
+
+
+def test_example_contract_fixtures_and_docs_are_one_onboarding_path() -> None:
+    root, config = load_config(EXAMPLE)
+    target, source = load_target(root)
+    spec = PydanticAIAdapter().inspect(target, source=source)
+    fixtures = load_fixture_pack(root)
+
+    assert config.adapter == "pydantic_ai"
+    assert config.entrypoint == "agent.py:agent"
+    assert config.controlled_model is False
+    assert config.allow_network is False
+    assert spec.identity.name.value == "Offline Order Support"
+    assert [item.value.name for item in spec.tools.items] == ["lookup_order"]
+    assert fixtures is not None
+    assert fixtures.tools["lookup_order"].arguments == {"order_id": "order_123"}
+    assert fixtures.tools["lookup_order"].user_request is not None
+    assert fixtures.prerequisites == {}
+
+    source_text = (EXAMPLE / "agent.py").read_text(encoding="utf-8")
+    assert "FunctionModel(_script)" in source_text
+    assert "original lookup_order handler must never run" in source_text
+
+    docs = PYDANTIC_DOC.read_text(encoding="utf-8")
+    example_docs = (EXAMPLE / "README.md").read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    for text in (docs, example_docs):
+        assert "pydantic-ai-slim >=2.32,<2.33" in text
+        assert "agentcheck inspect" in text
+        assert "agentcheck generate" in text
+        assert "agentcheck test" in text
+        assert "controlled_model" in text
+        assert "prerequisite" in text.casefold()
+        assert "no API key" in text
+    assert "docs/pydantic-ai.md" in readme
+
+
+def test_example_cli_flow_exercises_a_simulated_tool_without_provider_or_handler(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = tmp_path / "pydantic-agent"
+    shutil.copytree(EXAMPLE, target)
+
+    source = target / "agent.py"
+    instrumented = source.read_text(encoding="utf-8").replace(
+        "from typing import Any\n",
+        "from pathlib import Path\nfrom typing import Any\n",
+    )
+    handler_line = '    ORIGINAL_HANDLER_CALLS.append("lookup_order")'
+    instrumented = instrumented.replace(
+        handler_line,
+        (
+            '    Path(__file__).with_name("original-handler-executed").write_text(\n'
+            '        "executed\\n", encoding="utf-8"\n'
+            "    )\n"
+            f"{handler_line}"
+        ),
+    )
+    assert instrumented != source.read_text(encoding="utf-8")
+    source.write_text(instrumented, encoding="utf-8")
+    handler_probe = target / "original-handler-executed"
+
+    assert main(["inspect", str(target)]) == 0
+    assert main(["generate", str(target)]) == 0
+    assert (
+        main(
+            [
+                "test",
+                str(target),
+                "--run-id",
+                "pydantic-example-test",
+                "--no-store",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "Preflight: supported" in output
+    assert "Action paths exercised: 1/1" in output
+    assert "Infra errors:  0" in output
+    assert not handler_probe.exists()
+
+    run_root = target / ".agentcheck" / "runs" / "pydantic-example-test"
+    runs = tuple(
+        CanonicalRun.model_validate_json(line)
+        for line in (run_root / "runs.jsonl").read_text(encoding="utf-8").splitlines()
+        if line
+    )
+    evaluations = tuple(
+        CaseEvaluation.model_validate_json(line)
+        for line in (run_root / "evaluations.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line
+    )
+
+    assert len(runs) == 4
+    assert len(evaluations) == 4
+    assert any(run.tool_attempts for run in runs)
+    assert all(run.provider_request_ids == () for run in runs)
+    assert all(
+        outcome.metadata.get("simulated") is True
+        for run in runs
+        for outcome in run.tool_outcomes
+    )
+    assert all(item.verdict == Verdict.PASS for item in evaluations)
+    assert all(item.infrastructure_error is None for item in evaluations)
+    assert (run_root / "report.html").is_file()
+    assert not handler_probe.exists()
+
+
+def test_pydantic_guide_explains_controlled_model_limits_and_fail_closed_setup() -> None:
+    docs = " ".join(PYDANTIC_DOC.read_text(encoding="utf-8").split())
+
+    assert "pydantic-ai-slim >=2.32,<2.33" in docs
+    assert "unsupported_sdk_version" in docs
+    assert "ControlledPydanticModel" in docs
+    assert "never chooses a tool" in docs
+    assert "passing tool-action assertion may be vacuous" in docs
+    assert "Action paths exercised: 1/1" in docs
+    assert "matching focal or prerequisite fixture" in docs
+    assert "fails closed" in docs
+    assert "`INFRA_ERROR`" in docs
+    assert "Original target handlers do not execute" in docs
+    assert "outside the declared-tool guarantee" in docs


### PR DESCRIPTION
## Summary

- clarify the declared-tool safety boundary across CLI and documentation
- add a self-contained PydanticAI onboarding guide and credential-free worked example
- document ControlledModel behavior for PydanticAI and OpenAI Agents SDK
- surface bounded, redacted INFRA_ERROR diagnostics in terminal output
- improve init and Custom Agent starter guidance
- remove stale test counts and clarify the handoff-router example

## Validation

- 524 relevant offline regression tests passed with `-n 2`
- Ruff, mypy, secret scan, and workflow safety passed
- wheel and sdist build/content audit passed
- PydanticAI example exercised one simulated tool path
- original handler executions: 0
- provider requests: 0
- API spend: $0

No schema, worker-protocol, ToolGateway, adapter-architecture, CI, version, or safety-budget changes.