### PR TITLE
Finalize public CI safety and hosted-runner headroom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    # This is a library with tested compatibility ranges, not an application
+    # lockfile. Do not raise a supported minimum when the declared range already
+    # permits the newly released version.
+    versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 5
     labels:
       - dependencies

--- a/.github/workflows/agentcheck-example.yml
+++ b/.github/workflows/agentcheck-example.yml
@@ -49,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -69,7 +69,7 @@ jobs:
     needs: scope
     if: needs.scope.outputs.expensive == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/docs/ci-trust-model.md
+++ b/docs/ci-trust-model.md
@@ -30,24 +30,20 @@ are not widened for CI.
 
 ## Self-hosted runners
 
-A personal self-hosted runner must not remain attached when this repository is
-public. A fork can propose a workflow that targets any repository-level runner;
-job guards, CODEOWNERS, and branch rules operate too late to prevent that
-pre-merge execution. The repository's personal-account ownership also provides
-no organization runner group that can restrict a runner to a selected trusted
-workflow.
+No self-hosted runner is registered with this public repository, and public
+workflows must remain GitHub-hosted. A fork can propose a workflow that targets
+any repository-level runner; job guards, CODEOWNERS, and branch rules operate
+too late to prevent that pre-merge execution.
 
-Before changing visibility, remove the repository-level self-hosted runner under
-**Settings → Actions → Runners**. If trusted self-hosted execution is needed in
-the future, move the repository to an organization and use an isolated ephemeral
-runner group limited to selected repositories and a trusted workflow pinned to
-`refs/heads/main`. Do not rely on a YAML `if` condition alone.
+If a repository-level self-hosted runner is ever attached accidentally, remove
+it under **Settings → Actions → Runners**. Do not rely on a YAML `if`
+condition to protect a personal machine from untrusted pull-request code.
 
 ## Fork approval and secrets
 
-After the repository is public, set **Settings → Actions → General → Approval for
-running fork pull request workflows** to require approval for all external
-contributors. Review workflow changes before approving a run. This is
+Set **Settings → Actions → General → Approval for running fork pull request
+workflows** to require approval for all external contributors. Review workflow
+changes before approving a run. This is
 defense-in-depth; GitHub-hosted isolation, read-only permissions, and the absence
 of secrets are still required.
 

--- a/tests/agentcheck/test_workflow_safety.py
+++ b/tests/agentcheck/test_workflow_safety.py
@@ -151,6 +151,18 @@ def test_public_trust_model_is_discoverable() -> None:
 
 
 def test_process_heavy_pytest_commands_are_serial_on_hosted_runners() -> None:
+    workflow = _load(WORKFLOWS / "ci.yml")
+    assert workflow["jobs"]["tests"]["timeout-minutes"] == 60
     ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     assert "tests -q -n 1" in ci
     assert '"${compat[@]}" -q -n 1' in ci
+
+
+def test_dependabot_preserves_supported_python_dependency_ranges() -> None:
+    config = _load(REPOSITORY_ROOT / ".github" / "dependabot.yml")
+    pip_updates = next(
+        update
+        for update in config["updates"]
+        if update["package-ecosystem"] == "pip"
+    )
+    assert pip_updates["versioning-strategy"] == "increase-if-necessary"

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -1,9 +1,8 @@
 """The cross-version compatibility suite: what runs on every supported Python.
 
 The full suite runs once, on the newest supported interpreter. Running the entire
-suite three times costs about 70 minutes of a single self-hosted runner's
-serial queue, and most of that third and second pass re-executes pure logic that
-cannot behave differently between 3.10 and 3.12.
+suite on all three interpreters would repeat most process-heavy pure-logic tests
+that cannot behave differently between 3.10 and 3.12.
 
 What *can* differ is narrow and identifiable. The package contains no
 ``sys.version_info`` branching at all, so cross-version risk is not in its


### PR DESCRIPTION
## Summary

- increase only the GitHub-hosted Python test-job timeout from 40 to 60 minutes
- retain serialized pytest execution on standard `ubuntu-latest` runners
- update the remaining SHA-pinned Checkout and Setup Python actions to the versions already used by the release workflow
- keep Dependabot from raising supported Python dependency minimums when current ranges already admit a release
- update the CI trust guide to reflect the repository's current public, GitHub-hosted-only posture
- add regression coverage for the 60-minute CI cap and dependency-range policy

This supersedes #17 and #20. It does not change AgentCheck scenario, worker, provider, or product wall-clock budgets.

## Validation

- full Python 3.12 suite: 1,118 passed, serial `-n 1`
- focused workflow/documentation/package-boundary tests: 118 passed
- Ruff: passed
- mypy: passed
- workflow safety and YAML parsing: passed
- current-tree secret scan: passed
- wheel/sdist content audit and clean-wheel smoke install: passed
- provider calls: 0
- API spend: $0

No evaluation semantics, ToolGateway behavior, isolation, source integrity, replay behavior, package version, release, or tag changes.