### PR TITLE
Improve AgentCheck CLI test progress

### DIFF
--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -109,6 +109,8 @@ from agentcheck.runner.orchestrator import (
 
 
 ProgressCallback = Callable[[int, int, Scenario, CaseEvaluation], None]
+InspectionProgressCallback = Callable[[AgentSpec], None]
+PreparationProgressCallback = Callable[[FrozenSuite | None, int, int, int], None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -320,6 +322,8 @@ def execute_suite(
     seed: int | None = None,
     run_id: str | None = None,
     progress: ProgressCallback | None = None,
+    on_inspected: InspectionProgressCallback | None = None,
+    on_prepared: PreparationProgressCallback | None = None,
     persist_store: bool = True,
     select: str | None = None,
     python_executable: str | None = None,
@@ -343,6 +347,8 @@ def execute_suite(
         root, config, spec=_require_supported_spec(inspection)
     )
     spec = attach_declared_policies(_require_supported_spec(inspection), packs)
+    if on_inspected is not None:
+        on_inspected(spec)
 
     frozen: FrozenSuite | None = None
     if configured is None:
@@ -423,6 +429,12 @@ def execute_suite(
                 "No valid scenarios remain after coverage selection; "
                 "no agent verdict was produced."
             )
+
+    if on_prepared is not None:
+        excluded_by_selection = (
+            len(selection_plan.excluded_ids) if selection_plan is not None else 0
+        )
+        on_prepared(frozen, len(valid), len(invalid), excluded_by_selection)
 
     return _execute_valid_scenarios(
         root=root,

--- a/agentcheck/cli.py
+++ b/agentcheck/cli.py
@@ -7,9 +7,10 @@ import json
 import os
 import re
 import sys
+import threading
 from collections import Counter
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, TextIO
 
 from agentcheck import __version__
 from agentcheck.adapters.base import SupportIssue
@@ -31,6 +32,7 @@ from agentcheck.fixtures import (
 from agentcheck.domain import (
     AgentSpec,
     CaseEvaluation,
+    Scenario,
     Severity,
     Verdict,
     action_path_exercise,
@@ -59,6 +61,9 @@ from agentcheck.shrink import (
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$")
 _CONSOLE_ERROR_CODE_CHARS = 80
 _CONSOLE_ERROR_MESSAGE_CHARS = 320
+_CONSOLE_SCENARIO_TITLE_CHARS = 96
+_TEST_PROGRESS_HEARTBEAT_SECONDS = 10.0
+_TEST_PROGRESS_RESULT_COLUMN = 72
 _TRUNCATION_MARKER = "...[TRUNCATED]"
 
 
@@ -932,8 +937,12 @@ def _bounded_console_diagnostic(value: str, *, max_chars: int) -> str:
     return f"{normalized[:prefix_chars].rstrip()}{_TRUNCATION_MARKER}"
 
 
-def _print_case_evaluation(evaluation: CaseEvaluation, *, title: str) -> None:
-    print(f"{evaluation.verdict.value:<12} {title}")
+def _print_infrastructure_diagnostic(
+    evaluation: CaseEvaluation,
+    *,
+    prefix: str,
+    stream: TextIO,
+) -> None:
     if evaluation.verdict != Verdict.INFRA_ERROR:
         return
     error = evaluation.infrastructure_error
@@ -947,7 +956,163 @@ def _print_case_evaluation(evaluation: CaseEvaluation, *, title: str) -> None:
         error.message,
         max_chars=_CONSOLE_ERROR_MESSAGE_CHARS,
     )
-    print(f"{'':12} INFRA_ERROR — {code}: {message}")
+    print(f"{prefix}INFRA_ERROR — {code}: {message}", file=stream, flush=True)
+
+
+def _print_case_evaluation(evaluation: CaseEvaluation, *, title: str) -> None:
+    print(f"{evaluation.verdict.value:<12} {title}")
+    _print_infrastructure_diagnostic(
+        evaluation,
+        prefix=" " * 12,
+        stream=sys.stdout,
+    )
+
+
+def _print_progress_case_evaluation(
+    evaluation: CaseEvaluation,
+    *,
+    title: str,
+    completed: int,
+    total: int,
+    stream: TextIO,
+) -> None:
+    safe_title = _bounded_console_diagnostic(
+        title,
+        max_chars=_CONSOLE_SCENARIO_TITLE_CHARS,
+    )
+    count_prefix = f"[{completed}/{total}] "
+    label = f"{count_prefix}{safe_title}"
+    dots = "." * max(3, _TEST_PROGRESS_RESULT_COLUMN - len(label))
+    print(
+        f"{label} {dots} {evaluation.verdict.value}",
+        file=stream,
+        flush=True,
+    )
+    _print_infrastructure_diagnostic(
+        evaluation,
+        prefix=" " * len(count_prefix),
+        stream=stream,
+    )
+
+
+class _TestProgressReporter:
+    # Newline-only output keeps redirected and CI logs readable.
+    def __init__(
+        self,
+        *,
+        stream: TextIO,
+        heartbeat_seconds: float = _TEST_PROGRESS_HEARTBEAT_SECONDS,
+    ) -> None:
+        self._stream = stream
+        self._heartbeat_seconds = heartbeat_seconds
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._stage = "Inspecting agent"
+        self._completed = 0
+        self._total: int | None = None
+
+    def start(self) -> None:
+        self._write("Inspecting agent...")
+        self._thread = threading.Thread(
+            target=self._heartbeat_loop,
+            name="agentcheck-cli-progress",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def inspection_complete(self) -> None:
+        with self._lock:
+            self._write_locked("Inspection complete. ✓")
+            self._stage = "Preparing suite"
+
+    def suite_ready(
+        self,
+        frozen: Any,
+        total: int,
+        invalid: int,
+        excluded_by_selection: int,
+    ) -> None:
+        scenario_word = "scenario" if total == 1 else "scenarios"
+        with self._lock:
+            if frozen is not None:
+                self._write_locked(
+                    f"Loading frozen suite... ✓ {total} {scenario_word}"
+                )
+                self._write_locked(f"Suite ID: {frozen.suite_id}")
+                self._write_locked(f"Seed:     {frozen.seed}")
+            else:
+                self._write_locked(
+                    "Building deterministic test suite... "
+                    f"✓ {total} {scenario_word}"
+                )
+            if invalid:
+                self._write_locked(
+                    f"Excluded: {invalid} invalid scenario(s); "
+                    "these do not affect results"
+                )
+            if excluded_by_selection:
+                self._write_locked(
+                    f"Excluded by selection: {excluded_by_selection} "
+                    "valid scenario(s); these are not scored"
+                )
+            self._write_locked("")
+            self._write_locked(
+                f"Running {total} {scenario_word} in isolated workers..."
+            )
+            self._completed = 0
+            self._total = total
+            self._stage = "Running scenarios"
+
+    def case_completed(
+        self,
+        completed: int,
+        total: int,
+        scenario: Scenario,
+        evaluation: CaseEvaluation,
+    ) -> None:
+        with self._lock:
+            self._completed = completed
+            self._total = total
+            _print_progress_case_evaluation(
+                evaluation,
+                title=scenario.title,
+                completed=completed,
+                total=total,
+                stream=self._stream,
+            )
+            if completed >= total:
+                self._stage = "Finalizing report"
+                self._total = None
+                self._write_locked("Finalizing report...")
+
+    def emit_heartbeat(self) -> None:
+        with self._lock:
+            if self._total is None:
+                self._write_locked(f"{self._stage}... still running")
+            elif self._completed < self._total:
+                remaining = self._total - self._completed
+                scenario_word = "scenario" if remaining == 1 else "scenarios"
+                self._write_locked(
+                    f"{remaining} {scenario_word} still running "
+                    f"({self._completed}/{self._total} complete)"
+                )
+
+    def close(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+
+    def _heartbeat_loop(self) -> None:
+        while not self._stop.wait(self._heartbeat_seconds):
+            self.emit_heartbeat()
+
+    def _write(self, line: str) -> None:
+        with self._lock:
+            self._write_locked(line)
+
+    def _write_locked(self, line: str) -> None:
+        print(line, file=self._stream, flush=True)
 
 
 def _init_command(target: str, *, entrypoint: str, adapter: str, force: bool) -> int:
@@ -1073,46 +1238,46 @@ def _test_command(
     select: str | None,
     python_executable: str | None,
 ) -> int:
-    print("Inspecting agent...")
-    print()
-    execution = execute_suite(
-        target,
-        seed=seed,
-        run_id=run_id,
-        persist_store=persist_store,
-        select=select,
-        python_executable=python_executable,
-    )
+    reporter = _TestProgressReporter(stream=sys.stdout)
+
+    def on_inspected(spec: AgentSpec) -> None:
+        reporter.inspection_complete()
+        print()
+        _print_inspection(spec)
+        print()
+
+    def on_prepared(
+        frozen: Any,
+        total: int,
+        invalid: int,
+        excluded_by_selection: int,
+    ) -> None:
+        reporter.suite_ready(
+            frozen,
+            total,
+            invalid,
+            excluded_by_selection,
+        )
+
+    reporter.start()
+    try:
+        execution = execute_suite(
+            target,
+            seed=seed,
+            run_id=run_id,
+            progress=reporter.case_completed,
+            on_inspected=on_inspected,
+            on_prepared=on_prepared,
+            persist_store=persist_store,
+            select=select,
+            python_executable=python_executable,
+        )
+    finally:
+        reporter.close()
     if not execution.scenarios:
         raise ScenarioValidationError(
             "No valid scenarios remain after linting; no agent verdict was produced."
         )
-    _print_inspection(execution.spec)
-    print()
-    if execution.frozen_suite is not None:
-        print("Using frozen suite...")
-        print(f"Suite ID: {execution.frozen_suite.suite_id}")
-        print(f"Seed:     {execution.frozen_suite.seed}")
-    else:
-        print("Building deterministic test suite...")
-    print(f"Generated: {len(execution.scenarios)} valid scenarios")
-    if execution.invalid_scenarios:
-        print(
-            f"Excluded: {len(execution.invalid_scenarios)} invalid scenario(s); "
-            "these do not affect results"
-        )
-    if execution.selection is not None and execution.selection.excluded_ids:
-        print(
-            f"Excluded by selection: {len(execution.selection.excluded_ids)} "
-            "valid scenario(s); these are not scored"
-        )
-    print()
-    print(f"Running {len(execution.scenarios)} scenarios in isolated child processes...")
-    print()
-    evaluation_by_id = {item.scenario_id: item for item in execution.evaluations}
-    for scenario in execution.scenarios:
-        evaluation = evaluation_by_id[scenario.scenario_id]
-        _print_case_evaluation(evaluation, title=scenario.title)
 
     counts: Counter[Verdict] = execution.counts
     pass_rate = execution.observed_pass_rate

--- a/tests/agentcheck/test_cli_diagnostics.py
+++ b/tests/agentcheck/test_cli_diagnostics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
@@ -42,6 +43,72 @@ def _infra_execution(
     )
 
 
+def _execution_for_verdict(
+    scenario: Scenario,
+    verdict: Verdict,
+) -> SimpleNamespace:
+    if verdict == Verdict.INFRA_ERROR:
+        return _infra_execution(
+            scenario,
+            code="fixture_not_found",
+            message="No fixture declared for tool 'lookup_customer'.",
+        )
+    evaluation = SimpleNamespace(
+        scenario_id=scenario.scenario_id,
+        verdict=verdict,
+        infrastructure_error=None,
+    )
+    return SimpleNamespace(
+        scenarios=(scenario,),
+        evaluations=(evaluation,),
+        spec=object(),
+        frozen_suite=None,
+        invalid_scenarios=(),
+        selection=None,
+        counts=Counter({verdict: 1}),
+        observed_pass_rate=1.0 if verdict == Verdict.PASS else 0.0,
+        runs=(),
+        findings=(),
+        report_path=Path("report.html"),
+        replay_manifest_path=None,
+    )
+
+
+def _execute_with_progress(execution: SimpleNamespace):
+    def execute(*_args: object, **kwargs: object) -> SimpleNamespace:
+        on_inspected = kwargs["on_inspected"]
+        on_prepared = kwargs["on_prepared"]
+        progress = kwargs["progress"]
+        assert callable(on_inspected)
+        assert callable(on_prepared)
+        assert callable(progress)
+        on_inspected(execution.spec)
+        excluded = (
+            len(execution.selection.excluded_ids)
+            if execution.selection is not None
+            else 0
+        )
+        on_prepared(
+            execution.frozen_suite,
+            len(execution.scenarios),
+            len(execution.invalid_scenarios),
+            excluded,
+        )
+        for completed, (scenario, evaluation) in enumerate(
+            zip(execution.scenarios, execution.evaluations),
+            start=1,
+        ):
+            progress(
+                completed,
+                len(execution.scenarios),
+                scenario,
+                evaluation,
+            )
+        return execution
+
+    return execute
+
+
 @pytest.mark.parametrize(
     ("code", "message"),
     [
@@ -67,7 +134,7 @@ def test_test_command_surfaces_actionable_infrastructure_diagnostics(
 ) -> None:
     scenario = build_account_support_suite()[0]
     execution = _infra_execution(scenario, code=code, message=message)
-    monkeypatch.setattr(cli, "execute_suite", lambda *_args, **_kwargs: execution)
+    monkeypatch.setattr(cli, "execute_suite", _execute_with_progress(execution))
     monkeypatch.setattr(cli, "_print_inspection", lambda *_args, **_kwargs: None)
 
     assert cli.main(["test", "."]) == 2
@@ -76,6 +143,95 @@ def test_test_command_surfaces_actionable_infrastructure_diagnostics(
     assert f"INFRA_ERROR — {code}: {message}" in output
     assert scenario.title in output
     assert "Traceback" not in output
+
+
+def test_test_command_reports_stages_and_scenario_progress_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    scenario = build_account_support_suite()[0]
+    execution = _execution_for_verdict(scenario, Verdict.PASS)
+    monkeypatch.setattr(cli, "execute_suite", _execute_with_progress(execution))
+    monkeypatch.setattr(cli, "_print_inspection", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli,
+        "_print_action_path_exercise",
+        lambda *_args, **_kwargs: None,
+    )
+
+    assert cli.main(["test", "."]) == 0
+
+    output = capsys.readouterr().out
+    expected = (
+        "Inspecting agent...",
+        "Inspection complete. ✓",
+        "Building deterministic test suite... ✓ 1 scenario",
+        "Running 1 scenario in isolated workers...",
+        "[1/1]",
+        "Finalizing report...",
+    )
+    positions = [output.index(item) for item in expected]
+    assert positions == sorted(positions)
+    assert scenario.title in output
+    assert "[1/1]" in output
+    assert output.count(" PASS") >= 1
+
+
+@pytest.mark.parametrize(
+    ("verdict", "exit_code"),
+    [
+        (Verdict.PASS, 0),
+        (Verdict.FAIL, 1),
+        (Verdict.INCONCLUSIVE, 3),
+        (Verdict.INFRA_ERROR, 2),
+    ],
+)
+def test_test_progress_renders_each_verdict_without_changing_exit_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    verdict: Verdict,
+    exit_code: int,
+) -> None:
+    scenario = build_account_support_suite()[0]
+    execution = _execution_for_verdict(scenario, verdict)
+    monkeypatch.setattr(cli, "execute_suite", _execute_with_progress(execution))
+    monkeypatch.setattr(cli, "_print_inspection", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli,
+        "_print_action_path_exercise",
+        lambda *_args, **_kwargs: None,
+    )
+
+    assert cli.main(["test", "."]) == exit_code
+
+    output = capsys.readouterr().out
+    result_line = next(line for line in output.splitlines() if line.startswith("[1/1]"))
+    assert result_line.endswith(verdict.value)
+
+
+def test_test_progress_heartbeat_is_readable_without_a_tty() -> None:
+    stream = io.StringIO()
+    reporter = cli._TestProgressReporter(
+        stream=stream,
+        heartbeat_seconds=60.0,
+    )
+    reporter.start()
+    reporter.inspection_complete()
+    reporter.suite_ready(None, 2, 0, 0)
+    scenario = build_account_support_suite()[0]
+    evaluation = _execution_for_verdict(scenario, Verdict.PASS).evaluations[0]
+    reporter.case_completed(1, 2, scenario, evaluation)
+    reporter.emit_heartbeat()
+    reporter.close()
+
+    output = stream.getvalue()
+    result_position = output.index("[1/2]")
+    heartbeat_position = output.index("1 scenario still running (1/2 complete)")
+    assert result_position < heartbeat_position
+    assert "[1/2] Still running..." not in output
+    assert "\r" not in output
+    assert "\x1b" not in output
+    assert "\b" not in output
 
 
 def test_infrastructure_diagnostic_is_redacted_single_line_and_bounded(

--- a/tests/agentcheck/test_cli_e2e.py
+++ b/tests/agentcheck/test_cli_e2e.py
@@ -201,8 +201,24 @@ def test_offline_cli_runs_complete_phase1_flow_with_intercepted_tools(
 
     assert execution.returncode == 1, execution.stderr
     assert execution.stderr == ""
-    assert len(re.findall(r"^PASS\s+", execution.stdout, flags=re.MULTILINE)) == 7
-    assert len(re.findall(r"^FAIL\s+", execution.stdout, flags=re.MULTILINE)) == 5
+    assert len(
+        re.findall(r"^\[\d+/12\].+\sPASS$", execution.stdout, flags=re.MULTILINE)
+    ) == 7
+    assert len(
+        re.findall(r"^\[\d+/12\].+\sFAIL$", execution.stdout, flags=re.MULTILINE)
+    ) == 5
+    stages = (
+        "Inspecting agent...",
+        "Inspection complete. ✓",
+        "Building deterministic test suite... ✓ 12 scenarios",
+        "Running 12 scenarios in isolated workers...",
+        "[1/12]",
+        "Finalizing report...",
+    )
+    positions = [execution.stdout.index(stage) for stage in stages]
+    assert positions == sorted(positions)
+    assert "\r" not in execution.stdout
+    assert "\x1b" not in execution.stdout
     assert "Observed suite pass rate: 58.3%" in execution.stdout
     assert "Passed:        7" in execution.stdout
     assert "Failed:        5" in execution.stdout

--- a/tests/agentcheck/test_suite_compatibility.py
+++ b/tests/agentcheck/test_suite_compatibility.py
@@ -239,7 +239,7 @@ def test_cli_test_with_frozen_suite_does_not_report_suite_mismatch(
     assert "No compatible built-in suite" not in combined
     assert "No valid scenarios remain after linting" not in captured.err
     assert "INFRA_ERROR" in captured.out
-    assert "Using frozen suite" in captured.out
+    assert "Loading frozen suite... ✓" in captured.out
 
 
 def test_unsupported_preflight_is_reported_before_suite_mismatch(


### PR DESCRIPTION
## Summary

- adds clear stage progress for `agentcheck test`
- adds per-scenario `PASS` / `FAIL` / `INCONCLUSIVE` / `INFRA_ERROR` output
- adds a low-frequency 10-second heartbeat for long-running scenarios
- keeps output bounded, redacted, newline-only, and CI-safe
- changes no evaluation semantics
- used no provider calls during validation