### PR TITLE
Bump AgentCheck to 0.1.1

### DIFF
--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ name = "agentcheck-ai"
 # fingerprint is a hash of that document. Bumping it re-identifies every
 # existing suite, baseline, and replay manifest, so treat it as a contract
 # change rather than a routine version bump.
-version = "0.1.0"
+version = "0.1.1"
 description = "Deterministic, local behavioral and safety evaluation for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the `agentcheck-ai` distribution and runtime version to `0.1.1`
- publish the already-merged CLI progress UX improvement as a patch release
- leave frozen-suite fingerprint/version coupling unchanged

## Validation

- both source version declarations report `0.1.1`
- `agentcheck --version` reports `agentcheck 0.1.1`
- wheel and sdist built successfully
- strict metadata, version, entry-point, and distribution-content validation passed
- `git diff --check` passed
- provider calls: 0

No runtime, evaluation-semantic, workflow, or AgentLens changes.