### PR TITLE
Add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+# PyPI Trusted Publishing. This workflow intentionally has no manual trigger:
+# publishing starts only when a non-prerelease GitHub Release is published.
+#
+# Before the first release, create the `pypi` GitHub Environment with a required
+# reviewer (where the repository plan supports it), then register this exact
+# workflow and environment as the pending publisher for `agentcheck-ai` on PyPI.
+
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and validate distributions
+    if: ${{ github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the published release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify release source and version
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          metadata = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = metadata["project"]["version"]
+          expected_tag = f"v{version}"
+          release_tag = os.environ["RELEASE_TAG"]
+          if release_tag != expected_tag:
+              raise SystemExit(
+                  f"release tag {release_tag!r} does not match package version {version!r}; "
+                  f"expected {expected_tag!r}"
+              )
+          print(f"release tag matches agentcheck-ai {version}")
+          PY
+
+          if [ "$(git rev-parse HEAD)" != "$RELEASE_SHA" ]; then
+            echo "checked-out source does not match the published release tag" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor HEAD "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "published release tag is not reachable from $DEFAULT_BRANCH" >&2
+            exit 1
+          fi
+
+      - name: Install build validation tools
+        run: python -m pip install "build==1.5.0" "twine==7.0.0"
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Validate distributions
+        run: |
+          python -m twine check --strict dist/*
+          python scripts/check_distribution.py
+          python - <<'PY'
+          import pathlib
+          import tomllib
+
+          metadata = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = metadata["project"]["version"]
+          expected = {
+              f"agentcheck_ai-{version}-py3-none-any.whl",
+              f"agentcheck_ai-{version}.tar.gz",
+          }
+          actual = {path.name for path in pathlib.Path("dist").iterdir() if path.is_file()}
+          if actual != expected:
+              raise SystemExit(
+                  f"release artifact set mismatch: expected {sorted(expected)!r}, "
+                  f"found {sorted(actual)!r}"
+              )
+          print(f"validated release artifacts: {sorted(actual)!r}")
+          PY
+
+      - name: Upload validated distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish distributions to PyPI
+    if: ${{ github.event.release.prerelease == false }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/agentcheck-ai
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download validated distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary

- add a dedicated GitHub Release-triggered publishing workflow for `agentcheck-ai`
- build wheel and sdist separately from publication
- validate release tag, package version, and release source before publishing
- publish through PyPI Trusted Publishing / GitHub OIDC
- use the protected `pypi` GitHub environment
- require no long-lived PyPI API token or publishing secret

## Validation

- local package build and distribution audit passed
- `twine check --strict` passed for wheel and sdist
- clean-room wheel installation passed
- `agentcheck --help`, `agentcheck --version`, and import smoke tests passed
- credential-free installed-wheel smoke evaluation passed
- workflow structure and workflow-safety checks passed
- secret scan passed
- provider requests: 0
- API spend: $0

No runtime, adapter, ToolGateway, schema, worker-protocol, version, public-CI, or AgentLens changes.
