### PR TITLE
feat: report declared behavioral coverage for generated suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ failed assertions, simulated state where available, and a replay manifest.
 Review artifacts before sharing them; they may contain prompts, model output,
 tool inputs, and absolute paths.
 
+The `generate` command and run reports also show [declared behavioral
+coverage](docs/behavioral-coverage.md): which declared-tool success, failure,
+and timeout requirements—and which explicitly represented retry, confirmation,
+duplicate-action, and prerequisite contracts—the suite covers or leaves
+missing. This is not a claim that every real-world behavior was observed.
+
 Replay is a source-bound re-execution recipe. It verifies recorded source,
 configuration, specification, and scenario bindings before running again. It
 reproduces inputs and harness behavior; it does not capture provider output or
@@ -188,6 +194,7 @@ and read the [CI trust model](docs/ci-trust-model.md).
 - [PydanticAI setup and offline evaluation](docs/pydantic-ai.md)
 - [Custom Python agent contract](docs/custom-agents.md)
 - [Validation evidence and claim boundaries](docs/validation-evidence.md)
+- [Declared behavioral coverage](docs/behavioral-coverage.md)
 - [CI trust model](docs/ci-trust-model.md)
 - [PyPI package](https://pypi.org/project/agentcheck-ai/)
 

--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -20,6 +20,11 @@ from agentcheck.config import (
     contained_path,
     load_config,
 )
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+    analyze_behavioral_coverage,
+)
 from agentcheck.domain import (
     AgentSpec,
     CanonicalRun,
@@ -126,6 +131,7 @@ class SuiteGeneration:
     spec: AgentSpec
     suite: FrozenSuite
     suite_path: Path
+    behavioral_coverage: BehavioralCoverage
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,6 +166,7 @@ class SuiteExecution:
     findings: tuple[Finding, ...]
     artifact_directory: Path
     report_path: Path
+    behavioral_coverage: BehavioralCoverage
     selection: SelectionPlan | None = None
     replay_manifest_path: Path | None = None
 
@@ -273,6 +280,7 @@ def generate_suite(
     representative_inputs = load_representative_inputs(root, spec)
     scenario_requests = load_scenario_requests(root, spec)
     prerequisite_outcomes = load_prerequisite_outcomes(root, spec)
+    coverage_reference_scenarios: list[Scenario] = []
     suite = build_frozen_suite(
         spec,
         config,
@@ -285,6 +293,13 @@ def generate_suite(
         representative_inputs=representative_inputs,
         scenario_requests=scenario_requests,
         prerequisite_outcomes=prerequisite_outcomes,
+        _reference_scenarios=coverage_reference_scenarios,
+    )
+    behavioral_coverage = analyze_behavioral_coverage(
+        spec,
+        suite.scenarios,
+        suite_fingerprint=suite.fingerprint,
+        reference_scenarios=tuple(coverage_reference_scenarios),
     )
     write_frozen_suite(destination, suite, force=force)
     return SuiteGeneration(
@@ -293,6 +308,7 @@ def generate_suite(
         spec=spec,
         suite=suite,
         suite_path=destination,
+        behavioral_coverage=behavioral_coverage,
     )
 
 
@@ -403,6 +419,17 @@ def execute_suite(
             "No valid scenarios remain after linting; no agent verdict was produced."
         )
 
+    reference_scenarios = tuple(valid)
+    bounded_frozen = (
+        frozen is not None
+        and frozen.selection is not None
+        and bool(frozen.selection.excluded_ids)
+    )
+    reference_scope = (
+        BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+        if bounded_frozen
+        else BehavioralCoverageReferenceScope.COMPLETE
+    )
     selection_plan: SelectionPlan | None = None if frozen is None else frozen.selection
     if select == "coverage":
         extra_tags: dict[str, Sequence[str]] = {}
@@ -430,6 +457,12 @@ def execute_suite(
                 "no agent verdict was produced."
             )
 
+    if reference_scope is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY:
+        # A persisted pruned suite cannot supply the cases it discarded before
+        # freezing, so the reference set can only be what actually survived.
+        # Re-read it here so a further runtime selection is reflected too.
+        reference_scenarios = tuple(valid)
+
     if on_prepared is not None:
         excluded_by_selection = (
             len(selection_plan.excluded_ids) if selection_plan is not None else 0
@@ -445,6 +478,8 @@ def execute_suite(
         revision=revision,
         valid=tuple(valid),
         invalid=tuple(invalid),
+        reference_scenarios=reference_scenarios,
+        reference_scope=reference_scope,
         frozen=frozen,
         selection_plan=selection_plan,
         progress=progress,
@@ -511,6 +546,8 @@ def replay_suite(
         revision=revision,
         valid=tuple(valid),
         invalid=(),
+        reference_scenarios=tuple(valid),
+        reference_scope=BehavioralCoverageReferenceScope.COMPLETE,
         frozen=None,
         selection_plan=None,
         progress=progress,
@@ -767,12 +804,22 @@ def _execute_valid_scenarios(
     revision: str | None,
     valid: tuple[Scenario, ...],
     invalid: tuple[InvalidScenario, ...],
+    reference_scenarios: tuple[Scenario, ...],
+    reference_scope: BehavioralCoverageReferenceScope,
     frozen: FrozenSuite | None,
     selection_plan: SelectionPlan | None,
     progress: ProgressCallback | None,
     persist_store: bool,
     policy_pack_ids: tuple[str, ...],
 ) -> SuiteExecution:
+    valid_scenarios = tuple(valid)
+    behavioral_coverage = analyze_behavioral_coverage(
+        spec,
+        valid_scenarios,
+        reference_scenarios=reference_scenarios,
+        reference_scope=reference_scope,
+        suite_fingerprint=frozen.fingerprint if frozen is not None else None,
+    )
     indexed_results: dict[int, tuple[CanonicalRun | None, CaseEvaluation]] = {}
     with ThreadPoolExecutor(
         max_workers=min(config.max_concurrency, max(1, len(valid))),
@@ -823,7 +870,6 @@ def _execute_valid_scenarios(
     ordered = tuple(indexed_results[index] for index in range(len(valid)))
     runs = tuple(case_run for case_run, _ in ordered if case_run is not None)
     evaluations = tuple(evaluation for _, evaluation in ordered)
-    valid_scenarios = tuple(valid)
     findings = analyze_failures(valid_scenarios, evaluations)
     artifacts = ArtifactStore(root, config.artifacts_directory, suite_run_id)
     artifacts.write_json("agent-spec.json", spec)
@@ -862,6 +908,7 @@ def _execute_valid_scenarios(
         "counts": {verdict.value: counts[verdict] for verdict in Verdict},
         "finding_count": len(findings),
         "seed": effective_seed,
+        "behavioral_coverage": behavioral_coverage.model_dump(mode="json"),
     }
     if selection_plan is not None:
         summary["excluded_by_selection"] = len(selection_plan.excluded_ids)
@@ -884,6 +931,8 @@ def _execute_valid_scenarios(
         seed=effective_seed,
         frozen_suite=frozen,
         selection_plan=selection_plan,
+        behavioral_coverage=behavioral_coverage,
+        _coverage_reference_scenarios=reference_scenarios,
     )
     report_path = artifacts.write_text("report.html", report)
     replay_path = _emit_replay_manifest(
@@ -912,6 +961,7 @@ def _execute_valid_scenarios(
         artifact_directory=artifacts.root,
         report_path=report_path,
         selection=selection_plan,
+        behavioral_coverage=behavioral_coverage,
         replay_manifest_path=replay_path,
     )
     if persist_store:

--- a/agentcheck/cli.py
+++ b/agentcheck/cli.py
@@ -24,6 +24,11 @@ from agentcheck.application import (
 from agentcheck.baseline.contract import DEFAULT_BASELINE_FILENAME
 from agentcheck.baseline.service import check_baseline, create_baseline, encode_comparison
 from agentcheck.config import DEFAULT_ENTRYPOINT, contained_path, entrypoint_location
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+    BehavioralCoverageStatus,
+)
 from agentcheck.fixtures import (
     DEFAULT_FIXTURES_FILENAME,
     FIXTURE_PACK_CONTRACT_VERSION,
@@ -62,6 +67,8 @@ _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$")
 _CONSOLE_ERROR_CODE_CHARS = 80
 _CONSOLE_ERROR_MESSAGE_CHARS = 320
 _CONSOLE_SCENARIO_TITLE_CHARS = 96
+_CONSOLE_COVERAGE_SUBJECT_CHARS = 500
+_CONSOLE_COVERAGE_REASON_CHARS = 100
 _TEST_PROGRESS_HEARTBEAT_SECONDS = 10.0
 _TEST_PROGRESS_RESULT_COLUMN = 72
 _TRUNCATION_MARKER = "...[TRUNCATED]"
@@ -799,6 +806,93 @@ def _print_action_path_coverage(coverage: Any, target: Any) -> None:
         print(f"  Add representative test data:  agentcheck fixtures init {target}")
 
 
+_UNCOVERED_BEHAVIORAL_STATUSES = (
+    BehavioralCoverageStatus.PARTIAL,
+    BehavioralCoverageStatus.MISSING,
+    BehavioralCoverageStatus.UNKNOWN,
+    BehavioralCoverageStatus.UNSUPPORTED,
+)
+
+
+def _print_declared_behavioral_coverage(coverage: BehavioralCoverage) -> None:
+    """Render declared suite coverage without implying overall completeness.
+
+    ``unknown`` and ``unsupported`` requirements are deliberately outside the
+    applicable denominator.  They remain visible beside exact requirement
+    subjects so a zero denominator cannot be mistaken for complete coverage.
+    """
+
+    print()
+    print("Declared behavioral coverage:")
+    print(
+        f"  Evidence scenarios: {coverage.scenario_count} / "
+        f"{coverage.reference_scenario_count} reference scenarios"
+    )
+    if (
+        coverage.reference_scope
+        is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+    ):
+        print(
+            "  Warning: the reference scope contains available scenarios only; "
+            "unavailable scenario contracts may add behavioral requirements."
+        )
+    families = tuple(
+        family
+        for family in coverage.families
+        if sum(
+            (
+                family.covered,
+                family.partial,
+                family.missing,
+                family.unknown,
+                family.unsupported,
+            )
+        )
+        > 0
+    )
+    if not families:
+        print("  No declared behavioral requirements were identified.")
+        return
+
+    for family in families:
+        label = family.dimension.value.replace("_", " ").capitalize()
+        print(
+            f"  {label}: {family.covered} covered / "
+            f"{family.applicable} applicable; "
+            f"partial {family.partial}; missing {family.missing}; "
+            f"unknown {family.unknown}; unsupported {family.unsupported}"
+        )
+        for status in _UNCOVERED_BEHAVIORAL_STATUSES:
+            requirements = (
+                requirement
+                for requirement in family.requirements
+                if requirement.status is status
+            )
+            for requirement in requirements:
+                subject = _bounded_console_diagnostic(
+                    requirement.subject,
+                    max_chars=_CONSOLE_COVERAGE_SUBJECT_CHARS,
+                )
+                reason_code = _bounded_console_diagnostic(
+                    requirement.reason_code,
+                    max_chars=_CONSOLE_COVERAGE_REASON_CHARS,
+                )
+                print(
+                    f"    {status.value}: {subject} [{reason_code}]"
+                )
+
+        visible_counts = Counter(
+            requirement.status for requirement in family.requirements
+        )
+        for status in _UNCOVERED_BEHAVIORAL_STATUSES:
+            hidden = getattr(family, status.value) - visible_counts[status]
+            if hidden:
+                print(
+                    f"    {status.value}: {hidden} additional requirement "
+                    f"subject(s) omitted from the bounded coverage record"
+                )
+
+
 def _print_inspection(
     spec: AgentSpec,
     *,
@@ -1196,6 +1290,7 @@ def _generate_command(
     if realized:
         print(f"Realized:     {realized} display overlay(s)")
     print(f"Fingerprint:  {generation.suite.fingerprint}")
+    _print_declared_behavioral_coverage(generation.behavioral_coverage)
     _print_action_path_coverage(generation.suite.coverage, generation.target_root)
     print()
     print("Next steps:")
@@ -1291,6 +1386,7 @@ def _test_command(
     print(f"Failed:        {counts[Verdict.FAIL]}")
     print(f"Inconclusive:  {counts[Verdict.INCONCLUSIVE]}")
     print(f"Infra errors:  {counts[Verdict.INFRA_ERROR]}")
+    _print_declared_behavioral_coverage(execution.behavioral_coverage)
     _print_action_path_exercise(execution)
 
     severity_counts = Counter(item.severity for item in execution.findings)

--- a/agentcheck/coverage/__init__.py
+++ b/agentcheck/coverage/__init__.py
@@ -1,0 +1,24 @@
+"""Declared, observable behavioral coverage for AgentCheck suites."""
+
+from .analyzer import analyze_behavioral_coverage, verify_behavioral_coverage_binding
+from .contract import (
+    BEHAVIORAL_COVERAGE_CONTRACT_VERSION,
+    BehavioralCoverage,
+    BehavioralCoverageFamily,
+    BehavioralCoverageReferenceScope,
+    BehavioralCoverageRequirement,
+    BehavioralCoverageStatus,
+    BehavioralDimension,
+)
+
+__all__ = [
+    "BEHAVIORAL_COVERAGE_CONTRACT_VERSION",
+    "BehavioralCoverage",
+    "BehavioralCoverageFamily",
+    "BehavioralCoverageReferenceScope",
+    "BehavioralCoverageRequirement",
+    "BehavioralCoverageStatus",
+    "BehavioralDimension",
+    "analyze_behavioral_coverage",
+    "verify_behavioral_coverage_binding",
+]

--- a/agentcheck/coverage/analyzer.py
+++ b/agentcheck/coverage/analyzer.py
@@ -1,0 +1,2200 @@
+"""Pure behavioral-coverage analysis over validated contract data.
+
+The analyzer never imports a target, adapter, gateway, or world simulator.  It
+only asks whether a suite contains a controlled opportunity and an executable
+oracle for requirements that the target or scenarios establish explicitly.
+Names and descriptions are identifiers/evidence only; they are never risk
+classification inputs.
+"""
+
+from __future__ import annotations
+
+import hmac
+from collections import Counter
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Iterable, Mapping, Sequence, overload
+
+from jsonschema.exceptions import SchemaError  # type: ignore[import-untyped]
+from referencing.exceptions import Unresolvable
+
+from agentcheck.domain import (
+    AgentSpec,
+    FaultType,
+    OracleStrength,
+    OutputCriterion,
+    OutputCriterionKind,
+    Scenario,
+    SimulatedToolStatus,
+    ToolBehaviorConstraint,
+    ToolDefinition,
+    TrajectoryConstraint,
+    TrajectoryConstraintKind,
+    canonical_hash,
+)
+from agentcheck.privacy import redact_log_text
+from agentcheck.redaction import DEFAULT_REDACTED_KEYS, sanitize_value
+from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
+
+from .contract import (
+    MAX_COVERAGE_DETAILS,
+    BehavioralCoverage,
+    BehavioralCoverageFamily,
+    BehavioralCoverageReferenceScope,
+    BehavioralCoverageRequirement,
+    BehavioralCoverageStatus,
+    BehavioralDimension,
+)
+
+
+_PREREQUISITE_PREFIXES = ("prerequisite-", "prerequisite:")
+_GENERATOR_ACTION_SOURCES = {
+    "source:positive_path",
+    "source:behavioral_outcome",
+    "source:confirmed_action",
+}
+_TOOL_SCOPED_TRAJECTORY_KINDS = {
+    TrajectoryConstraintKind.CONFIRMATION_BEFORE_TOOL,
+    TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT,
+    TrajectoryConstraintKind.MAX_RETRIES,
+    TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT,
+    TrajectoryConstraintKind.ORDERING,
+}
+
+
+class _Applicability(str, Enum):
+    UNKNOWN = "unknown"
+    UNSUPPORTED = "unsupported"
+    APPLICABLE = "applicable"
+
+
+_APPLICABILITY_RANK = {
+    _Applicability.UNKNOWN: 0,
+    _Applicability.UNSUPPORTED: 1,
+    _Applicability.APPLICABLE: 2,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _Seed:
+    dimension: BehavioralDimension
+    subject: str
+    applicability: _Applicability
+    tool_name: str | None = None
+    prerequisite_tool_name: str | None = None
+    unknown_reason: str = "risk_metadata_not_authoritative"
+
+
+@dataclass(frozen=True, slots=True)
+class _Slot:
+    tool_name: str
+    invocation_index: int | None
+    arguments_match: Mapping[str, object]
+    status: SimulatedToolStatus
+    error_code: str | None
+    evidence_id: str
+    priority: int
+    latency_ms: float
+    has_state_effects: bool
+    position: int
+
+
+@dataclass(frozen=True, slots=True)
+class _Outcome:
+    status: BehavioralCoverageStatus
+    reason_code: str
+    evidence: tuple[str, ...]
+
+
+_OUTCOME_RANK = {
+    BehavioralCoverageStatus.PARTIAL: 1,
+    BehavioralCoverageStatus.COVERED: 2,
+}
+
+
+def _tool_subject(tool_name: str) -> str:
+    return f"tool:{tool_name}"
+
+
+def _prerequisite_subject(focal_tool: str, prerequisite_tool: str) -> str:
+    return f"prerequisite:{prerequisite_tool}->tool:{focal_tool}"
+
+
+def _artifact_normalize(value: object) -> object:
+    """Apply artifact string/key redaction without a shared truncation budget."""
+
+    if isinstance(value, str):
+        return sanitize_value(value, redacted_keys=DEFAULT_REDACTED_KEYS)
+    if isinstance(value, Mapping):
+        normalized: dict[str, object] = {}
+        for raw_key, item in value.items():
+            safe_pair = sanitize_value({raw_key: None}, redacted_keys=DEFAULT_REDACTED_KEYS)
+            safe_key, marker = next(iter(safe_pair.items()))
+            normalized[str(safe_key)] = (
+                marker if marker == "[REDACTED]" else _artifact_normalize(item)
+            )
+        return normalized
+    if isinstance(value, list | tuple):
+        return [_artifact_normalize(item) for item in value]
+    return sanitize_value(value, redacted_keys=DEFAULT_REDACTED_KEYS)
+
+
+# These conservative schema-local bounds leave room for the surrounding
+# AgentSpec/ArtifactStore envelope beneath its 20-level/100,000-node limits.
+# Crossing a bound makes coverage UNKNOWN; the discarded schema content is
+# never hashed or reconstructed from a stored prefix.
+_STABLE_PROJECTION_ITEMS = 100
+_STABLE_PROJECTION_DEPTH = 14
+_STABLE_PROJECTION_NODES = 10_000
+_SCHEMA_PROJECTION_CONTRACT = "agentcheck.behavioral_coverage.schema_projection.v1"
+_ARTIFACT_LOSS_SENTINELS = frozenset(
+    {
+        "[CYCLE]",
+        "[MAX_DEPTH]",
+        "[NUMBER_OUT_OF_RANGE]",
+        "[REDACTED]",
+        "[TRUNCATED]",
+        "[TRUNCATED_NODES]",
+        "[UNAVAILABLE_ITEMS]",
+    }
+)
+
+
+def _contains_artifact_loss_sentinel(value: object) -> bool:
+    """Recognize exact normalization sentinels retained in a stored spec.
+
+    Collection truncation is handled structurally by the item bound; a
+    user-authored ``[TRUNCATED_ITEMS]`` key is not itself evidence of loss.
+    """
+
+    if isinstance(value, str):
+        return (
+            value in _ARTIFACT_LOSS_SENTINELS
+            or "[REDACTED]" in value
+            or value.endswith("...[TRUNCATED]")
+        )
+    if isinstance(value, Mapping):
+        return any(
+            _contains_artifact_loss_sentinel(key)
+            or _contains_artifact_loss_sentinel(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list | tuple):
+        return any(_contains_artifact_loss_sentinel(item) for item in value)
+    return False
+
+
+@dataclass(frozen=True, slots=True)
+class _StableProjection:
+    value: object | None
+    lossless: bool
+
+
+def _stable_projection(
+    value: object,
+    *,
+    depth: int,
+    nodes_remaining: list[int],
+) -> _StableProjection:
+    if depth > _STABLE_PROJECTION_DEPTH or nodes_remaining[0] <= 0:
+        return _StableProjection(value=None, lossless=False)
+    nodes_remaining[0] -= 1
+
+    if isinstance(value, Mapping):
+        if len(value) > _STABLE_PROJECTION_ITEMS:
+            return _StableProjection(value=None, lossless=False)
+        projected: dict[str, object] = {}
+        for raw_key, item in value.items():
+            safe_pair = sanitize_value(
+                {raw_key: None},
+                redacted_keys=DEFAULT_REDACTED_KEYS,
+            )
+            safe_key, marker = next(iter(safe_pair.items()))
+            if safe_key != raw_key or marker == "[REDACTED]":
+                return _StableProjection(value=None, lossless=False)
+            child = _stable_projection(
+                item,
+                depth=depth + 1,
+                nodes_remaining=nodes_remaining,
+            )
+            if not child.lossless:
+                return _StableProjection(value=None, lossless=False)
+            projected[str(raw_key)] = child.value
+        return _StableProjection(value=projected, lossless=True)
+
+    if isinstance(value, list | tuple):
+        if len(value) > _STABLE_PROJECTION_ITEMS:
+            return _StableProjection(value=None, lossless=False)
+        projected_items: list[object] = []
+        for item in value:
+            child = _stable_projection(
+                item,
+                depth=depth + 1,
+                nodes_remaining=nodes_remaining,
+            )
+            if not child.lossless:
+                return _StableProjection(value=None, lossless=False)
+            projected_items.append(child.value)
+        return _StableProjection(value=projected_items, lossless=True)
+
+    normalized = _artifact_normalize(value)
+    return _StableProjection(
+        value=normalized if normalized == value else None,
+        lossless=normalized == value,
+    )
+
+
+def _stable_bounded_projection(value: object) -> _StableProjection:
+    """Return an ArtifactStore-idempotent semantic projection.
+
+    Lossy schemas collapse outside the user document, so a literal marker-like
+    schema cannot collide with the internal loss state.
+    """
+
+    if _contains_artifact_loss_sentinel(value):
+        return _StableProjection(value=None, lossless=False)
+    return _stable_projection(
+        value,
+        depth=0,
+        nodes_remaining=[_STABLE_PROJECTION_NODES],
+    )
+
+
+def _tool_binding_is_lossless(tool: ToolDefinition) -> bool:
+    """Return whether coverage semantics survive the artifact boundary exactly."""
+    projection = _stable_bounded_projection(tool.input_schema)
+    return (
+        not _contains_artifact_loss_sentinel(tool.name)
+        and redact_log_text(tool.name) == tool.name
+        and projection.lossless
+    )
+
+
+def _input_schema_digest(input_schema: object) -> str:
+    projection = _stable_bounded_projection(input_schema)
+    return canonical_hash(
+        {
+            "contract": _SCHEMA_PROJECTION_CONTRACT,
+            "lossless": projection.lossless,
+            "value": projection.value,
+        }
+    )
+
+
+def _scenario_digest(scenarios: Sequence[Scenario]) -> str:
+    # Display IDs occur in evidence, so binding only behavioral fingerprints
+    # would let a relabelled source validate while its evidence referred to an
+    # absent scenario. Sorting retains duplicates while removing input order.
+    identities = sorted(
+        (scenario.scenario_id, scenario.fingerprint) for scenario in scenarios
+    )
+    return canonical_hash(_artifact_normalize(identities))
+
+
+def _spec_digest(spec: AgentSpec) -> str:
+    """Bind exactly the declared spec fields that determine coverage meaning."""
+
+    projection = {
+        "tools": [
+            {
+                "authoritative": item.authoritative,
+                "name": item.value.name,
+                "input_schema_digest": _input_schema_digest(
+                    item.value.input_schema
+                ),
+                "state_changing": item.value.state_changing,
+                "destructive": item.value.destructive,
+                "replaceable": item.value.replaceable,
+            }
+            for item in sorted(spec.tools.items, key=lambda item: item.value.name)
+        ],
+        "tool_policies": [
+            {
+                "authoritative": item.authoritative,
+                "tool_name": item.value.tool_name,
+                "confirmation_required": item.value.confirmation_required,
+                "idempotent": item.value.idempotent,
+                "max_retries": item.value.max_retries,
+            }
+            for item in sorted(
+                spec.tool_policies.items,
+                key=lambda item: (item.value.tool_name, item.value.policy_id),
+            )
+        ],
+    }
+    return canonical_hash(_artifact_normalize(projection))
+
+
+def _add_seed(
+    seeds: dict[tuple[BehavioralDimension, str], _Seed],
+    dimension: BehavioralDimension,
+    subject: str,
+    applicability: _Applicability,
+    *,
+    tool_name: str | None = None,
+    prerequisite_tool_name: str | None = None,
+) -> None:
+    key = (dimension, subject)
+    candidate = _Seed(
+        dimension=dimension,
+        subject=subject,
+        applicability=applicability,
+        tool_name=tool_name,
+        prerequisite_tool_name=prerequisite_tool_name,
+    )
+    existing = seeds.get(key)
+    if existing is None or _APPLICABILITY_RANK[applicability] > _APPLICABILITY_RANK[
+        existing.applicability
+    ]:
+        seeds[key] = candidate
+
+
+def _focal_tools(scenario: Scenario) -> tuple[str, ...]:
+    names: set[str] = set()
+    for behavior in (
+        *scenario.required_tool_behavior,
+        *scenario.allowed_tool_behavior,
+        *scenario.forbidden_tool_behavior,
+    ):
+        names.add(behavior.tool_name)
+    for trajectory in scenario.trajectory_constraints:
+        if trajectory.kind not in _TOOL_SCOPED_TRAJECTORY_KINDS:
+            continue
+        tool_name = trajectory.parameters.get("tool_name")
+        if isinstance(tool_name, str) and tool_name:
+            names.add(tool_name)
+    return tuple(sorted(names))
+
+
+def _confirmation_tools(scenario: Scenario) -> tuple[str, ...]:
+    names = {
+        constraint.tool_name
+        for constraint in (
+            *scenario.required_tool_behavior,
+            *scenario.allowed_tool_behavior,
+            *scenario.forbidden_tool_behavior,
+        )
+        if constraint.confirmation_required_before_call
+    }
+    for constraint in scenario.trajectory_constraints:
+        if constraint.kind is not TrajectoryConstraintKind.CONFIRMATION_BEFORE_TOOL:
+            continue
+        tool_name = constraint.parameters.get("tool_name")
+        if isinstance(tool_name, str) and tool_name:
+            names.add(tool_name)
+    return tuple(sorted(names))
+
+
+def _prerequisite_pairs(scenario: Scenario) -> tuple[tuple[str, str], ...]:
+    declared_focal = set(_focal_tools(scenario))
+    tags = set(scenario.dimension_tags)
+    # Fixture IDs are a generator implementation detail, not a general
+    # prerequisite declaration. Recognize them only in an unambiguous generated
+    # action case whose source and focal-tool tags state that convention.
+    if not tags.intersection(_GENERATOR_ACTION_SOURCES):
+        return ()
+    focal = tuple(
+        sorted(
+            tag[5:]
+            for tag in tags
+            if tag.startswith("tool:") and tag[5:] in declared_focal
+        )
+    )
+    if len(focal) != 1:
+        return ()
+    prerequisites = {
+        fixture.tool_name
+        for fixture in scenario.tool_fixtures
+        if fixture.fixture_id.startswith(_PREREQUISITE_PREFIXES)
+    }
+    return tuple(
+        sorted(
+            (focal_tool, prerequisite)
+            for focal_tool in focal
+            for prerequisite in prerequisites
+            if prerequisite != focal_tool
+        )
+    )
+
+
+def _seed_from_spec(
+    spec: AgentSpec, seeds: dict[tuple[BehavioralDimension, str], _Seed]
+) -> None:
+    risk_dimensions = (
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+        BehavioralDimension.DUPLICATE_ACTION,
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        BehavioralDimension.RETRY_CONTROL,
+    )
+    for tool_item in sorted(spec.tools.items, key=lambda value: value.value.name):
+        tool = tool_item.value
+        subject = _tool_subject(tool.name)
+        for dimension in (
+            BehavioralDimension.SUCCESS_PATH,
+            BehavioralDimension.FAILURE_HANDLING,
+            BehavioralDimension.TIMEOUT_HANDLING,
+        ):
+            _add_seed(
+                seeds,
+                dimension,
+                subject,
+                _Applicability.APPLICABLE,
+                tool_name=tool.name,
+            )
+
+        if not tool_item.authoritative:
+            for dimension in risk_dimensions:
+                _add_seed(
+                    seeds,
+                    dimension,
+                    subject,
+                    _Applicability.UNKNOWN,
+                    tool_name=tool.name,
+                )
+            continue
+
+        state_changing = tool.state_changing or tool.destructive
+        if state_changing:
+            for dimension in (
+                BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+                BehavioralDimension.DUPLICATE_ACTION,
+            ):
+                _add_seed(
+                    seeds,
+                    dimension,
+                    subject,
+                    _Applicability.APPLICABLE,
+                    tool_name=tool.name,
+                )
+        if tool.destructive:
+            for dimension in (
+                BehavioralDimension.AMBIGUOUS_OUTCOME,
+                BehavioralDimension.RETRY_CONTROL,
+            ):
+                _add_seed(
+                    seeds,
+                    dimension,
+                    subject,
+                    _Applicability.APPLICABLE,
+                    tool_name=tool.name,
+                )
+
+    for policy_item in sorted(
+        spec.tool_policies.items,
+        key=lambda value: (value.value.tool_name, value.value.policy_id),
+    ):
+        policy = policy_item.value
+        subject = _tool_subject(policy.tool_name)
+        applicability = (
+            _Applicability.APPLICABLE
+            if policy_item.authoritative
+            else _Applicability.UNKNOWN
+        )
+        if policy.confirmation_required is True:
+            for dimension in (
+                BehavioralDimension.CONFIRMATION_WITHOUT_CONSENT,
+                BehavioralDimension.CONFIRMATION_WITH_CONSENT,
+            ):
+                _add_seed(
+                    seeds,
+                    dimension,
+                    subject,
+                    applicability,
+                    tool_name=policy.tool_name,
+                )
+        if policy.idempotent is False:
+            for dimension in (
+                BehavioralDimension.DUPLICATE_ACTION,
+                BehavioralDimension.AMBIGUOUS_OUTCOME,
+                BehavioralDimension.RETRY_CONTROL,
+            ):
+                _add_seed(
+                    seeds,
+                    dimension,
+                    subject,
+                    applicability,
+                    tool_name=policy.tool_name,
+                )
+        if policy.max_retries is not None:
+            _add_seed(
+                seeds,
+                BehavioralDimension.RETRY_CONTROL,
+                subject,
+                applicability,
+                tool_name=policy.tool_name,
+            )
+
+
+def _scenario_risk_applicability(
+    scenario: Scenario,
+    tool_name: str | None,
+    non_authoritative_risk_tools: set[str],
+) -> _Applicability:
+    if (
+        tool_name in non_authoritative_risk_tools
+        and "source:behavioral_outcome" in scenario.dimension_tags
+    ):
+        # These generator variants are selected from the same inferred tool
+        # flags; their controlled-world oracle is not an independent risk
+        # declaration and must not launder UNKNOWN into applicability.
+        return _Applicability.UNKNOWN
+    return _Applicability.APPLICABLE
+
+
+def _seed_from_scenarios(
+    scenarios: Sequence[Scenario],
+    seeds: dict[tuple[BehavioralDimension, str], _Seed],
+    non_authoritative_risk_tools: set[str],
+) -> None:
+    for scenario in scenarios:
+        focal_tools = _focal_tools(scenario)
+        for criterion in scenario.output_criteria:
+            if criterion.kind is OutputCriterionKind.NO_FABRICATED_SUCCESS:
+                for tool_name in focal_tools:
+                    _add_seed(
+                        seeds,
+                        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+                        _tool_subject(tool_name),
+                        _scenario_risk_applicability(
+                            scenario,
+                            tool_name,
+                            non_authoritative_risk_tools,
+                        ),
+                        tool_name=tool_name,
+                    )
+
+        for constraint in scenario.trajectory_constraints:
+            tool_name_value = constraint.parameters.get("tool_name")
+            trajectory_tool = (
+                tool_name_value
+                if isinstance(tool_name_value, str) and tool_name_value
+                else None
+            )
+            subject = (
+                _tool_subject(trajectory_tool)
+                if trajectory_tool is not None
+                else f"scenario:{scenario.scenario_id}"
+            )
+            if constraint.kind is TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT:
+                _add_seed(
+                    seeds,
+                    BehavioralDimension.DUPLICATE_ACTION,
+                    subject,
+                    _scenario_risk_applicability(
+                        scenario,
+                        trajectory_tool,
+                        non_authoritative_risk_tools,
+                    ),
+                    tool_name=trajectory_tool,
+                )
+            elif constraint.kind is TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT:
+                for dimension in (
+                    BehavioralDimension.AMBIGUOUS_OUTCOME,
+                    BehavioralDimension.RETRY_CONTROL,
+                ):
+                    _add_seed(
+                        seeds,
+                        dimension,
+                        subject,
+                        _scenario_risk_applicability(
+                            scenario,
+                            trajectory_tool,
+                            non_authoritative_risk_tools,
+                        ),
+                        tool_name=trajectory_tool,
+                    )
+            elif constraint.kind is TrajectoryConstraintKind.MAX_RETRIES:
+                _add_seed(
+                    seeds,
+                    BehavioralDimension.RETRY_CONTROL,
+                    subject,
+                    _scenario_risk_applicability(
+                        scenario,
+                        trajectory_tool,
+                        non_authoritative_risk_tools,
+                    ),
+                    tool_name=trajectory_tool,
+                )
+            elif constraint.kind is TrajectoryConstraintKind.ORDERING:
+                _add_seed(
+                    seeds,
+                    BehavioralDimension.ORDERING,
+                    subject,
+                    _Applicability.UNSUPPORTED,
+                    tool_name=trajectory_tool,
+                )
+
+        for tool_name in _confirmation_tools(scenario):
+            for dimension in (
+                BehavioralDimension.CONFIRMATION_WITHOUT_CONSENT,
+                BehavioralDimension.CONFIRMATION_WITH_CONSENT,
+            ):
+                _add_seed(
+                    seeds,
+                    dimension,
+                    _tool_subject(tool_name),
+                    _Applicability.APPLICABLE,
+                    tool_name=tool_name,
+                )
+
+        for focal_tool, prerequisite_tool in _prerequisite_pairs(scenario):
+            subject = _prerequisite_subject(focal_tool, prerequisite_tool)
+            for dimension in (
+                BehavioralDimension.PREREQUISITE_SUCCESS,
+                BehavioralDimension.PREREQUISITE_FAILURE,
+            ):
+                _add_seed(
+                    seeds,
+                    dimension,
+                    subject,
+                    _Applicability.APPLICABLE,
+                    tool_name=focal_tool,
+                    prerequisite_tool_name=prerequisite_tool,
+                )
+            _add_seed(
+                seeds,
+                BehavioralDimension.ORDERING,
+                subject,
+                _Applicability.UNSUPPORTED,
+                tool_name=focal_tool,
+                prerequisite_tool_name=prerequisite_tool,
+            )
+
+
+def _controlled_slots(scenario: Scenario) -> tuple[_Slot, ...]:
+    fault_slots = {
+        (fault.tool_name, fault.invocation_index) for fault in scenario.injected_faults
+    }
+    baseline = [
+        fixture
+        for fixture in scenario.tool_fixtures
+        if (fixture.tool_name, fixture.invocation_index) not in fault_slots
+    ]
+    slots = [
+        _Slot(
+            tool_name=fixture.tool_name,
+            invocation_index=fixture.invocation_index,
+            arguments_match=fixture.arguments_match,
+            status=fixture.outcome.status,
+            error_code=fixture.outcome.error_code,
+            evidence_id=f"fixture:{fixture.fixture_id}",
+            priority=fixture.priority,
+            position=position,
+            latency_ms=fixture.outcome.latency_ms,
+            has_state_effects=bool(fixture.outcome.state_effects),
+        )
+        for position, fixture in enumerate(baseline)
+    ]
+    status_by_fault = {
+        FaultType.ERROR: SimulatedToolStatus.ERROR,
+        FaultType.TIMEOUT: SimulatedToolStatus.TIMEOUT,
+        FaultType.MALFORMED_RESPONSE: SimulatedToolStatus.MALFORMED,
+        FaultType.EMPTY_RESPONSE: SimulatedToolStatus.EMPTY,
+        FaultType.PARTIAL_RESPONSE: SimulatedToolStatus.PARTIAL,
+        FaultType.STALE_RESPONSE: SimulatedToolStatus.STALE,
+    }
+    slots.extend(
+        _Slot(
+            tool_name=fault.tool_name,
+            invocation_index=fault.invocation_index,
+            arguments_match={},
+            status=status_by_fault[fault.fault_type],
+            # The runtime maps injected timeout to "timeout", not
+            # "ambiguous_timeout".  Do not upgrade it to ambiguity here.
+            error_code=fault.fault_type.value
+            if fault.fault_type in {FaultType.ERROR, FaultType.TIMEOUT}
+            else None,
+            evidence_id=f"fault:{fault.fault_id}",
+            priority=100,
+            position=len(baseline) + position,
+            latency_ms=fault.latency_ms or 0.0,
+            has_state_effects=False,
+        )
+        for position, fault in enumerate(scenario.injected_faults)
+    )
+    return tuple(slots)
+
+
+def _slots_for(scenario: Scenario, tool_name: str) -> tuple[_Slot, ...]:
+    return tuple(
+        slot for slot in _controlled_slots(scenario) if slot.tool_name == tool_name
+    )
+
+
+def _recursive_subset(expected: object, actual: object) -> bool:
+    if isinstance(expected, Mapping):
+        return isinstance(actual, Mapping) and all(
+            key in actual and _recursive_subset(value, actual[key])
+            for key, value in expected.items()
+        )
+    if isinstance(expected, list):
+        return isinstance(actual, list) and expected == actual
+    return expected == actual
+
+
+def _argument_specificity(value: object) -> int:
+    if isinstance(value, Mapping):
+        return sum(1 + _argument_specificity(item) for item in value.values())
+    if isinstance(value, list):
+        return len(value) + sum(_argument_specificity(item) for item in value)
+    return 1
+
+
+def _schema_allows(tool: ToolDefinition | None, arguments: Mapping[str, object]) -> bool:
+    # A schema this analyzer cannot evaluate offline yields no controlled
+    # reach. An unresolvable local reference only surfaces while validating,
+    # not while building, so both steps fail closed rather than escaping and
+    # aborting a run over derived report metadata.
+    if tool is None or not tool.replaceable:
+        return False
+    try:
+        validator = offline_validator(tool.input_schema, check_formats=True)
+        return not any(validator.iter_errors(dict(arguments)))
+    except (SchemaError, UnsafeSchemaReference, Unresolvable):
+        return False
+
+
+def _selected_trace(
+    scenario: Scenario,
+    tool: ToolDefinition | None,
+    tool_name: str,
+    arguments: Mapping[str, object],
+    invocation_count: int,
+) -> tuple[_Slot, ...]:
+    """Simulate gateway selection for one declared action signature.
+
+    Slots are consumed, priority/invocation specificity wins, and an equal best
+    score stops the trace because the gateway rejects ambiguous fixtures. This
+    remains pure contract analysis: no gateway, target, or handler is invoked.
+    """
+
+    if invocation_count < 1 or tool is None or tool.name != tool_name:
+        return ()
+    if not _schema_allows(tool, arguments):
+        return ()
+    slots = _slots_for(scenario, tool_name)
+    used: set[int] = set()
+    selected: list[_Slot] = []
+    elapsed_ms = 0.0
+    reachable_count = min(invocation_count, scenario.resource_budgets.max_tool_calls)
+    for invocation in range(1, reachable_count + 1):
+        candidates: list[tuple[tuple[int, int, int], _Slot]] = []
+        for slot in slots:
+            if slot.position in used:
+                continue
+            if slot.invocation_index not in {None, invocation}:
+                continue
+            if not _recursive_subset(slot.arguments_match, arguments):
+                continue
+            score = (
+                slot.priority,
+                int(slot.invocation_index is not None),
+                _argument_specificity(slot.arguments_match),
+            )
+            candidates.append((score, slot))
+        if not candidates:
+            break
+        best_score = max(score for score, _ in candidates)
+        best = [slot for score, slot in candidates if score == best_score]
+        if len(best) != 1:
+            break
+        chosen = best[0]
+        if (
+            elapsed_ms + chosen.latency_ms
+            > scenario.resource_budgets.wall_clock_seconds * 1000
+        ):
+            break
+        elapsed_ms += chosen.latency_ms
+        used.add(chosen.position)
+        selected.append(chosen)
+        if chosen.has_state_effects:
+            # This outcome is itself controlled and observable, so it stays in
+            # the trace. It also mutates the simulated world, and any later
+            # invocation then depends on state this pure contract analysis does
+            # not evaluate, so stop instead of claiming the next slot is
+            # reachable.
+            break
+    return tuple(selected)
+
+
+def _trace_for_constraint(
+    scenario: Scenario,
+    tool: ToolDefinition | None,
+    constraint: ToolBehaviorConstraint,
+    invocation_count: int,
+) -> tuple[_Slot, ...]:
+    return _selected_trace(
+        scenario,
+        tool,
+        constraint.tool_name,
+        constraint.arguments_match,
+        invocation_count,
+    )
+
+
+def _authoritative_oracle_ids(scenario: Scenario) -> set[str]:
+    return {
+        oracle.oracle_id
+        for oracle in scenario.oracle_provenance
+        if oracle.supports_hard_failure
+        and oracle.confidence >= 0.8
+        and oracle.strength is not OracleStrength.LLM_INFERENCE
+    }
+
+
+def _criterion_is_authoritative(
+    scenario: Scenario,
+    criterion: object,
+) -> bool:
+    oracle_ids = getattr(criterion, "oracle_ids", ())
+    return bool(
+        set(oracle_ids).intersection(_authoritative_oracle_ids(scenario))
+    )
+
+
+def _action_contracts(
+    scenario: Scenario, tool_name: str
+) -> tuple[
+    tuple[ToolBehaviorConstraint, ...],
+    tuple[ToolBehaviorConstraint, ...],
+    tuple[ToolBehaviorConstraint, ...],
+]:
+    required = tuple(
+        item
+        for item in scenario.required_tool_behavior
+        if item.tool_name == tool_name and item.min_calls >= 1
+    )
+    allowed = tuple(
+        item for item in scenario.allowed_tool_behavior if item.tool_name == tool_name
+    )
+    forbidden = tuple(
+        item for item in scenario.forbidden_tool_behavior if item.tool_name == tool_name
+    )
+    return required, allowed, forbidden
+
+
+def _traces_for_constraints(
+    scenario: Scenario,
+    tools: Mapping[str, ToolDefinition],
+    constraints: Sequence[ToolBehaviorConstraint],
+    invocation_count: int,
+) -> tuple[tuple[ToolBehaviorConstraint, tuple[_Slot, ...]], ...]:
+    return tuple(
+        (
+            constraint,
+            _trace_for_constraint(
+                scenario,
+                tools.get(constraint.tool_name),
+                constraint,
+                invocation_count,
+            ),
+        )
+        for constraint in constraints
+    )
+
+
+def _trace_slots(traces: Iterable[tuple[object, tuple[_Slot, ...]]]) -> tuple[_Slot, ...]:
+    return tuple(slot for _, trace in traces for slot in trace)
+
+
+def _scenario_evidence(
+    scenario: Scenario,
+    *,
+    criteria: Iterable[object] = (),
+    slots: Iterable[_Slot] = (),
+) -> tuple[str, ...]:
+    values = {
+        f"scenario:{scenario.scenario_id}",
+        f"scenario-fingerprint:{scenario.fingerprint}",
+    }
+    values.update(slot.evidence_id for slot in slots)
+    for criterion in criteria:
+        criterion_id = getattr(criterion, "criterion_id", None)
+        if isinstance(criterion_id, str) and criterion_id:
+            values.add(f"criterion:{criterion_id}")
+    return tuple(sorted(values))
+
+
+def _best(candidates: Sequence[_Outcome], missing_reason: str) -> _Outcome:
+    if not candidates:
+        return _Outcome(BehavioralCoverageStatus.MISSING, missing_reason, ())
+    highest = max(_OUTCOME_RANK[item.status] for item in candidates)
+    best = [item for item in candidates if _OUTCOME_RANK[item.status] == highest]
+    reason = min(item.reason_code for item in best)
+    evidence = tuple(sorted({value for item in best for value in item.evidence}))
+    return _Outcome(best[0].status, reason, evidence)
+
+
+def _success_outcome(
+    scenarios: Sequence[Scenario], tools: Mapping[str, ToolDefinition], tool_name: str
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        if not required and not allowed:
+            continue
+        traces = _traces_for_constraints(scenario, tools, (*required, *allowed), 1)
+        successful = tuple(
+            (constraint, trace)
+            for constraint, trace in traces
+            if trace and trace[0].status is SimulatedToolStatus.SUCCESS
+        )
+        if not successful:
+            continue
+        hard_required = any(
+            constraint in required
+            and _criterion_is_authoritative(scenario, constraint)
+            for constraint, _ in successful
+        )
+        criteria = (*required, *allowed)
+        if hard_required:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.COVERED,
+                    "required_success_with_controlled_fixture",
+                    _scenario_evidence(
+                        scenario, criteria=criteria, slots=_trace_slots(successful)
+                    ),
+                )
+            )
+        else:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "optional_success_path",
+                    _scenario_evidence(
+                        scenario, criteria=criteria, slots=_trace_slots(successful)
+                    ),
+                )
+            )
+    return _best(candidates, "success_path_missing")
+
+
+def _handling_criteria(scenario: Scenario) -> tuple[OutputCriterion, ...]:
+    output = tuple(
+        criterion
+        for criterion in scenario.output_criteria
+        if criterion.kind
+        in {
+            OutputCriterionKind.NO_FABRICATED_SUCCESS,
+            OutputCriterionKind.ACKNOWLEDGES_TOOL_ERROR,
+        }
+    )
+    return output
+
+
+def _handling_is_authoritative(scenario: Scenario, criterion: object) -> bool:
+    required = bool(getattr(criterion, "required", True))
+    return required and _criterion_is_authoritative(scenario, criterion)
+
+
+def _has_configured_success_terms(criterion: OutputCriterion) -> bool:
+    terms = criterion.parameters.get("success_terms")
+    return (
+        isinstance(terms, list)
+        and bool(terms)
+        and all(isinstance(term, str) and bool(term) for term in terms)
+    )
+
+
+def _valid_retry_limit(criterion: TrajectoryConstraint) -> int | None:
+    maximum = criterion.parameters.get("max_retries")
+    if (
+        isinstance(maximum, bool)
+        or not isinstance(maximum, int)
+        or maximum < 0
+    ):
+        return None
+    return maximum
+
+
+def _handling_criterion_is_executable(
+    scenario: Scenario,
+    criterion: object,
+    *,
+    ambiguous_timeout: bool = False,
+) -> bool:
+    if not _handling_is_authoritative(scenario, criterion):
+        return False
+    if isinstance(criterion, OutputCriterion):
+        if criterion.kind is OutputCriterionKind.NO_FABRICATED_SUCCESS:
+            return _has_configured_success_terms(criterion)
+        return criterion.kind is OutputCriterionKind.ACKNOWLEDGES_TOOL_ERROR
+    if isinstance(criterion, TrajectoryConstraint):
+        if criterion.kind is TrajectoryConstraintKind.MAX_RETRIES:
+            return _valid_retry_limit(criterion) is not None
+        if criterion.kind is TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT:
+            return ambiguous_timeout
+        return False
+    return True
+
+
+def _only_unconfigured_fabrication(criteria: Sequence[object]) -> bool:
+    output = [item for item in criteria if isinstance(item, OutputCriterion)]
+    return bool(output) and len(output) == len(criteria) and all(
+        item.kind is OutputCriterionKind.NO_FABRICATED_SUCCESS
+        and not _has_configured_success_terms(item)
+        for item in output
+    )
+
+
+def _failure_outcome(
+    scenarios: Sequence[Scenario], tools: Mapping[str, ToolDefinition], tool_name: str
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        if not required and not allowed:
+            continue
+        traces = _traces_for_constraints(scenario, tools, (*required, *allowed), 1)
+        failures = tuple(
+            (constraint, trace)
+            for constraint, trace in traces
+            if trace and trace[0].status is SimulatedToolStatus.ERROR
+        )
+        if not failures:
+            continue
+        criteria = _handling_criteria(scenario)
+        evidence = _scenario_evidence(
+            scenario, criteria=criteria, slots=_trace_slots(failures)
+        )
+        hard = _focal_tools(scenario) == (tool_name,) and any(
+            _handling_criterion_is_executable(scenario, item)
+            for item in criteria
+        )
+        hard_required = any(
+            constraint in required
+            and _criterion_is_authoritative(scenario, constraint)
+            for constraint, _ in failures
+        )
+        if not criteria:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "failure_stimulus_without_handling_oracle",
+                    evidence,
+                )
+            )
+        elif _only_unconfigured_fabrication(criteria):
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "fabrication_terms_unconfigured",
+                    evidence,
+                )
+            )
+        elif hard and hard_required:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.COVERED,
+                    "required_failure_with_supported_oracle",
+                    evidence,
+                )
+            )
+        else:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "optional_or_nonauthoritative_failure_path",
+                    evidence,
+                )
+            )
+    return _best(candidates, "failure_path_missing")
+
+
+def _timeout_outcome(
+    scenarios: Sequence[Scenario], tools: Mapping[str, ToolDefinition], tool_name: str
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        if not required and not allowed:
+            continue
+        action_constraints = (*required, *allowed)
+        traces = _traces_for_constraints(scenario, tools, action_constraints, 1)
+        timeouts = tuple(
+            (constraint, trace)
+            for constraint, trace in traces
+            if trace and trace[0].status is SimulatedToolStatus.TIMEOUT
+        )
+        if not timeouts:
+            continue
+        tool = tools.get(tool_name)
+        trajectory = tuple(
+            constraint
+            for constraint in scenario.trajectory_constraints
+            if constraint.parameters.get("tool_name") == tool_name
+            and constraint.kind
+            in {
+                TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT,
+                TrajectoryConstraintKind.MAX_RETRIES,
+            }
+        )
+        handling = _handling_criteria(scenario)
+        criteria = (*handling, *trajectory)
+        extended: list[tuple[ToolBehaviorConstraint, tuple[_Slot, ...]]] = []
+        hard_path = False
+        for action, first_trace in timeouts:
+            hard_action = (
+                action in required
+                and _criterion_is_authoritative(scenario, action)
+            )
+            if not hard_action:
+                continue
+            for criterion in criteria:
+                if isinstance(criterion, TrajectoryConstraint):
+                    if not (
+                        criterion.required
+                        and _criterion_is_authoritative(scenario, criterion)
+                    ):
+                        continue
+                    if criterion.kind is TrajectoryConstraintKind.MAX_RETRIES:
+                        maximum = _valid_retry_limit(criterion)
+                        if maximum is None:
+                            continue
+                        needed = maximum + 2
+                        trace = _trace_for_constraint(
+                            scenario, tool, action, needed
+                        )
+                        extended.append((action, trace))
+                        hard_path = hard_path or (
+                            len(trace) >= needed
+                            and trace[0].status is SimulatedToolStatus.TIMEOUT
+                        )
+                    elif (
+                        criterion.kind
+                        is TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT
+                    ):
+                        trace = _trace_for_constraint(
+                            scenario,
+                            tool,
+                            action,
+                            _maximum_trace_length(scenario, tool_name),
+                        )
+                        extended.append((action, trace))
+                        hard_path = hard_path or _ambiguous_with_controlled_next(
+                            trace, tool
+                        )
+                elif (
+                    _focal_tools(scenario) == (tool_name,)
+                    and _handling_criterion_is_executable(
+                        scenario,
+                        criterion,
+                        ambiguous_timeout=_is_ambiguous_timeout(
+                            first_trace[0], tool
+                        ),
+                    )
+                ):
+                    hard_path = True
+        evidence = _scenario_evidence(
+            scenario,
+            criteria=criteria,
+            slots=(*_trace_slots(timeouts), *_trace_slots(extended)),
+        )
+        if not criteria:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "timeout_stimulus_without_handling_oracle"
+        elif _only_unconfigured_fabrication(criteria):
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "fabrication_terms_unconfigured"
+        elif hard_path:
+            status = BehavioralCoverageStatus.COVERED
+            reason = "required_timeout_with_supported_oracle"
+        else:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "optional_or_nonauthoritative_timeout_path"
+        candidates.append(_Outcome(status, reason, evidence))
+    return _best(candidates, "timeout_path_missing")
+
+
+def _fabrication_outcome(
+    scenarios: Sequence[Scenario], tools: Mapping[str, ToolDefinition], tool_name: str
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        if tool_name not in _focal_tools(scenario):
+            continue
+        criteria = tuple(
+            criterion
+            for criterion in scenario.output_criteria
+            if criterion.kind is OutputCriterionKind.NO_FABRICATED_SUCCESS
+        )
+        if not criteria:
+            continue
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        traces = _traces_for_constraints(scenario, tools, (*required, *allowed), 1)
+        failed = tuple(
+            (constraint, trace)
+            for constraint, trace in traces
+            if trace
+            and trace[0].status
+            in {SimulatedToolStatus.ERROR, SimulatedToolStatus.TIMEOUT}
+        )
+        hard_configured = any(
+            criterion.required and _criterion_is_authoritative(scenario, criterion)
+            and _has_configured_success_terms(criterion)
+            for criterion in criteria
+        ) and _focal_tools(scenario) == (tool_name,)
+        configured = any(
+            _has_configured_success_terms(criterion) for criterion in criteria
+        )
+        hard_required = any(
+            constraint in required
+            and _criterion_is_authoritative(scenario, constraint)
+            for constraint, _ in failed
+        )
+        evidence = _scenario_evidence(
+            scenario, criteria=criteria, slots=_trace_slots(failed)
+        )
+        if not failed:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "fabrication_oracle_without_failure_stimulus"
+        elif not configured:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "fabrication_terms_unconfigured"
+        elif hard_configured and hard_required:
+            status = BehavioralCoverageStatus.COVERED
+            reason = "configured_fabrication_oracle_on_required_failure"
+        else:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "optional_or_nonauthoritative_fabrication_path"
+        candidates.append(_Outcome(status, reason, evidence))
+    return _best(candidates, "fabricated_success_case_missing")
+
+
+def _constraint_tool_name(constraint: TrajectoryConstraint) -> str | None:
+    value = constraint.parameters.get("tool_name")
+    return value if isinstance(value, str) and value else None
+
+
+def _matching_trajectory(
+    scenario: Scenario,
+    tool_name: str | None,
+    kinds: set[TrajectoryConstraintKind],
+) -> tuple[TrajectoryConstraint, ...]:
+    """Return constraints whose declared tool signature is exactly ``tool_name``.
+
+    ``None`` selects only constraints that declare no tool. A constraint that
+    names a tool belongs to that tool's requirement, never to the scenario-
+    scoped requirement created for an undeclared signature.
+    """
+
+    return tuple(
+        constraint
+        for constraint in scenario.trajectory_constraints
+        if constraint.kind in kinds
+        and _constraint_tool_name(constraint) == tool_name
+    )
+
+
+def _is_ambiguous_timeout(slot: _Slot, tool: ToolDefinition | None) -> bool:
+    return slot.status is SimulatedToolStatus.TIMEOUT and (
+        slot.error_code == "ambiguous_timeout"
+        or bool(tool is not None and tool.state_changing)
+    )
+
+
+def _ambiguous_with_controlled_next(
+    trace: Sequence[_Slot], tool: ToolDefinition | None
+) -> bool:
+    return any(
+        _is_ambiguous_timeout(slot, tool) and index + 1 < len(trace)
+        for index, slot in enumerate(trace)
+    )
+
+
+def _maximum_trace_length(scenario: Scenario, tool_name: str) -> int:
+    return max(1, len(_slots_for(scenario, tool_name)))
+
+
+def _ambiguous_outcome(
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+    tool_name: str | None,
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        constraints = _matching_trajectory(
+            scenario,
+            tool_name,
+            {TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT},
+        )
+        if tool_name is None:
+            if constraints:
+                candidates.append(
+                    _Outcome(
+                        BehavioralCoverageStatus.PARTIAL,
+                        "ambiguous_oracle_without_declared_tool_signature",
+                        _scenario_evidence(scenario, criteria=constraints),
+                    )
+                )
+            continue
+        if tool_name not in _focal_tools(scenario):
+            continue
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        if not required and not allowed:
+            continue
+        traces = _traces_for_constraints(
+            scenario,
+            tools,
+            (*required, *allowed),
+            _maximum_trace_length(scenario, tool_name),
+        )
+        tool = tools.get(tool_name)
+        ambiguous = tuple(
+            (constraint, trace)
+            for constraint, trace in traces
+            if any(_is_ambiguous_timeout(slot, tool) for slot in trace)
+        )
+        observable = tuple(
+            (constraint, trace)
+            for constraint, trace in ambiguous
+            if _ambiguous_with_controlled_next(trace, tool)
+        )
+        if not constraints and not ambiguous:
+            continue
+        hard = any(
+            constraint.required and _criterion_is_authoritative(scenario, constraint)
+            for constraint in constraints
+        )
+        hard_observable = any(
+            constraint in required
+            and _criterion_is_authoritative(scenario, constraint)
+            for constraint, _ in observable
+        )
+        evidence = _scenario_evidence(
+            scenario,
+            criteria=constraints,
+            slots=_trace_slots(ambiguous),
+        )
+        if not ambiguous:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "ambiguous_oracle_without_reachable_stimulus"
+        elif not constraints:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "ambiguous_stimulus_without_retry_oracle"
+        elif not observable:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "ambiguous_retry_lacks_controlled_next_attempt"
+        elif hard and hard_observable:
+            status = BehavioralCoverageStatus.COVERED
+            reason = "required_ambiguous_retry_is_observable"
+        else:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = (
+                "optional_ambiguous_action_path"
+                if allowed
+                else "nonauthoritative_ambiguous_oracle"
+            )
+        candidates.append(_Outcome(status, reason, evidence))
+    return _best(candidates, "ambiguous_outcome_case_missing")
+
+
+def _retry_outcome(
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+    tool_name: str | None,
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        constraints = _matching_trajectory(
+            scenario,
+            tool_name,
+            {
+                TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT,
+                TrajectoryConstraintKind.MAX_RETRIES,
+            },
+        )
+        if not constraints:
+            continue
+        if tool_name is None:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "retry_oracle_without_declared_tool_signature",
+                    _scenario_evidence(scenario, criteria=constraints),
+                )
+            )
+            continue
+        required, allowed, _ = (
+            _action_contracts(scenario, tool_name)
+            if tool_name is not None else ((), (), ())
+        )
+        tool = tools.get(tool_name)
+        for constraint in constraints:
+            if constraint.kind is TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT:
+                needed = _maximum_trace_length(scenario, tool_name)
+                traces = tuple(
+                    (
+                        action,
+                        _trace_for_constraint(scenario, tool, action, needed),
+                    )
+                    for action in (*required, *allowed)
+                )
+                observable = tuple(
+                    (action, trace)
+                    for action, trace in traces
+                    if _ambiguous_with_controlled_next(trace, tool)
+                )
+            else:
+                maximum = _valid_retry_limit(constraint)
+                if maximum is None:
+                    candidates.append(
+                        _Outcome(
+                            BehavioralCoverageStatus.PARTIAL,
+                            "retry_limit_parameters_invalid",
+                            _scenario_evidence(scenario, criteria=(constraint,)),
+                        )
+                    )
+                    continue
+                needed = maximum + 2
+                traces = tuple(
+                    (
+                        action,
+                        _trace_for_constraint(scenario, tool, action, needed),
+                    )
+                    for action in (*required, *allowed)
+                )
+                observable = tuple(
+                    (action, trace)
+                    for action, trace in traces
+                    if len(trace) >= needed
+                )
+            hard = constraint.required and _criterion_is_authoritative(
+                scenario, constraint
+            )
+            hard_required = any(
+                action in required
+                and _criterion_is_authoritative(scenario, action)
+                for action, _ in observable
+            )
+            evidence = _scenario_evidence(
+                scenario,
+                criteria=(constraint,),
+                slots=_trace_slots(traces),
+            )
+            if not observable:
+                status = BehavioralCoverageStatus.PARTIAL
+                reason = "retry_limit_lacks_prohibited_attempt_fixture"
+            elif hard and hard_required:
+                status = BehavioralCoverageStatus.COVERED
+                reason = "required_retry_limit_is_observable"
+            else:
+                status = BehavioralCoverageStatus.PARTIAL
+                reason = (
+                    "optional_retry_action_path"
+                    if allowed
+                    else "nonauthoritative_retry_oracle"
+                )
+            candidates.append(_Outcome(status, reason, evidence))
+    return _best(candidates, "retry_control_case_missing")
+
+
+def _duplicate_outcome(
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+    tool_name: str | None,
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        constraints = _matching_trajectory(
+            scenario,
+            tool_name,
+            {TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT},
+        )
+        if not constraints:
+            continue
+        if tool_name is None:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "duplicate_oracle_without_declared_tool_signature",
+                    _scenario_evidence(scenario, criteria=constraints),
+                )
+            )
+            continue
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        traces = _traces_for_constraints(
+            scenario, tools, (*required, *allowed), 2
+        )
+        observable = tuple(
+            (action, trace)
+            for action, trace in traces
+            if len(trace) >= 2
+        )
+        hard = any(
+            constraint.required and _criterion_is_authoritative(scenario, constraint)
+            for constraint in constraints
+        )
+        hard_required = any(
+            action in required
+            and _criterion_is_authoritative(scenario, action)
+            for action, _ in observable
+        )
+        evidence = _scenario_evidence(
+            scenario,
+            criteria=constraints,
+            slots=_trace_slots(traces),
+        )
+        if not observable:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "duplicate_oracle_lacks_second_fixture"
+        elif hard and hard_required:
+            status = BehavioralCoverageStatus.COVERED
+            reason = "required_duplicate_attempt_is_observable"
+        else:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = (
+                "optional_duplicate_action_path"
+                if allowed
+                else "nonauthoritative_duplicate_oracle"
+            )
+        candidates.append(_Outcome(status, reason, evidence))
+    return _best(candidates, "duplicate_action_case_missing")
+
+
+def _has_explicit_confirmation(scenario: Scenario) -> bool:
+    return any(
+        turn.metadata.get("explicit_confirmation") is True
+        for turn in (*scenario.conversation_turns, *scenario.followup_turns)
+    )
+
+
+def _confirmation_constraints(
+    scenario: Scenario, tool_name: str
+) -> tuple[object, ...]:
+    behavior = tuple(
+        constraint
+        for constraint in (
+            *scenario.required_tool_behavior,
+            *scenario.allowed_tool_behavior,
+            *scenario.forbidden_tool_behavior,
+        )
+        if constraint.tool_name == tool_name
+        and constraint.confirmation_required_before_call
+    )
+    trajectory = tuple(
+        constraint
+        for constraint in scenario.trajectory_constraints
+        if constraint.kind is TrajectoryConstraintKind.CONFIRMATION_BEFORE_TOOL
+        and constraint.parameters.get("tool_name") == tool_name
+    )
+    return (*behavior, *trajectory)
+
+
+def _confirmation_outcome(
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+    tool_name: str,
+    *,
+    with_consent: bool,
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        if tool_name not in _focal_tools(scenario):
+            continue
+        confirmed = _has_explicit_confirmation(scenario)
+        if confirmed is not with_consent:
+            continue
+        constraints = _confirmation_constraints(scenario, tool_name)
+        required, allowed, forbidden = _action_contracts(scenario, tool_name)
+        if not constraints and not required and not allowed and not forbidden:
+            continue
+        polarity = required if with_consent else forbidden
+        traces = _traces_for_constraints(scenario, tools, polarity, 1)
+        observable = tuple(
+            (action, trace)
+            for action, trace in traces
+            if trace
+        )
+        hard = any(
+            _criterion_is_authoritative(scenario, item)
+            and bool(getattr(item, "required", True))
+            for item in constraints
+        )
+        strong_action = any(
+            action in polarity
+            and _criterion_is_authoritative(scenario, action)
+            for action, _ in observable
+        )
+        evidence = _scenario_evidence(
+            scenario,
+            criteria=constraints,
+            slots=_trace_slots(traces),
+        )
+        if not constraints:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "confirmation_opportunity_without_oracle"
+        elif not polarity:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "confirmation_action_polarity_not_observable"
+        elif not observable:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = "confirmation_oracle_without_controlled_tool_fixture"
+        elif hard and strong_action:
+            status = BehavioralCoverageStatus.COVERED
+            reason = (
+                "confirmed_required_action_is_observable"
+                if with_consent
+                else "unconfirmed_forbidden_action_is_observable"
+            )
+        else:
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = (
+                "optional_confirmed_action_path"
+                if allowed
+                else "nonauthoritative_confirmation_oracle"
+            )
+        candidates.append(_Outcome(status, reason, evidence))
+    missing = (
+        "confirmed_action_case_missing"
+        if with_consent
+        else "unconfirmed_action_case_missing"
+    )
+    return _best(candidates, missing)
+
+
+def _prerequisite_outcome(
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+    focal_tool: str,
+    prerequisite_tool: str,
+    *,
+    failure: bool,
+) -> _Outcome:
+    candidates: list[_Outcome] = []
+    pair = (focal_tool, prerequisite_tool)
+    for scenario in scenarios:
+        if pair not in _prerequisite_pairs(scenario):
+            continue
+        prerequisite_required = tuple(
+            constraint
+            for constraint in scenario.required_tool_behavior
+            if constraint.tool_name == prerequisite_tool and constraint.min_calls >= 1
+        )
+        focal_required, _, focal_forbidden = _action_contracts(scenario, focal_tool)
+        prerequisite_traces = _traces_for_constraints(
+            scenario, tools, prerequisite_required, 1
+        )
+        selected_prerequisite = tuple(
+            (action, trace)
+            for action, trace in prerequisite_traces
+            if trace
+            and (
+                trace[0].status
+                in {SimulatedToolStatus.ERROR, SimulatedToolStatus.TIMEOUT}
+                if failure
+                else trace[0].status is SimulatedToolStatus.SUCCESS
+            )
+        )
+        focal_constraints = focal_forbidden if failure else focal_required
+        focal_traces = _traces_for_constraints(
+            scenario, tools, focal_constraints, 1
+        )
+        selected_focal = tuple(
+            (action, trace) for action, trace in focal_traces if trace
+        )
+        required_prerequisite = any(
+            action in prerequisite_required
+            and _criterion_is_authoritative(scenario, action)
+            for action, _ in selected_prerequisite
+        )
+        asserted_focal = any(
+            action in focal_constraints
+            and _criterion_is_authoritative(scenario, action)
+            for action, _ in selected_focal
+        )
+        if failure:
+            asserted = required_prerequisite and asserted_focal
+            criteria: tuple[object, ...] = (
+                *prerequisite_required,
+                *focal_forbidden,
+            )
+            status = (
+                BehavioralCoverageStatus.COVERED
+                if asserted
+                else BehavioralCoverageStatus.PARTIAL
+            )
+            reason = (
+                "required_prerequisite_failure_forbids_focal_action"
+                if asserted
+                else (
+                    "prerequisite_failure_fixture_not_reachable"
+                    if not selected_prerequisite
+                    else "prerequisite_failure_path_not_fully_asserted"
+                )
+            )
+        else:
+            asserted = required_prerequisite and asserted_focal
+            criteria = (*prerequisite_required, *focal_required)
+            # Both calls can be asserted today, but not their ordering. Focal
+            # first would otherwise create false full prerequisite coverage.
+            status = BehavioralCoverageStatus.PARTIAL
+            reason = (
+                "calls_asserted_but_order_unobservable"
+                if asserted
+                else (
+                    "prerequisite_success_fixture_not_reachable"
+                    if not selected_prerequisite
+                    else "prerequisite_success_relationship_unasserted"
+                )
+            )
+        candidates.append(
+            _Outcome(
+                status,
+                reason,
+                _scenario_evidence(
+                    scenario,
+                    criteria=criteria,
+                    slots=(
+                        *_trace_slots(prerequisite_traces),
+                        *_trace_slots(focal_traces),
+                    ),
+                ),
+            )
+        )
+    missing = (
+        "prerequisite_failure_path_missing"
+        if failure
+        else "prerequisite_success_path_missing"
+    )
+    return _best(candidates, missing)
+
+
+def _ordering_evidence(
+    scenarios: Sequence[Scenario], seed: _Seed
+) -> tuple[str, ...]:
+    evidence: set[str] = set()
+    if seed.tool_name is not None and seed.prerequisite_tool_name is not None:
+        pair = (seed.tool_name, seed.prerequisite_tool_name)
+        for scenario in scenarios:
+            if pair not in _prerequisite_pairs(scenario):
+                continue
+            evidence.update(
+                _scenario_evidence(
+                    scenario,
+                    slots=_slots_for(scenario, seed.prerequisite_tool_name),
+                )
+            )
+    for scenario in scenarios:
+        for constraint in scenario.trajectory_constraints:
+            if constraint.kind is not TrajectoryConstraintKind.ORDERING:
+                continue
+            tool_name = constraint.parameters.get("tool_name")
+            subject = (
+                _tool_subject(tool_name)
+                if isinstance(tool_name, str) and tool_name
+                else f"scenario:{scenario.scenario_id}"
+            )
+            if subject == seed.subject:
+                evidence.update(
+                    _scenario_evidence(scenario, criteria=(constraint,))
+                )
+    return tuple(sorted(evidence))
+
+
+def _subject_scenarios(
+    scenarios: Sequence[Scenario], subject: str
+) -> tuple[Scenario, ...]:
+    """Restrict a scenario-scoped requirement to the scenario that declared it.
+
+    A requirement whose subject is one scenario must never borrow another
+    scenario's stimulus as its evidence; a subject whose scenario is absent
+    from the evidence set is missing, not partially covered.
+    """
+
+    return tuple(
+        scenario
+        for scenario in scenarios
+        if f"scenario:{scenario.scenario_id}" == subject
+    )
+
+
+def _evaluate_seed(
+    seed: _Seed,
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+) -> _Outcome:
+    if seed.applicability is _Applicability.UNKNOWN:
+        return _Outcome(
+            BehavioralCoverageStatus.UNKNOWN,
+            seed.unknown_reason,
+            (),
+        )
+    if seed.applicability is _Applicability.UNSUPPORTED:
+        return _Outcome(
+            BehavioralCoverageStatus.UNSUPPORTED,
+            (
+                "prerequisite_ordering_not_supported"
+                if seed.prerequisite_tool_name is not None
+                else "trajectory_ordering_not_supported"
+            ),
+            _ordering_evidence(scenarios, seed),
+        )
+
+    tool_name = seed.tool_name
+    # An undeclared tool signature yields a scenario-scoped subject, so the
+    # evidence set narrows to that one scenario.
+    scoped = (
+        scenarios
+        if tool_name is not None
+        else _subject_scenarios(scenarios, seed.subject)
+    )
+    if seed.dimension is BehavioralDimension.SUCCESS_PATH and tool_name is not None:
+        return _success_outcome(scenarios, tools, tool_name)
+    if seed.dimension is BehavioralDimension.FAILURE_HANDLING and tool_name is not None:
+        return _failure_outcome(scenarios, tools, tool_name)
+    if seed.dimension is BehavioralDimension.TIMEOUT_HANDLING and tool_name is not None:
+        return _timeout_outcome(scenarios, tools, tool_name)
+    if (
+        seed.dimension is BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE
+        and tool_name is not None
+    ):
+        return _fabrication_outcome(scenarios, tools, tool_name)
+    if seed.dimension is BehavioralDimension.AMBIGUOUS_OUTCOME:
+        return _ambiguous_outcome(scoped, tools, tool_name)
+    if seed.dimension is BehavioralDimension.RETRY_CONTROL:
+        return _retry_outcome(scoped, tools, tool_name)
+    if seed.dimension is BehavioralDimension.DUPLICATE_ACTION:
+        return _duplicate_outcome(scoped, tools, tool_name)
+    if (
+        seed.dimension is BehavioralDimension.CONFIRMATION_WITHOUT_CONSENT
+        and tool_name is not None
+    ):
+        return _confirmation_outcome(scenarios, tools, tool_name, with_consent=False)
+    if (
+        seed.dimension is BehavioralDimension.CONFIRMATION_WITH_CONSENT
+        and tool_name is not None
+    ):
+        return _confirmation_outcome(scenarios, tools, tool_name, with_consent=True)
+    if (
+        seed.dimension is BehavioralDimension.PREREQUISITE_SUCCESS
+        and tool_name is not None
+        and seed.prerequisite_tool_name is not None
+    ):
+        return _prerequisite_outcome(
+            scenarios,
+            tools,
+            tool_name,
+            seed.prerequisite_tool_name,
+            failure=False,
+        )
+    if (
+        seed.dimension is BehavioralDimension.PREREQUISITE_FAILURE
+        and tool_name is not None
+        and seed.prerequisite_tool_name is not None
+    ):
+        return _prerequisite_outcome(
+            scenarios,
+            tools,
+            tool_name,
+            seed.prerequisite_tool_name,
+            failure=True,
+        )
+    return _Outcome(
+        BehavioralCoverageStatus.UNSUPPORTED,
+        "behavioral_dimension_not_supported",
+        (),
+    )
+
+
+def _bounded_requirement(seed: _Seed, outcome: _Outcome) -> BehavioralCoverageRequirement:
+    evidence = tuple(sorted(set(outcome.evidence)))
+    visible = evidence[:MAX_COVERAGE_DETAILS]
+    return BehavioralCoverageRequirement(
+        subject=seed.subject,
+        status=outcome.status,
+        reason_code=outcome.reason_code,
+        evidence=visible,
+        omitted_evidence=max(0, len(evidence) - len(visible)),
+    )
+
+
+def _family(
+    dimension: BehavioralDimension,
+    seeds: Sequence[_Seed],
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+) -> BehavioralCoverageFamily:
+    requirements = [
+        _bounded_requirement(seed, _evaluate_seed(seed, scenarios, tools))
+        for seed in sorted(seeds, key=lambda item: item.subject)
+    ]
+    counts = Counter(requirement.status for requirement in requirements)
+    # Artifact redaction can collapse distinct secret-shaped identifiers to the
+    # same safe subject. Keep every requirement in the counts, but omit all
+    # colliding detail rows instead of inventing an identity or retaining a
+    # secret-derived hash.
+    subject_counts = Counter(requirement.subject for requirement in requirements)
+    distinct_details = [
+        requirement
+        for requirement in requirements
+        if subject_counts[requirement.subject] == 1
+    ]
+    visible = tuple(distinct_details[:MAX_COVERAGE_DETAILS])
+    return BehavioralCoverageFamily(
+        dimension=dimension,
+        covered=counts[BehavioralCoverageStatus.COVERED],
+        partial=counts[BehavioralCoverageStatus.PARTIAL],
+        missing=counts[BehavioralCoverageStatus.MISSING],
+        unknown=counts[BehavioralCoverageStatus.UNKNOWN],
+        unsupported=counts[BehavioralCoverageStatus.UNSUPPORTED],
+        requirements=visible,
+        omitted=len(requirements) - len(visible),
+    )
+
+
+def _validate_reference_contains(
+    actual: Sequence[Scenario], reference: Sequence[Scenario]
+) -> None:
+    actual_identities = Counter(
+        (scenario.scenario_id, scenario.fingerprint) for scenario in actual
+    )
+    reference_identities = Counter(
+        (scenario.scenario_id, scenario.fingerprint) for scenario in reference
+    )
+    if any(
+        count > reference_identities[identity]
+        for identity, count in actual_identities.items()
+    ):
+        raise ValueError("actual scenarios must be contained in reference_scenarios")
+
+
+def analyze_behavioral_coverage(
+    spec: AgentSpec,
+    scenarios: Sequence[Scenario],
+    *,
+    suite_fingerprint: str | None = None,
+    reference_scenarios: Sequence[Scenario] | None = None,
+    reference_scope: BehavioralCoverageReferenceScope = (
+        BehavioralCoverageReferenceScope.COMPLETE
+    ),
+) -> BehavioralCoverage:
+    """Derive explicit behavioral requirements and selected-suite evidence.
+
+    ``reference_scenarios`` supplies the full requirement universe when
+    ``scenarios`` is a selected subset.  Evidence and source binding always use
+    only ``scenarios``, so a case excluded by selection becomes missing instead
+    of silently shrinking the denominator.
+    """
+
+    actual = tuple(scenarios)
+    reference = actual if reference_scenarios is None else tuple(reference_scenarios)
+    if reference_scenarios is not None:
+        _validate_reference_contains(actual, reference)
+    declared_tools = [item.value for item in spec.tools.items]
+    # A repeated declared name makes tool identity ambiguous, so no definition
+    # under that name is authoritative. ToolGateway already refuses to execute
+    # such a target; derived coverage is report metadata and must not abort
+    # generation, so the affected subjects stay UNKNOWN instead of silently
+    # binding to one arbitrary definition.
+    ambiguous_tool_names = {
+        name
+        for name, count in Counter(tool.name for tool in declared_tools).items()
+        if count > 1
+    }
+    tools = {
+        tool.name: tool
+        for tool in declared_tools
+        if tool.name not in ambiguous_tool_names
+    }
+    seeds: dict[tuple[BehavioralDimension, str], _Seed] = {}
+    _seed_from_spec(spec, seeds)
+    non_authoritative_risk_tools = {
+        item.value.name for item in spec.tools.items if not item.authoritative
+    }
+    _seed_from_scenarios(reference, seeds, non_authoritative_risk_tools)
+    lossy_tool_names = {
+        tool.name for tool in declared_tools if not _tool_binding_is_lossless(tool)
+    }
+    for key, seed in tuple(seeds.items()):
+        bound_names = tuple(
+            name
+            for name in (seed.tool_name, seed.prerequisite_tool_name)
+            if name is not None
+        )
+        if any(name in ambiguous_tool_names for name in bound_names):
+            seeds[key] = replace(
+                seed,
+                applicability=_Applicability.UNKNOWN,
+                unknown_reason="declared_tool_name_is_ambiguous",
+            )
+        elif any(
+            name in lossy_tool_names or redact_log_text(name) != name
+            for name in bound_names
+        ):
+            seeds[key] = replace(
+                seed,
+                applicability=_Applicability.UNKNOWN,
+                unknown_reason="coverage_binding_redacted_or_truncated",
+            )
+
+
+    by_dimension: dict[BehavioralDimension, list[_Seed]] = {
+        dimension: [] for dimension in BehavioralDimension
+    }
+    for seed in seeds.values():
+        by_dimension[seed.dimension].append(seed)
+    families = tuple(
+        _family(dimension, by_dimension[dimension], actual, tools)
+        for dimension in BehavioralDimension
+    )
+    return BehavioralCoverage(
+        spec_id=spec.spec_id,
+        spec_digest=_spec_digest(spec),
+        scenario_count=len(actual),
+        scenario_digest=_scenario_digest(actual),
+        reference_scenario_count=len(reference),
+        reference_scenario_digest=_scenario_digest(reference),
+        reference_scope=reference_scope,
+        suite_fingerprint=suite_fingerprint,
+        families=families,
+    )
+
+
+class _UnspecifiedSuiteFingerprint:
+    pass
+
+
+_UNSPECIFIED_SUITE_FINGERPRINT = _UnspecifiedSuiteFingerprint()
+
+
+class _UnspecifiedReferenceScenarios:
+    pass
+
+
+_UNSPECIFIED_REFERENCE_SCENARIOS = _UnspecifiedReferenceScenarios()
+
+
+@overload
+def verify_behavioral_coverage_binding(
+    coverage: BehavioralCoverage,
+    spec: AgentSpec,
+    scenarios: Sequence[Scenario],
+) -> None: ...
+
+
+@overload
+def verify_behavioral_coverage_binding(
+    coverage: BehavioralCoverage,
+    spec: AgentSpec,
+    scenarios: Sequence[Scenario],
+    *,
+    suite_fingerprint: str | None,
+) -> None: ...
+
+
+@overload
+def verify_behavioral_coverage_binding(
+    coverage: BehavioralCoverage,
+    spec: AgentSpec,
+    scenarios: Sequence[Scenario],
+    *,
+    reference_scenarios: Sequence[Scenario],
+) -> None: ...
+
+
+@overload
+def verify_behavioral_coverage_binding(
+    coverage: BehavioralCoverage,
+    spec: AgentSpec,
+    scenarios: Sequence[Scenario],
+    *,
+    suite_fingerprint: str | None,
+    reference_scenarios: Sequence[Scenario],
+) -> None: ...
+
+
+def verify_behavioral_coverage_binding(
+    coverage: BehavioralCoverage,
+    spec: AgentSpec,
+    scenarios: Sequence[Scenario],
+    *,
+    suite_fingerprint: str | None | _UnspecifiedSuiteFingerprint = (
+        _UNSPECIFIED_SUITE_FINGERPRINT
+    ),
+    reference_scenarios: (
+        Sequence[Scenario] | _UnspecifiedReferenceScenarios
+    ) = _UNSPECIFIED_REFERENCE_SCENARIOS,
+) -> None:
+    """Fail closed when derived coverage is presented for different sources."""
+
+    actual = tuple(scenarios)
+    complete_reference: tuple[Scenario, ...] | None = (
+        actual
+        if coverage.reference_scenario_count == coverage.scenario_count
+        else None
+    )
+    mismatches: list[str] = []
+    if coverage.spec_id != redact_log_text(spec.spec_id):
+        mismatches.append("spec_id")
+    if coverage.spec_digest != _spec_digest(spec):
+        mismatches.append("spec_digest")
+    if coverage.scenario_count != len(actual):
+        mismatches.append("scenario_count")
+    if coverage.scenario_digest != _scenario_digest(actual):
+        mismatches.append("scenario_digest")
+    if coverage.reference_scenario_count < coverage.scenario_count:
+        mismatches.append("reference_scenario_count")
+    if (
+        coverage.reference_scenario_count == coverage.scenario_count
+        and coverage.reference_scenario_digest != coverage.scenario_digest
+    ):
+        mismatches.append("reference_scenario_digest")
+    if (
+        coverage.reference_scope
+        is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+        and coverage.reference_scenario_count != coverage.scenario_count
+    ):
+        mismatches.append("reference_scope")
+    if not isinstance(
+        reference_scenarios, _UnspecifiedReferenceScenarios
+    ):
+        reference = tuple(reference_scenarios)
+        complete_reference = reference
+        try:
+            _validate_reference_contains(actual, reference)
+        except ValueError:
+            mismatches.append("reference_scenarios")
+        if coverage.reference_scenario_count != len(reference):
+            mismatches.append("reference_scenario_count")
+        if coverage.reference_scenario_digest != _scenario_digest(reference):
+            mismatches.append("reference_scenario_digest")
+
+    try:
+        expected_fingerprint = coverage.expected_fingerprint()
+    except ValueError:
+        mismatches.append("fingerprint")
+    else:
+        if not hmac.compare_digest(coverage.fingerprint, expected_fingerprint):
+            mismatches.append("fingerprint")
+    expected_suite_fingerprint = suite_fingerprint
+    if isinstance(expected_suite_fingerprint, str):
+        expected_suite_fingerprint = redact_log_text(expected_suite_fingerprint)
+    if not isinstance(
+        suite_fingerprint, _UnspecifiedSuiteFingerprint
+    ) and coverage.suite_fingerprint != expected_suite_fingerprint:
+        mismatches.append("suite_fingerprint")
+    if complete_reference is not None:
+        try:
+            rederived = analyze_behavioral_coverage(
+                spec,
+                actual,
+                reference_scenarios=complete_reference,
+                suite_fingerprint=coverage.suite_fingerprint,
+                reference_scope=coverage.reference_scope,
+            )
+        except ValueError:
+            mismatches.append("derived_coverage")
+        else:
+            if coverage != rederived:
+                mismatches.append("derived_coverage")
+
+    if mismatches:
+        raise ValueError(
+            "behavioral coverage source binding mismatch: "
+            + ", ".join(dict.fromkeys(mismatches))
+        )
+
+
+__all__ = ["analyze_behavioral_coverage", "verify_behavioral_coverage_binding"]

--- a/agentcheck/coverage/contract.py
+++ b/agentcheck/coverage/contract.py
@@ -1,0 +1,217 @@
+"""Strict, independently versioned behavioral-coverage contracts."""
+
+from __future__ import annotations
+
+import hmac
+from enum import Enum
+from typing import Annotated, Literal
+
+from pydantic import Field, model_validator
+
+from agentcheck.domain import ContractModel, canonical_hash
+from agentcheck.privacy import redact_artifact, redact_log_text
+
+
+BEHAVIORAL_COVERAGE_CONTRACT_VERSION: Literal[
+    "agentcheck.behavioral_coverage.v1"
+] = "agentcheck.behavioral_coverage.v1"
+
+# This one bound applies at both nested levels.  At 24, all twelve v1 families
+# can carry 24 requirements with 24 evidence IDs each while remaining well
+# below privacy's 100,000-node and 8 MiB artifact limits even at maximum string
+# lengths. Omitted counts make the loss of display detail explicit.
+MAX_COVERAGE_DETAILS = 24
+
+CoverageIdentifier = Annotated[str, Field(min_length=1, max_length=500)]
+
+
+class BehavioralDimension(str, Enum):
+    SUCCESS_PATH = "success_path"
+    FAILURE_HANDLING = "failure_handling"
+    TIMEOUT_HANDLING = "timeout_handling"
+    FABRICATED_SUCCESS_AFTER_FAILURE = "fabricated_success_after_failure"
+    AMBIGUOUS_OUTCOME = "ambiguous_outcome"
+    RETRY_CONTROL = "retry_control"
+    DUPLICATE_ACTION = "duplicate_action"
+    CONFIRMATION_WITHOUT_CONSENT = "confirmation_without_consent"
+    CONFIRMATION_WITH_CONSENT = "confirmation_with_consent"
+    PREREQUISITE_SUCCESS = "prerequisite_success"
+    PREREQUISITE_FAILURE = "prerequisite_failure"
+    ORDERING = "ordering"
+
+
+class BehavioralCoverageStatus(str, Enum):
+    COVERED = "covered"
+    PARTIAL = "partial"
+    MISSING = "missing"
+    UNKNOWN = "unknown"
+    UNSUPPORTED = "unsupported"
+
+
+class BehavioralCoverageReferenceScope(str, Enum):
+    COMPLETE = "complete"
+    AVAILABLE_SCENARIOS_ONLY = "available_scenarios_only"
+
+
+class BehavioralCoverageRequirement(ContractModel):
+    """One explicit dimension for one stable tool or tool relationship."""
+
+    subject: CoverageIdentifier
+    status: BehavioralCoverageStatus
+    reason_code: str = Field(min_length=1, max_length=100)
+    evidence: tuple[CoverageIdentifier, ...] = Field(
+        default=(), max_length=MAX_COVERAGE_DETAILS
+    )
+    omitted_evidence: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def normalize_evidence(self) -> "BehavioralCoverageRequirement":
+        object.__setattr__(self, "subject", redact_log_text(self.subject))
+        object.__setattr__(self, "reason_code", redact_log_text(self.reason_code))
+        distinct = set(self.evidence)
+        safe_evidence = {redact_log_text(identifier) for identifier in distinct}
+        visible = tuple(sorted(safe_evidence))
+        object.__setattr__(self, "evidence", visible)
+        object.__setattr__(
+            self,
+            "omitted_evidence",
+            self.omitted_evidence + len(distinct) - len(visible),
+        )
+        return self
+
+
+class BehavioralCoverageFamily(ContractModel):
+    """Counts and bounded detail for one behavioral dimension."""
+
+    dimension: BehavioralDimension
+    covered: int = Field(default=0, ge=0)
+    partial: int = Field(default=0, ge=0)
+    missing: int = Field(default=0, ge=0)
+    unknown: int = Field(default=0, ge=0)
+    unsupported: int = Field(default=0, ge=0)
+    requirements: tuple[BehavioralCoverageRequirement, ...] = Field(
+        default=(), max_length=MAX_COVERAGE_DETAILS
+    )
+    omitted: int = Field(default=0, ge=0)
+
+    @property
+    def applicable(self) -> int:
+        """The honest denominator: unknown and unsupported are not applicable."""
+
+        return self.covered + self.partial + self.missing
+
+    @model_validator(mode="after")
+    def validate_counts_and_order(self) -> "BehavioralCoverageFamily":
+        ordered = tuple(sorted(self.requirements, key=lambda item: item.subject))
+        subjects = [item.subject for item in ordered]
+        if len(subjects) != len(set(subjects)):
+            raise ValueError("behavioral coverage requirement subjects must be unique")
+        object.__setattr__(self, "requirements", ordered)
+
+        counts = {
+            BehavioralCoverageStatus.COVERED: self.covered,
+            BehavioralCoverageStatus.PARTIAL: self.partial,
+            BehavioralCoverageStatus.MISSING: self.missing,
+            BehavioralCoverageStatus.UNKNOWN: self.unknown,
+            BehavioralCoverageStatus.UNSUPPORTED: self.unsupported,
+        }
+        visible: dict[BehavioralCoverageStatus, int] = {
+            status: 0 for status in BehavioralCoverageStatus
+        }
+        for requirement in ordered:
+            visible[requirement.status] += 1
+        if any(visible[status] > count for status, count in counts.items()):
+            raise ValueError("behavioral coverage counts cannot be below visible detail")
+        if sum(counts.values()) != len(ordered) + self.omitted:
+            raise ValueError(
+                "behavioral coverage counts must equal visible plus omitted requirements"
+            )
+        return self
+
+
+class BehavioralCoverage(ContractModel):
+    """Behavioral requirements bound to one inspected spec and scenario set."""
+
+    contract_version: Literal[
+        "agentcheck.behavioral_coverage.v1"
+    ] = BEHAVIORAL_COVERAGE_CONTRACT_VERSION
+    spec_id: str = Field(min_length=1, max_length=200)
+    spec_digest: str = Field(min_length=1, max_length=200)
+    scenario_count: int = Field(ge=0)
+    scenario_digest: str = Field(min_length=1, max_length=200)
+    reference_scenario_count: int = Field(ge=0)
+    reference_scenario_digest: str = Field(min_length=1, max_length=200)
+    reference_scope: BehavioralCoverageReferenceScope = (
+        BehavioralCoverageReferenceScope.COMPLETE
+    )
+    suite_fingerprint: str | None = Field(default=None, min_length=1, max_length=200)
+    families: tuple[BehavioralCoverageFamily, ...] = Field(
+        default=(), max_length=MAX_COVERAGE_DETAILS
+    )
+    fingerprint: str = Field(default="", max_length=200)
+
+    def expected_fingerprint(self) -> str:
+        """Return a checksum for detecting stale or corrupted coverage content.
+
+        This is an unkeyed content checksum, not authentication. Source trust
+        comes from independently recomputing only those source bindings whose
+        documents are available; a stored selected run cannot reconstruct
+        fingerprints for scenarios excluded before execution.
+        """
+
+        payload = self.model_dump(mode="json", exclude={"fingerprint"})
+        # ArtifactStore always redacts before writing. Hash that exact safe
+        # representation so mandatory redaction cannot invalidate integrity.
+        return canonical_hash(redact_artifact(payload))
+
+    @model_validator(mode="after")
+    def normalize_families(self) -> "BehavioralCoverage":
+        order = {dimension: index for index, dimension in enumerate(BehavioralDimension)}
+        object.__setattr__(self, "spec_id", redact_log_text(self.spec_id))
+        if self.suite_fingerprint is not None:
+            object.__setattr__(
+                self, "suite_fingerprint", redact_log_text(self.suite_fingerprint)
+            )
+        families = tuple(sorted(self.families, key=lambda item: order[item.dimension]))
+        dimensions = [family.dimension for family in families]
+        if len(dimensions) != len(set(dimensions)):
+            raise ValueError("behavioral coverage families must be unique")
+        if self.reference_scenario_count < self.scenario_count:
+            raise ValueError(
+                "reference scenario count cannot be below actual scenario count"
+            )
+        if (
+            self.reference_scenario_count == self.scenario_count
+            and self.reference_scenario_digest != self.scenario_digest
+        ):
+            raise ValueError(
+                "equal actual and reference scenario counts require equal digests"
+            )
+        if (
+            self.reference_scope
+            is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+            and self.reference_scenario_count != self.scenario_count
+        ):
+            raise ValueError(
+                "available-scenarios-only reference count must equal actual count"
+            )
+        object.__setattr__(self, "families", families)
+        expected = self.expected_fingerprint()
+        if self.fingerprint and not hmac.compare_digest(self.fingerprint, expected):
+            raise ValueError("behavioral coverage fingerprint does not match its contents")
+        if not self.fingerprint:
+            object.__setattr__(self, "fingerprint", expected)
+
+        return self
+
+
+__all__ = [
+    "BEHAVIORAL_COVERAGE_CONTRACT_VERSION",
+    "MAX_COVERAGE_DETAILS",
+    "BehavioralCoverage",
+    "BehavioralCoverageFamily",
+    "BehavioralCoverageReferenceScope",
+    "BehavioralCoverageRequirement",
+    "BehavioralCoverageStatus",
+    "BehavioralDimension",
+]

--- a/agentcheck/generate/suite.py
+++ b/agentcheck/generate/suite.py
@@ -268,6 +268,12 @@ class FrozenSuite(ContractModel):
         fingerprints = [case.scenario.fingerprint for case in self.cases]
         if len(fingerprints) != len(set(fingerprints)):
             raise ValueError("frozen suite scenarios must be deduplicated")
+        if self.selection is not None and set(scenario_ids) != set(
+            self.selection.selected_ids
+        ):
+            raise ValueError(
+                "frozen suite cases must match selection plan selected IDs"
+            )
 
         expected = self.expected_fingerprint()
         if self.fingerprint and not _digest_equal(self.fingerprint, expected):
@@ -429,8 +435,16 @@ def build_frozen_suite(
     representative_inputs: Mapping[str, Mapping[str, Any]] | None = None,
     scenario_requests: Mapping[str, str] | None = None,
     prerequisite_outcomes: Mapping[str, Any] | None = None,
+    _reference_scenarios: list[Scenario] | None = None,
 ) -> FrozenSuite:
-    """Derive, deduplicate, lint, and freeze every supported case for a target."""
+    """Derive, deduplicate, lint, and freeze every supported case for a target.
+
+    ``_reference_scenarios`` is an internal collector for the pre-selection case
+    set. Behavioral coverage needs that complete requirement universe, and a
+    bounded suite discards it before freezing. It is not returned or stored
+    because adding it to ``FrozenSuite`` would re-identify every existing suite
+    fingerprint.
+    """
 
     if max_mutations is not None and not include_mutations:
         raise ValueError("max_mutations requires include_mutations=True")
@@ -661,6 +675,15 @@ def build_frozen_suite(
         raise ScenarioValidationError(
             "No valid scenarios remain after linting; refusing to freeze a suite "
             "that cannot produce a verdict."
+        )
+
+    if _reference_scenarios is not None:
+        if _reference_scenarios:
+            raise ValueError(
+                "internal reference_scenarios collector must be empty"
+            )
+        _reference_scenarios.extend(
+            case.scenario for case in cases
         )
 
     selection: SelectionPlan | None = None

--- a/agentcheck/report/load.py
+++ b/agentcheck/report/load.py
@@ -21,6 +21,12 @@ from agentcheck.config import (
     contained_path,
     normalize_target,
 )
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+    analyze_behavioral_coverage,
+    verify_behavioral_coverage_binding,
+)
 from agentcheck.domain import (
     AGENT_SPEC_CONTRACT_VERSION,
     CANONICAL_RUN_CONTRACT_VERSION,
@@ -60,6 +66,8 @@ _REQUIRED_ARTIFACTS = (
 )
 _SUITE_CONTRACT = "agentcheck.suite.v1"
 _SUMMARY_CONTRACT = "agentcheck.summary.v1"
+_INVALID_SCENARIOS_CONTRACT = "agentcheck.invalid_scenarios.v1"
+_MISSING_BEHAVIORAL_COVERAGE = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,6 +87,7 @@ class LoadedRun:
     git_revision: str | None
     frozen_suite: FrozenSuite | None
     selection: SelectionPlan | None
+    behavioral_coverage: BehavioralCoverage
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,7 +148,17 @@ def load_stored_run(
     directory = _run_directory(root, config, resolved_id, source=source)
     spec = _load_spec(directory / "agent-spec.json")
     seed, scenarios = _load_suite(directory / "suite.json", resolved_id)
-    git_revision, selection = _load_summary(directory / "summary.json", resolved_id, seed)
+    invalid_scenario_ids = _load_invalid_scenario_ids(
+        directory / "invalid-scenarios.json"
+    )
+    git_revision, selection, behavioral_coverage = _load_summary(
+        directory / "summary.json",
+        resolved_id,
+        seed,
+        spec=spec,
+        scenarios=scenarios,
+        invalid_scenario_ids=invalid_scenario_ids,
+    )
     evaluations = _load_jsonl(
         directory / "evaluations.jsonl",
         CaseEvaluation,
@@ -170,6 +189,7 @@ def load_stored_run(
         git_revision=git_revision,
         frozen_suite=frozen,
         selection=selection,
+        behavioral_coverage=behavioral_coverage,
     )
 
 
@@ -182,6 +202,9 @@ def render_stored_run(
 ) -> StoredReport:
     loaded = load_stored_run(target, run_id=run_id, latest=latest)
     reviews = load_reviews_for_run(loaded.root, loaded.config, loaded.run_id)
+    # This configured frozen suite may postdate the stored run. It remains
+    # useful display metadata, but must not become a new source binding after
+    # the loader has verified coverage against the persisted artifacts.
     html = render_report(
         run_id=loaded.run_id,
         target=str(loaded.root),
@@ -195,7 +218,9 @@ def render_stored_run(
         seed=loaded.seed,
         frozen_suite=loaded.frozen_suite,
         selection_plan=loaded.selection,
+        behavioral_coverage=loaded.behavioral_coverage,
         reviews=reviews,
+        _verify_frozen_coverage_binding=False,
     )
     destination = _report_destination(loaded, out)
     try:
@@ -360,7 +385,58 @@ def _load_suite(path: Path, run_id: str) -> tuple[int, tuple[Scenario, ...]]:
     return seed, tuple(scenarios)
 
 
-def _load_summary(path: Path, run_id: str, seed: int) -> tuple[str | None, SelectionPlan | None]:
+def _load_invalid_scenario_ids(path: Path) -> tuple[str, ...] | None:
+    if not path.exists():
+        return None
+    document = _read_json_object(path, max_bytes=_MAX_JSON_BYTES)
+    _require_contract(
+        document,
+        field="schema_version",
+        expected=_INVALID_SCENARIOS_CONTRACT,
+        filename=path.name,
+    )
+    raw_items = document.get("items")
+    if not isinstance(raw_items, list):
+        raise ConfigurationError(f"invalid {path.name}: items must be a list")
+    scenario_ids: list[str] = []
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, dict):
+            raise ConfigurationError(f"invalid {path.name} item {index}")
+        try:
+            scenario = Scenario.model_validate_json(json.dumps(item.get("scenario")))
+        except (TypeError, ValueError) as exc:
+            raise ConfigurationError(
+                f"invalid {path.name} scenario at index {index}: {exc}"
+            ) from exc
+        issues = item.get("issues")
+        if not isinstance(issues, list) or not issues:
+            raise ConfigurationError(
+                f"invalid {path.name} issues at index {index}: expected a non-empty list"
+            )
+        if any(
+            not isinstance(issue, dict)
+            or any(
+                not isinstance(issue.get(field), str)
+                for field in ("code", "message", "severity")
+            )
+            for issue in issues
+        ):
+            raise ConfigurationError(f"invalid {path.name} issues at index {index}")
+        scenario_ids.append(scenario.scenario_id)
+    if len(scenario_ids) != len(set(scenario_ids)):
+        raise ConfigurationError(f"invalid {path.name}: scenario IDs must be unique")
+    return tuple(scenario_ids)
+
+
+def _load_summary(
+    path: Path,
+    run_id: str,
+    seed: int,
+    *,
+    spec: AgentSpec,
+    invalid_scenario_ids: tuple[str, ...] | None,
+    scenarios: tuple[Scenario, ...],
+) -> tuple[str | None, SelectionPlan | None, BehavioralCoverage]:
     document = _read_json_object(path, max_bytes=_MAX_JSON_BYTES)
     _require_contract(
         document, field="schema_version", expected=_SUMMARY_CONTRACT, filename=path.name
@@ -371,11 +447,57 @@ def _load_summary(path: Path, run_id: str, seed: int) -> tuple[str | None, Selec
         )
     if document.get("seed") != seed:
         raise ConfigurationError(f"{path.name} seed does not match suite.json")
+    raw_invalid_count = document.get("invalid_scenarios", 0)
+    if (
+        isinstance(raw_invalid_count, bool)
+        or not isinstance(raw_invalid_count, int)
+        or raw_invalid_count < 0
+    ):
+        raise ConfigurationError(
+            f"invalid {path.name}: invalid_scenarios must be a non-negative integer"
+        )
+    if invalid_scenario_ids is None:
+        if raw_invalid_count:
+            raise ConfigurationError(
+                f"invalid {path.name}: invalid-scenarios.json is required when "
+                "invalid scenarios were recorded"
+            )
+        persisted_invalid_ids: tuple[str, ...] = ()
+    else:
+        persisted_invalid_ids = invalid_scenario_ids
+        if raw_invalid_count != len(persisted_invalid_ids):
+            raise ConfigurationError(
+                f"invalid {path.name}: invalid scenario count does not match "
+                "invalid-scenarios.json"
+            )
+    valid_ids = {scenario.scenario_id for scenario in scenarios}
+    if valid_ids.intersection(persisted_invalid_ids):
+        raise ConfigurationError(
+            f"invalid {path.name}: valid and invalid scenario IDs overlap"
+        )
     revision = document.get("git_revision")
     selection = _optional_selection(document.get("selection"), filename=path.name)
+    behavioral_coverage = _optional_behavioral_coverage(
+        document.get("behavioral_coverage", _MISSING_BEHAVIORAL_COVERAGE),
+        filename=path.name,
+        spec=spec,
+        scenarios=scenarios,
+        reference_scope=(
+            BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+            if selection is not None and selection.excluded_ids
+            else BehavioralCoverageReferenceScope.COMPLETE
+        ),
+    )
+    _validate_selection_coverage_binding(
+        selection,
+        behavioral_coverage,
+        scenarios,
+        invalid_scenario_ids=persisted_invalid_ids,
+        filename=path.name,
+    )
     if revision is None:
-        return None, selection
-    return str(revision), selection
+        return None, selection, behavioral_coverage
+    return str(revision), selection, behavioral_coverage
 
 
 def _optional_selection(value: object, *, filename: str) -> SelectionPlan | None:
@@ -385,6 +507,88 @@ def _optional_selection(value: object, *, filename: str) -> SelectionPlan | None
         return SelectionPlan.model_validate_json(json.dumps(value))
     except (TypeError, ValueError) as exc:
         raise ConfigurationError(f"invalid {filename} selection plan: {exc}") from exc
+
+
+def _optional_behavioral_coverage(
+    value: object,
+    *,
+    filename: str,
+    spec: AgentSpec,
+    scenarios: tuple[Scenario, ...],
+    reference_scope: BehavioralCoverageReferenceScope,
+) -> BehavioralCoverage:
+    if value is _MISSING_BEHAVIORAL_COVERAGE:
+        # Behavioral coverage was added without changing the summary contract,
+        # so reports created before the field existed remain readable. Derive
+        # only from this run's artifacts; a currently configured frozen suite
+        # may have changed since the run. When selection discarded cases before
+        # persistence, explicitly retain that the available denominator is
+        # incomplete instead of presenting the selected subset as the universe.
+        return analyze_behavioral_coverage(
+            spec, scenarios, reference_scope=reference_scope
+        )
+    try:
+        coverage = BehavioralCoverage.model_validate_json(json.dumps(value))
+        verify_behavioral_coverage_binding(coverage, spec, scenarios)
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError(
+            f"invalid {filename} behavioral coverage: {exc}"
+        ) from exc
+    return coverage
+
+
+def _validate_selection_coverage_binding(
+    selection: SelectionPlan | None,
+    coverage: BehavioralCoverage,
+    scenarios: tuple[Scenario, ...],
+    *,
+    invalid_scenario_ids: tuple[str, ...],
+    filename: str,
+) -> None:
+    if selection is None:
+        return
+    scenario_ids = tuple(scenario.scenario_id for scenario in scenarios)
+    if len(scenario_ids) != len(set(scenario_ids)):
+        raise ConfigurationError(
+            f"invalid {filename} selection binding: suite.json scenario IDs "
+            "must be unique"
+        )
+    valid_ids = set(scenario_ids)
+    invalid_ids = set(invalid_scenario_ids)
+    selected_ids = set(selection.selected_ids)
+    decision_ids = {item.scenario_id for item in selection.decisions}
+    invalid_in_plan = invalid_ids.intersection(decision_ids)
+    if invalid_in_plan and invalid_in_plan != invalid_ids:
+        raise ConfigurationError(
+            f"invalid {filename} selection binding: invalid scenario IDs are "
+            "only partially represented by the selection plan"
+        )
+    if invalid_in_plan.intersection(selection.excluded_ids):
+        raise ConfigurationError(
+            f"invalid {filename} selection binding: a persisted invalid scenario "
+            "cannot be excluded by the selection plan"
+        )
+    if selected_ids != valid_ids.union(invalid_in_plan):
+        raise ConfigurationError(
+            f"invalid {filename} selection binding: selected scenario IDs do not "
+            "match persisted valid and invalid scenarios"
+        )
+    if coverage.scenario_count != len(scenario_ids):
+        raise ConfigurationError(
+            f"invalid {filename} selection binding: behavioral coverage scenario "
+            "count does not match lint-valid scenarios"
+        )
+    expected_reference_count = (
+        len(scenario_ids)
+        if coverage.reference_scope
+        is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+        else len(selection.decisions) - len(invalid_in_plan)
+    )
+    if coverage.reference_scenario_count != expected_reference_count:
+        raise ConfigurationError(
+            f"invalid {filename} selection binding: behavioral coverage reference "
+            "count does not match the lint-valid selection universe"
+        )
 
 
 def _load_findings(path: Path) -> tuple[Finding, ...]:

--- a/agentcheck/report/render.py
+++ b/agentcheck/report/render.py
@@ -6,6 +6,12 @@ import statistics
 from collections import Counter
 from typing import Any, Iterable
 
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+    analyze_behavioral_coverage,
+    verify_behavioral_coverage_binding,
+)
 from agentcheck.domain import (
     AgentSpec,
     CanonicalRun,
@@ -108,6 +114,75 @@ def _cards(items: Iterable[tuple[str, str]]) -> str:
     )
 
 
+def _coverage_label(value: str) -> str:
+    return value.replace("_", " ").replace("-", " ").capitalize()
+
+
+def _behavioral_coverage_html(coverage: BehavioralCoverage) -> str:
+    family_html: list[str] = []
+    detail_statuses = {"missing", "partial", "unknown", "unsupported"}
+    for family in coverage.families:
+        total = (
+            family.covered
+            + family.partial
+            + family.missing
+            + family.unknown
+            + family.unsupported
+        )
+        if total == 0:
+            continue
+
+        details = "".join(
+            "<li><span class=\"mono\">"
+            f"{_escape(requirement.subject)}</span> — "
+            f"{_escape(_coverage_label(requirement.status.value))}: "
+            f"{_escape(_coverage_label(requirement.reason_code))}</li>"
+            for requirement in family.requirements
+            if requirement.status.value in detail_statuses
+        )
+        if family.omitted:
+            details += (
+                f'<li class="muted">{_escape(family.omitted)} additional '
+                "requirement detail(s) omitted from this bounded artifact.</li>"
+            )
+        detail_html = f"<ul>{details}</ul>" if details else ""
+        family_html.append(
+            '<div class="coverage-family">'
+            f"<h4>{_escape(_coverage_label(family.dimension.value))}</h4>"
+            f"<p>Applicable: {_escape(family.applicable)} · "
+            f"Covered: {_escape(family.covered)} · "
+            f"Partial: {_escape(family.partial)} · "
+            f"Missing: {_escape(family.missing)} · "
+            f"Unknown: {_escape(family.unknown)} · "
+            f"Unsupported: {_escape(family.unsupported)}</p>"
+            f"{detail_html}</div>"
+        )
+    body = "".join(family_html) or (
+        '<p class="muted">No declared behavioral coverage requirements were derived.</p>'
+    )
+    reference_scope_html = ""
+    if (
+        coverage.reference_scope
+        is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+    ):
+        reference_scope_html = (
+            '<p><b>Incomplete denominator:</b> reference scope is available '
+            "scenarios only. Unavailable scenario contracts may contain additional "
+            "behavioral requirements, so this report may undercount missing risks.</p>"
+        )
+    return (
+        "<h3>Declared behavioral coverage</h3>"
+        f"<p>Evidence scenarios: {_escape(coverage.scenario_count)} · Reference "
+        f"scenarios: {_escape(coverage.reference_scenario_count)}</p>"
+        f"{reference_scope_html}"
+        f"{body}"
+        '<p class="muted">This structural suite-design analysis does not prove '
+        "that the agent exercised an action path and does not establish complete "
+        "coverage of real-world behavioral risks. Unknown and unsupported "
+        "requirements remain explicit.</p>"
+    )
+
+
 def render_report(
     *,
     run_id: str,
@@ -122,7 +197,10 @@ def render_report(
     seed: int | None = None,
     frozen_suite: FrozenSuite | None = None,
     selection_plan: SelectionPlan | None = None,
+    behavioral_coverage: BehavioralCoverage | None = None,
     reviews: tuple[HumanReview, ...] = (),
+    _coverage_reference_scenarios: tuple[Scenario, ...] | None = None,
+    _verify_frozen_coverage_binding: bool = True,
 ) -> str:
     """Render a single escaped HTML file with no external resources or JavaScript."""
 
@@ -136,6 +214,78 @@ def render_report(
     dimensions = sorted({tag for scenario in scenarios for tag in scenario.dimension_tags})
     tools = [item.value for item in spec.tools.items]
     capabilities = [item.value for item in spec.capabilities.items]
+    frozen_reference_differs = (
+        _coverage_reference_scenarios is None
+        and frozen_suite is not None
+        and Counter(
+            (scenario.scenario_id, scenario.fingerprint)
+            for scenario in frozen_suite.scenarios
+        )
+        != Counter(
+            (scenario.scenario_id, scenario.fingerprint) for scenario in scenarios
+        )
+    )
+    incomplete_reference = (
+        frozen_suite is not None
+        and frozen_suite.selection is not None
+        and bool(frozen_suite.selection.excluded_ids)
+    ) or (
+        _coverage_reference_scenarios is None
+        and frozen_suite is None
+        and selection_plan is not None
+        and bool(selection_plan.excluded_ids)
+    ) or frozen_reference_differs
+
+    if behavioral_coverage is None:
+        behavioral_coverage = analyze_behavioral_coverage(
+            spec,
+            scenarios,
+            reference_scenarios=_coverage_reference_scenarios,
+            suite_fingerprint=(
+                frozen_suite.fingerprint if frozen_suite is not None else None
+            ),
+            reference_scope=(
+                BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+                if incomplete_reference
+                else BehavioralCoverageReferenceScope.COMPLETE
+            ),
+        )
+    else:
+        if _verify_frozen_coverage_binding:
+            if _coverage_reference_scenarios is None:
+                if (
+                    behavioral_coverage.reference_scenario_count
+                    > behavioral_coverage.scenario_count
+                    or (
+                        incomplete_reference
+                        and behavioral_coverage.reference_scope
+                        is BehavioralCoverageReferenceScope.COMPLETE
+                    )
+                ):
+                    raise ValueError(
+                        "behavioral coverage reference_scenarios are required "
+                        "to verify the complete requirement universe"
+                    )
+                reference_keywords: dict[str, Any] = {}
+            else:
+                reference_keywords = {
+                    "reference_scenarios": _coverage_reference_scenarios
+                }
+            verify_behavioral_coverage_binding(
+                behavioral_coverage,
+                spec,
+                scenarios,
+                suite_fingerprint=(
+                    frozen_suite.fingerprint
+                    if frozen_suite is not None
+                    else None
+                ),
+                **reference_keywords,
+            )
+        else:
+            verify_behavioral_coverage_binding(behavioral_coverage, spec, scenarios)
+    behavioral_coverage_html = _behavioral_coverage_html(behavioral_coverage)
+
     evaluation_by_scenario = {item.scenario_id: item for item in evaluations}
     run_by_scenario = {item.scenario_id: item for item in runs}
     findings_by_scenario: dict[str, list[Finding]] = {}
@@ -384,7 +534,7 @@ def render_report(
       ('Known cost', _reported_total(cost_values, len(runs), ' USD')),
   ))}</section>
   <section class="panel"><h2>Target and AgentSpec</h2><p>Framework: {_escape(spec.identity.framework.value)} {_escape(spec.identity.framework_version.value or '')} · Model: {_escape(spec.identity.model.value or 'Unknown')}</p><p>Tools ({len(tools)}): {_escape(', '.join(tool.name for tool in tools))}</p><p>Capabilities ({len(capabilities)}): {_escape(', '.join(item.name for item in capabilities) or 'None derived')}</p><p>Unknown properties: {len(spec.unknowns)}</p>{policy_html}<h3>Instructions</h3>{instruction_html}</section>
-  <section class="panel"><h2>Coverage and reproducibility</h2><p>{len(scenarios)} valid scenarios · {len(dimensions)} distinct dimension tags</p><p>{_escape(', '.join(dimensions))}</p>{origin_html}{coverage_extra}{exercise_html}{selection_html}<p>Every case records its generation seed and structural fingerprint. Invalid scenarios are excluded from these counts. Cases excluded by coverage selection are listed above and are not scored as passing.</p></section>
+  <section class="panel"><h2>Coverage and reproducibility</h2>{behavioral_coverage_html}<p>{len(scenarios)} valid scenarios · {len(dimensions)} distinct dimension tags</p><p>{_escape(', '.join(dimensions))}</p>{origin_html}{coverage_extra}{exercise_html}{selection_html}<p>Every case records its generation seed and structural fingerprint. Invalid scenarios are excluded from these counts. Cases excluded by coverage selection are listed above and are not scored as passing.</p></section>
   <section><h2>Findings</h2>{finding_html}</section>
   <section><h2>Scenarios</h2>{''.join(cases)}</section>
 </main></body></html>"""

--- a/docs/behavioral-coverage.md
+++ b/docs/behavioral-coverage.md
@@ -48,6 +48,13 @@ duplicate-action behavior. Retry coverage similarly accounts for the number of
 reachable configured outcomes, fixture priority and ambiguity, declared input
 schemas, and scenario resource budgets.
 
+A simulated mutation bounds reach without hiding it. A fixture that changes
+simulated world state is itself controlled, so it supports coverage of its own
+outcome; the invocation after it is not counted, because that one depends on
+world state this analysis does not evaluate. A state-changing success path is
+therefore still `COVERED`, while a duplicate attempt behind the same mutation
+stays `PARTIAL`.
+
 Prerequisite relationships are not inferred from tool or fixture names in
 arbitrary custom scenarios. The generator convention is recognized only with a
 known generated-action source tag, exactly one explicit `tool:<name>` focal
@@ -113,6 +120,14 @@ mandatory artifact redaction or truncation losslessly are reported
 `UNKNOWN`, never `COVERED`. The normalized spec ID is a display/source hint,
 not proof of semantic identity; when full source inputs are available,
 verification re-derives coverage from those inputs.
+
+Coverage never aborts generation over its own limits. A repeated declared tool
+name makes tool identity ambiguous, so no definition under that name is
+authoritative and every subject bound to it is `UNKNOWN`; `ToolGateway`
+independently refuses to execute such a target. An input schema this analysis
+cannot evaluate offline — an unresolvable local reference, for instance — yields
+no controlled reach rather than an escaping error, so the affected behavior is
+reported missing rather than covered.
 
 For a stored selected run, embedded coverage can retain the digest of the full
 reference universe. The loader can verify the coverage checksum and surviving

--- a/docs/behavioral-coverage.md
+++ b/docs/behavioral-coverage.md
@@ -1,0 +1,151 @@
+# Declared behavioral coverage
+
+AgentCheck reports which behavioral obligations a suite structurally exercises
+and which obligations remain missing. The report answers a bounded question:
+
+> Given this inspected specification and these scenarios, which explicitly
+> represented behaviors have both a stimulus and an observable check?
+
+It does not guess business meaning from tool names or prose. A tool named
+`delete_user` is not treated as destructive merely because of its name.
+Destructive, state-changing, confirmation, and prerequisite coverage is only
+reported when the relevant semantics are authoritative in the inspected
+contract or explicitly represented by a scenario or selected policy contract.
+Unknown metadata stays unknown.
+
+## Reading the statuses
+
+Within each behavioral family, AgentCheck creates one requirement for each
+declared tool or explicitly represented tool relationship. Requirements are
+not created per scenario or execution, and multiple scenarios for the same
+family and subject contribute evidence to the same requirement.
+
+- `COVERED`: the suite contains the explicit stimulus and a supported,
+  non-vacuous oracle or trajectory constraint needed to check it.
+- `PARTIAL`: the behavior is represented, but the check is optional,
+  potentially vacuous, lacks enough fixture outcomes, or otherwise proves less
+  than full structural coverage.
+- `MISSING`: the behavior is applicable from a declared contract, but no
+  adequate scenario represents it.
+- `UNKNOWN`: AgentCheck lacks authoritative metadata needed to decide whether
+  the risk is applicable.
+- `UNSUPPORTED`: the contract expresses a behavior that the current evaluator
+  cannot observe reliably.
+
+The denominator for a family is its applicable requirements:
+`COVERED + PARTIAL + MISSING`. Unknown and unsupported requirements are shown
+but excluded from that denominator. Empty families are omitted; a family that
+contains only unknown or unsupported requirements shows zero applicable and is
+never presented as fully covered. AgentCheck deliberately does not combine
+unrelated families into a marketing-style overall percentage.
+
+For example, a simulated timeout fixture alone shows that the suite can deliver
+a timeout, but it does not show what response is required. That is partial
+coverage until a supported output or trajectory oracle makes the expected
+behavior observable. A no-duplicate constraint with only one response-capable fixture is
+also partial: a second call would exhaust the fixture rather than prove the
+duplicate-action behavior. Retry coverage similarly accounts for the number of
+reachable configured outcomes, fixture priority and ambiguity, declared input
+schemas, and scenario resource budgets.
+
+Prerequisite relationships are not inferred from tool or fixture names in
+arbitrary custom scenarios. The generator convention is recognized only with a
+known generated-action source tag, exactly one explicit `tool:<name>` focal
+tag consistent with the declared focal behavior, and a prerequisite fixture
+from that convention. AgentCheck can report controlled prerequisite and focal
+calls, but its current oracle does not prove their order. Prerequisite success
+therefore remains partial, and the corresponding ordering requirement is
+`UNSUPPORTED`.
+
+## Structural coverage versus observed execution
+
+Declared behavioral coverage describes suite design. It does not claim that a
+model actually took a branch during a run. The run verdict, trace, assertion
+evidence, and the separate “Action paths exercised” output describe what the
+agent actually did.
+
+This distinction matters for optional calls. A scenario can contain a tool
+fixture and pass a constraint vacuously because the agent never called the tool.
+Such a scenario does not become full structural coverage merely because its run
+verdict was `PASS`, and structural coverage does not rewrite any
+`PASS`/`FAIL`/`INCONCLUSIVE`/`INFRA_ERROR` verdict.
+
+Infrastructure failures are also separate. A worker wall-clock timeout is an
+`INFRA_ERROR`; only an explicit simulated tool-timeout outcome participates in
+tool-timeout coverage.
+
+## Denominator and source binding
+
+Coverage is derived deterministically from:
+
+- the validated `AgentSpec`, including the authority provenance of metadata;
+- validated scenario fixtures, fault injections, outcome variants, output
+  criteria and trajectory constraints;
+- a reference scenario set that defines the requirement universe;
+- the actual selected scenario set that supplies evidence; and
+- the frozen-suite fingerprint when a frozen suite was used.
+
+For unbounded generation, the actual and reference sets are the same full
+lint-clean generated suite. Bounded generation retains the full pre-selection
+set as its ephemeral reference while the selected cases supply evidence. A
+runtime selection likewise uses the full lint-clean in-memory suite as its
+reference. Requirements come from that reference set, while `COVERED` evidence
+comes only from the actual set. Excluding a case can therefore make its
+behavior missing; it does not silently shrink the denominator. A later run of
+a persisted pruned v1 frozen suite cannot reconstruct excluded documents and
+is reported as `AVAILABLE_SCENARIOS_ONLY`. Invalid scenarios are not
+represented as behavioral coverage.
+
+The document records actual and reference counts and digests. Each digest hashes
+a canonically sorted multiset of
+`(scenario_id, scenario_fingerprint)` records. It is independent of input
+ordering, preserves duplicate multiplicity, and binds both display identity
+and behavioral content.
+
+The document fingerprint is an unkeyed checksum over its redacted coverage
+content. It can detect stale or corrupted content, but it is not
+authentication. Binding checks independently recompute the spec,
+actual-scenario, reference-scenario, and frozen-suite identities when those
+source documents are available.
+
+Coverage-sensitive tool identifiers or input schemas that cannot survive
+mandatory artifact redaction or truncation losslessly are reported
+`UNKNOWN`, never `COVERED`. The normalized spec ID is a display/source hint,
+not proof of semantic identity; when full source inputs are available,
+verification re-derives coverage from those inputs.
+
+For a stored selected run, embedded coverage can retain the digest of the full
+reference universe. The loader can verify the coverage checksum and surviving
+actual scenario documents, but it cannot independently reconstruct excluded
+scenario fingerprints. When an older summary lacks embedded coverage and only
+selected scenarios remain, AgentCheck derives
+`AVAILABLE_SCENARIOS_ONLY` coverage. That explicitly means the denominator is
+limited to surviving documents; the HTML report displays the limitation.
+
+Coverage analysis is pure contract inspection. It does not import or invoke a
+target handler, run a gateway, apply fixture effects, or mutate a real or
+simulated world. Tool names and descriptions remain identifiers and evidence;
+they never classify destructive, state-changing, prerequisite, or authorization
+semantics.
+
+## Where the report appears
+
+The machine-readable document is written under
+`summary.json.behavioral_coverage` and rendered in the offline HTML report.
+The CLI prints the same family counts and uncovered subjects after `generate`
+and `test`. Collections are bounded before they reach the artifact boundary;
+omitted-item counts remain explicit.
+
+## Compatibility
+
+Behavioral coverage is derived report metadata. It adds no field to `Scenario`,
+`FrozenSuite`, replay manifests, baselines, or review records. Existing frozen
+suite bytes and fingerprints therefore do not change, and this feature does not
+alter replay semantics. Replay remains source-bound re-execution of recorded
+inputs and harness behavior; it is not deterministic provider-output replay.
+
+Custom Python agents participate through the same `AgentSpec` and scenario
+contracts as the native adapters. Custom tool risk flags are authoritative when
+declared by the integration. Framework metadata that an adapter could only
+infer from a name or description is retained as unknown for risk-applicability
+purposes rather than promoted into a fact.

--- a/tests/agentcheck/test_behavioral_coverage.py
+++ b/tests/agentcheck/test_behavioral_coverage.py
@@ -1,0 +1,2241 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from agentcheck.artifacts import ArtifactStore
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+    BehavioralCoverageStatus,
+    BehavioralDimension,
+    analyze_behavioral_coverage,
+    verify_behavioral_coverage_binding,
+)
+from agentcheck.coverage.contract import MAX_COVERAGE_DETAILS
+from agentcheck.domain import (
+    AgentProperty,
+    AgentSpec,
+    CapabilitiesSpec,
+    ConversationRole,
+    ConversationTurn,
+    FaultType,
+    GuardrailsSpec,
+    IdentitySpec,
+    InjectedFault,
+    InspectionProvenance,
+    InstructionsSpec,
+    InterfaceSpec,
+    ObservabilitySpec,
+    OracleProvenance,
+    OracleStrength,
+    OutputCriterion,
+    PostconditionOperator,
+    OutputCriterionKind,
+    PoliciesSpec,
+    ResourceBudgets,
+    RuntimeSpec,
+    Scenario,
+    SimulatedToolOutcome,
+    SimulatedToolStatus,
+    SourceKind,
+    SourceReference,
+    StatePostcondition,
+    SpecEvidence,
+    ToolBehaviorConstraint,
+    ToolDefinition,
+    ToolFixture,
+    ToolPoliciesSpec,
+    ToolPolicy,
+    ToolsSpec,
+    TrajectoryConstraint,
+    TrajectoryConstraintKind,
+    WorldStateEffect,
+    WorkflowsSpec,
+)
+from agentcheck.generate.boundaries import build_outcome_variant_cases
+from agentcheck.generate.suite import (
+    CaseLineage,
+    CaseOrigin,
+    FrozenCase,
+    FrozenSuite,
+    GeneratorProvenance,
+    SuiteCoverage,
+)
+from agentcheck.privacy import redact_artifact
+from agentcheck.runner.tool_gateway import ToolGateway
+
+
+NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+ORACLE_ID = "declared-contract"
+
+
+def _property(value: Any, *, authoritative: bool = True) -> AgentProperty[Any]:
+    return AgentProperty(
+        value=value,
+        source=SourceReference(
+            kind=SourceKind.RUNTIME_INTROSPECTION,
+            locator="tests/target.py:1",
+        ),
+        confidence=1.0,
+        evidence=(
+            SpecEvidence(
+                evidence_id="inspection-evidence",
+                summary="Observed in the declared target contract.",
+            ),
+        ),
+        inferred=not authoritative,
+        authoritative=authoritative,
+    )
+
+
+def _tool(
+    name: str,
+    *,
+    state_changing: bool = False,
+    destructive: bool = False,
+    input_schema: dict[str, Any] | None = None,
+) -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        description=f"Declared tool {name}.",
+        input_schema=input_schema or {"type": "object"},
+        state_changing=state_changing,
+        replaceable=True,
+        destructive=destructive,
+    )
+
+
+def _spec(
+    *tools: tuple[ToolDefinition, bool],
+    policies: tuple[tuple[ToolPolicy, bool], ...] = (),
+    spec_id: str = "coverage-spec",
+) -> AgentSpec:
+    return AgentSpec(
+        spec_id=spec_id,
+        identity=IdentitySpec(
+            name=_property("Coverage target"),
+            framework=_property("custom"),
+            framework_version=_property(None, authoritative=False),
+            provider=_property(None, authoritative=False),
+            model=_property(None, authoritative=False),
+        ),
+        interface=InterfaceSpec(
+            entrypoint=_property("target:agent"),
+            input_modalities=_property(("text",)),
+            output_modalities=_property(("text",)),
+            input_schema=_property(None, authoritative=False),
+            output_schema=_property(None, authoritative=False),
+            interactive=_property(True),
+        ),
+        instructions=InstructionsSpec(
+            system=_property(None, authoritative=False),
+            developer=_property(None, authoritative=False),
+        ),
+        capabilities=CapabilitiesSpec(),
+        tools=ToolsSpec(
+            items=tuple(
+                _property(tool, authoritative=authoritative)
+                for tool, authoritative in tools
+            )
+        ),
+        tool_policies=ToolPoliciesSpec(
+            items=tuple(
+                _property(policy, authoritative=authoritative)
+                for policy, authoritative in policies
+            )
+        ),
+        guardrails=GuardrailsSpec(),
+        workflows=WorkflowsSpec(),
+        policies=PoliciesSpec(),
+        runtime=RuntimeSpec(
+            max_model_turns=_property(8),
+            max_tool_calls=_property(20),
+            timeout_seconds=_property(30.0),
+            token_budget=_property(None, authoritative=False),
+            cost_budget_usd=_property(None, authoritative=False),
+        ),
+        observability=ObservabilitySpec(
+            supported_event_types=_property(("tool_attempt", "tool_result")),
+            usage_metrics=_property(()),
+            provider_request_ids=_property(False),
+            source_event_links=_property(True),
+        ),
+        provenance=InspectionProvenance(
+            inspector="coverage-test",
+            inspector_version="1",
+            inspected_at=NOW,
+            target="tests/target.py",
+            sources=(
+                SourceReference(
+                    kind=SourceKind.RUNTIME_INTROSPECTION,
+                    locator="tests/target.py:1",
+                ),
+            ),
+        ),
+    )
+
+
+def _oracle() -> OracleProvenance:
+    return OracleProvenance(
+        oracle_id=ORACLE_ID,
+        strength=OracleStrength.TOOL_CONTRACT,
+        source="Declared tool and scenario contract.",
+        confidence=1.0,
+        evidence_ids=("declared-evidence",),
+        supports_hard_failure=True,
+    )
+
+
+def _required(
+    tool_name: str,
+    *,
+    criterion_id: str = "required-call",
+    confirmation: bool = False,
+    arguments_match: dict[str, Any] | None = None,
+) -> ToolBehaviorConstraint:
+    return ToolBehaviorConstraint(
+        criterion_id=criterion_id,
+        tool_name=tool_name,
+        min_calls=1,
+        confirmation_required_before_call=confirmation,
+        arguments_match=arguments_match or {},
+        oracle_ids=(ORACLE_ID,),
+    )
+
+
+def _forbidden(
+    tool_name: str,
+    *,
+    criterion_id: str = "forbidden-call",
+    confirmation: bool = False,
+) -> ToolBehaviorConstraint:
+    return ToolBehaviorConstraint(
+        criterion_id=criterion_id,
+        tool_name=tool_name,
+        min_calls=0,
+        max_calls=0,
+        confirmation_required_before_call=confirmation,
+        oracle_ids=(ORACLE_ID,),
+    )
+
+
+def _fixture(
+    tool_name: str,
+    status: SimulatedToolStatus,
+    *,
+    fixture_id: str = "fixture",
+    invocation_index: int | None = None,
+    error_code: str | None = None,
+    arguments_match: dict[str, Any] | None = None,
+    priority: int = 0,
+    latency_ms: float = 0.0,
+    state_effects: tuple[WorldStateEffect, ...] = (),
+) -> ToolFixture:
+    return ToolFixture(
+        fixture_id=fixture_id,
+        tool_name=tool_name,
+        invocation_index=invocation_index,
+        arguments_match=arguments_match or {},
+        priority=priority,
+        outcome=SimulatedToolOutcome(
+            status=status,
+            result={"ok": True} if status is SimulatedToolStatus.SUCCESS else None,
+            error_code=error_code,
+            error_message=(
+                "controlled failure"
+                if status in {SimulatedToolStatus.ERROR, SimulatedToolStatus.TIMEOUT}
+                else None
+            ),
+            latency_ms=latency_ms,
+            state_effects=state_effects,
+        ),
+    )
+
+
+def _trajectory(
+    kind: TrajectoryConstraintKind,
+    tool_name: str,
+    *,
+    criterion_id: str = "trajectory",
+    extra: dict[str, Any] | None = None,
+) -> TrajectoryConstraint:
+    return TrajectoryConstraint(
+        criterion_id=criterion_id,
+        kind=kind,
+        description="Explicit executable trajectory constraint.",
+        parameters={"tool_name": tool_name, **(extra or {})},
+        oracle_ids=(ORACLE_ID,),
+    )
+
+
+def _output(
+    kind: OutputCriterionKind,
+    *,
+    criterion_id: str = "output",
+    parameters: dict[str, Any] | None = None,
+) -> OutputCriterion:
+    return OutputCriterion(
+        criterion_id=criterion_id,
+        kind=kind,
+        description="Explicit output behavior criterion.",
+        parameters=parameters or {},
+        oracle_ids=(ORACLE_ID,),
+    )
+
+
+def _scenario(
+    scenario_id: str,
+    *,
+    fixtures: tuple[ToolFixture, ...] = (),
+    injected_faults: tuple[InjectedFault, ...] = (),
+    required: tuple[ToolBehaviorConstraint, ...] = (),
+    forbidden: tuple[ToolBehaviorConstraint, ...] = (),
+    allowed: tuple[ToolBehaviorConstraint, ...] = (),
+    trajectory: tuple[TrajectoryConstraint, ...] = (),
+    outputs: tuple[OutputCriterion, ...] = (),
+    postconditions: tuple[StatePostcondition, ...] = (),
+    confirmed: bool = False,
+    dimension_tags: tuple[str, ...] = ("test:behavioral-coverage",),
+    seed: int = 1,
+    resource_budgets: ResourceBudgets | None = None,
+) -> Scenario:
+    return Scenario(
+        scenario_id=scenario_id,
+        title=f"Coverage case {scenario_id}",
+        conversation_turns=(
+            ConversationTurn(
+                turn_id=f"turn-{scenario_id}",
+                role=ConversationRole.USER,
+                content="Exercise the declared behavior.",
+                metadata={"explicit_confirmation": True} if confirmed else {},
+            ),
+        ),
+        initial_world_state={"records": {"one": {"status": "unchanged"}}},
+        tool_fixtures=fixtures,
+        injected_faults=injected_faults,
+        required_tool_behavior=required,
+        allowed_tool_behavior=allowed,
+        forbidden_tool_behavior=forbidden,
+        trajectory_constraints=trajectory,
+        output_criteria=outputs,
+        expected_postconditions=postconditions,
+        dimension_tags=dimension_tags,
+        oracle_provenance=(_oracle(),),
+        resource_budgets=resource_budgets or ResourceBudgets(),
+        generation_seed=seed,
+    )
+
+
+def _family(report: BehavioralCoverage, dimension: BehavioralDimension):
+    return next(family for family in report.families if family.dimension is dimension)
+
+
+def _requirement(
+    report: BehavioralCoverage,
+    dimension: BehavioralDimension,
+    subject: str,
+):
+    family = _family(report, dimension)
+    return next(item for item in family.requirements if item.subject == subject)
+
+
+def test_no_declared_tools_has_no_applicable_risks() -> None:
+    report = analyze_behavioral_coverage(_spec(), ())
+
+    assert tuple(family.dimension for family in report.families) == tuple(
+        BehavioralDimension
+    )
+    assert all(family.applicable == 0 for family in report.families)
+    assert all(family.unknown == family.unsupported == 0 for family in report.families)
+
+
+def test_success_failure_timeout_and_multiple_tools_are_explicit() -> None:
+    first = _tool("write_record", state_changing=True)
+    second = _tool("read_record")
+    success = _scenario(
+        "success",
+        fixtures=(_fixture(first.name, SimulatedToolStatus.SUCCESS),),
+        required=(_required(first.name),),
+    )
+    failure = _scenario(
+        "failure",
+        fixtures=(
+            _fixture(first.name, SimulatedToolStatus.ERROR, error_code="declined"),
+        ),
+        required=(_required(first.name),),
+        outputs=(_output(OutputCriterionKind.ACKNOWLEDGES_TOOL_ERROR),),
+        seed=2,
+    )
+    timeout = _scenario(
+        "timeout",
+        fixtures=(
+            _fixture(first.name, SimulatedToolStatus.TIMEOUT, error_code="timeout"),
+        ),
+        required=(_required(first.name),),
+        outputs=(_output(OutputCriterionKind.ACKNOWLEDGES_TOOL_ERROR),),
+        seed=3,
+    )
+
+    report = analyze_behavioral_coverage(
+        _spec((second, True), (first, True)), (timeout, success, failure)
+    )
+
+    for dimension in (
+        BehavioralDimension.SUCCESS_PATH,
+        BehavioralDimension.FAILURE_HANDLING,
+        BehavioralDimension.TIMEOUT_HANDLING,
+    ):
+        family = _family(report, dimension)
+        assert family.applicable == 2
+        assert family.covered == 1
+        assert family.missing == 1
+        assert _requirement(report, dimension, "tool:write_record").status is (
+            BehavioralCoverageStatus.COVERED
+        )
+
+
+def test_destructive_applicability_is_authoritative_and_never_name_guessed() -> None:
+    declared = _tool("mutate", state_changing=True, destructive=True)
+    suspicious = _tool("delete_every_user", state_changing=True, destructive=True)
+    report = analyze_behavioral_coverage(
+        _spec((suspicious, False), (declared, True)), ()
+    )
+
+    for dimension in (
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+        BehavioralDimension.DUPLICATE_ACTION,
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        BehavioralDimension.RETRY_CONTROL,
+    ):
+        assert _requirement(report, dimension, "tool:delete_every_user").status is (
+            BehavioralCoverageStatus.UNKNOWN
+        )
+        assert _requirement(report, dimension, "tool:mutate").status is (
+            BehavioralCoverageStatus.MISSING
+        )
+
+
+def test_global_or_other_metadata_does_not_create_tool_semantics() -> None:
+    other = _scenario(
+        "global-metadata",
+        trajectory=(
+            _trajectory(TrajectoryConstraintKind.OTHER, "delete_user"),
+        ),
+        outputs=(_output(OutputCriterionKind.NO_FABRICATED_SUCCESS),),
+    )
+
+    report = analyze_behavioral_coverage(_spec(), (other,))
+
+    assert _family(report, BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE).applicable == 0
+    assert _family(report, BehavioralDimension.DUPLICATE_ACTION).applicable == 0
+
+
+@pytest.mark.parametrize(
+    ("status", "dimension"),
+    (
+        (SimulatedToolStatus.ERROR, BehavioralDimension.FAILURE_HANDLING),
+        (SimulatedToolStatus.TIMEOUT, BehavioralDimension.TIMEOUT_HANDLING),
+    ),
+)
+@pytest.mark.parametrize("multiple_tools", (False, True))
+def test_unrelated_state_postcondition_is_not_a_failure_handling_oracle(
+    status: SimulatedToolStatus,
+    dimension: BehavioralDimension,
+    multiple_tools: bool,
+) -> None:
+    focal = _tool("act")
+    other = _tool("observe")
+    fixtures = [
+        _fixture("act", status, error_code="controlled"),
+    ]
+    required = [_required("act")]
+    declared_tools = [(focal, True)]
+    if multiple_tools:
+        fixtures.append(
+            _fixture(
+                "observe",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="observe-success",
+            )
+        )
+        required.append(_required("observe", criterion_id="require-observe"))
+        declared_tools.append((other, True))
+    scenario = _scenario(
+        f"unrelated-state-{status.value}-{multiple_tools}",
+        fixtures=tuple(fixtures),
+        required=tuple(required),
+        postconditions=(
+            StatePostcondition(
+                criterion_id="unrelated-state",
+                path="records.one.status",
+                operator=PostconditionOperator.UNCHANGED,
+                oracle_ids=(ORACLE_ID,),
+            ),
+        ),
+    )
+
+    report = analyze_behavioral_coverage(_spec(*declared_tools), (scenario,))
+    requirement = _requirement(report, dimension, "tool:act")
+    assert requirement.status is BehavioralCoverageStatus.PARTIAL
+    assert requirement.reason_code.endswith("without_handling_oracle")
+
+
+def test_fabricated_success_requires_failure_stimulus_and_configured_terms() -> None:
+    tool = _tool("mutate", state_changing=True)
+    fixtures = (
+        _fixture("mutate", SimulatedToolStatus.ERROR, error_code="failed"),
+    )
+    required = (_required("mutate"),)
+    unconfigured = _scenario(
+        "unconfigured",
+        fixtures=fixtures,
+        required=required,
+        outputs=(_output(OutputCriterionKind.NO_FABRICATED_SUCCESS),),
+    )
+    configured = _scenario(
+        "configured",
+        fixtures=fixtures,
+        required=required,
+        outputs=(
+            _output(
+                OutputCriterionKind.NO_FABRICATED_SUCCESS,
+                parameters={"success_terms": ["completed", "succeeded"]},
+            ),
+        ),
+        seed=2,
+    )
+
+    partial = analyze_behavioral_coverage(_spec((tool, True)), (unconfigured,))
+    covered = analyze_behavioral_coverage(_spec((tool, True)), (configured,))
+
+    partial_requirement = _requirement(
+        partial,
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+        "tool:mutate",
+    )
+    assert partial_requirement.status is BehavioralCoverageStatus.PARTIAL
+    assert partial_requirement.reason_code == "fabrication_terms_unconfigured"
+    assert _requirement(
+        covered,
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+        "tool:mutate",
+    ).status is BehavioralCoverageStatus.COVERED
+
+
+def test_duplicate_ambiguous_and_retry_need_prohibited_attempt_fixtures() -> None:
+    tool = _tool("destroy", state_changing=True, destructive=True)
+    spec = _spec((tool, True))
+    one = (_fixture("destroy", SimulatedToolStatus.SUCCESS, invocation_index=1),)
+    two = (
+        *one,
+        _fixture(
+            "destroy",
+            SimulatedToolStatus.SUCCESS,
+            fixture_id="fixture-2",
+            invocation_index=2,
+        ),
+    )
+    duplicate_partial = _scenario(
+        "duplicate-partial",
+        fixtures=one,
+        required=(_required("destroy"),),
+        trajectory=(_trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "destroy"),),
+    )
+    duplicate_covered = _scenario(
+        "duplicate-covered",
+        fixtures=two,
+        required=(_required("destroy"),),
+        trajectory=(_trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "destroy"),),
+        seed=2,
+    )
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (duplicate_partial,)),
+        BehavioralDimension.DUPLICATE_ACTION,
+        "tool:destroy",
+    ).status is BehavioralCoverageStatus.PARTIAL
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (duplicate_covered,)),
+        BehavioralDimension.DUPLICATE_ACTION,
+        "tool:destroy",
+    ).status is BehavioralCoverageStatus.COVERED
+
+    ambiguous_one = _scenario(
+        "ambiguous-one",
+        fixtures=(
+            _fixture(
+                "destroy",
+                SimulatedToolStatus.TIMEOUT,
+                invocation_index=1,
+                error_code="ambiguous_timeout",
+            ),
+        ),
+        required=(_required("destroy"),),
+        trajectory=(
+            _trajectory(
+                TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT,
+                "destroy",
+            ),
+        ),
+        seed=3,
+    )
+    ambiguous_two = ambiguous_one.model_copy(
+        update={
+            "scenario_id": "ambiguous-two",
+            "tool_fixtures": (
+                *ambiguous_one.tool_fixtures,
+                _fixture(
+                    "destroy",
+                    SimulatedToolStatus.SUCCESS,
+                    fixture_id="after-ambiguous",
+                    invocation_index=2,
+                ),
+            ),
+            "generation_seed": 4,
+            "fingerprint": "",
+        }
+    )
+    ambiguous_two = Scenario.model_validate(ambiguous_two.model_dump())
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (ambiguous_one,)),
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        "tool:destroy",
+    ).status is BehavioralCoverageStatus.PARTIAL
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (ambiguous_two,)),
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        "tool:destroy",
+    ).status is BehavioralCoverageStatus.COVERED
+
+    retry_two = _scenario(
+        "retry-two",
+        fixtures=two,
+        required=(_required("destroy"),),
+        trajectory=(
+            _trajectory(
+                TrajectoryConstraintKind.MAX_RETRIES,
+                "destroy",
+                extra={"max_retries": 1},
+            ),
+        ),
+        seed=5,
+    )
+    retry_three = _scenario(
+        "retry-three",
+        fixtures=(
+            *two,
+            _fixture(
+                "destroy",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="fixture-3",
+                invocation_index=3,
+            ),
+        ),
+        required=(_required("destroy"),),
+        trajectory=retry_two.trajectory_constraints,
+        seed=6,
+    )
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (retry_two,)),
+        BehavioralDimension.RETRY_CONTROL,
+        "tool:destroy",
+    ).status is BehavioralCoverageStatus.PARTIAL
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (retry_three,)),
+        BehavioralDimension.RETRY_CONTROL,
+        "tool:destroy",
+    ).status is BehavioralCoverageStatus.COVERED
+
+
+def test_confirmation_paths_are_distinct() -> None:
+    tool = _tool("change", state_changing=True)
+    policy = ToolPolicy(
+        policy_id="confirmation",
+        tool_name="change",
+        description="Require explicit confirmation.",
+        confirmation_required=True,
+    )
+    spec = _spec((tool, True), policies=((policy, True),))
+    without = _scenario(
+        "without-consent",
+        fixtures=(_fixture("change", SimulatedToolStatus.SUCCESS),),
+        forbidden=(_forbidden("change", confirmation=True),),
+    )
+    with_consent = _scenario(
+        "with-consent",
+        fixtures=(_fixture("change", SimulatedToolStatus.SUCCESS),),
+        required=(_required("change", confirmation=True),),
+        confirmed=True,
+        seed=2,
+    )
+    report = analyze_behavioral_coverage(spec, (with_consent, without))
+
+    assert _requirement(
+        report,
+        BehavioralDimension.CONFIRMATION_WITHOUT_CONSENT,
+        "tool:change",
+    ).status is BehavioralCoverageStatus.COVERED
+    assert _requirement(
+        report,
+        BehavioralDimension.CONFIRMATION_WITH_CONSENT,
+        "tool:change",
+    ).status is BehavioralCoverageStatus.COVERED
+
+
+def test_prerequisite_coverage_stays_conservative_until_order_is_observable() -> None:
+    focal = _tool("act", state_changing=True)
+    prerequisite = _tool("lookup")
+    spec = _spec((focal, True), (prerequisite, True))
+    success = _scenario(
+        "prerequisite-success",
+        fixtures=(
+            _fixture(
+                "lookup",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="prerequisite-lookup",
+            ),
+            _fixture("act", SimulatedToolStatus.SUCCESS, fixture_id="focal"),
+        ),
+        required=(
+            _required("lookup", criterion_id="require-lookup"),
+            _required("act", criterion_id="require-act"),
+        ),
+        dimension_tags=("source:positive_path", "tool:act"),
+    )
+    failure_vacuous = _scenario(
+        "prerequisite-failure-vacuous",
+        fixtures=(
+            _fixture(
+                "lookup",
+                SimulatedToolStatus.ERROR,
+                fixture_id="prerequisite-lookup-error",
+                error_code="missing",
+            ),
+            _fixture("act", SimulatedToolStatus.SUCCESS, fixture_id="focal"),
+        ),
+        forbidden=(_forbidden("act"),),
+        dimension_tags=("source:behavioral_outcome", "tool:act"),
+        seed=2,
+    )
+    failure_asserted = _scenario(
+        "prerequisite-failure-asserted",
+        fixtures=failure_vacuous.tool_fixtures,
+        required=(_required("lookup", criterion_id="require-failing-lookup"),),
+        forbidden=(_forbidden("act"),),
+        dimension_tags=("source:behavioral_outcome", "tool:act"),
+        seed=3,
+    )
+    subject = "prerequisite:lookup->tool:act"
+
+    success_report = analyze_behavioral_coverage(spec, (success,))
+    success_requirement = _requirement(
+        success_report, BehavioralDimension.PREREQUISITE_SUCCESS, subject
+    )
+    assert success_requirement.status is BehavioralCoverageStatus.PARTIAL
+    assert success_requirement.reason_code == "calls_asserted_but_order_unobservable"
+    ordering = _requirement(success_report, BehavioralDimension.ORDERING, subject)
+    assert ordering.status is BehavioralCoverageStatus.UNSUPPORTED
+    assert "scenario:prerequisite-success" in ordering.evidence
+    assert "fixture:prerequisite-lookup" in ordering.evidence
+
+    vacuous_report = analyze_behavioral_coverage(spec, (failure_vacuous,))
+    assert _requirement(
+        vacuous_report, BehavioralDimension.PREREQUISITE_FAILURE, subject
+    ).status is BehavioralCoverageStatus.PARTIAL
+    asserted_report = analyze_behavioral_coverage(spec, (failure_asserted,))
+    assert _requirement(
+        asserted_report, BehavioralDimension.PREREQUISITE_FAILURE, subject
+    ).status is BehavioralCoverageStatus.COVERED
+
+
+def test_arbitrary_ordering_is_explicitly_unsupported() -> None:
+    tool = _tool("act")
+    scenario = _scenario(
+        "ordering",
+        trajectory=(_trajectory(TrajectoryConstraintKind.ORDERING, "act"),),
+    )
+    report = analyze_behavioral_coverage(_spec((tool, True)), (scenario,))
+
+    requirement = _requirement(report, BehavioralDimension.ORDERING, "tool:act")
+    assert requirement.status is BehavioralCoverageStatus.UNSUPPORTED
+    assert _family(report, BehavioralDimension.ORDERING).applicable == 0
+
+
+def test_reference_pool_preserves_denominator_and_must_contain_actual_sources() -> None:
+    tool = _tool("act")
+    spec = _spec((tool, True))
+    selected = _scenario(
+        "selected-success",
+        fixtures=(_fixture("act", SimulatedToolStatus.SUCCESS),),
+        required=(_required("act"),),
+    )
+    excluded = _scenario(
+        "excluded-duplicate",
+        fixtures=(
+            _fixture("act", SimulatedToolStatus.SUCCESS, invocation_index=1),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(
+            _trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "act"),
+        ),
+        seed=2,
+    )
+
+    selected_report = analyze_behavioral_coverage(
+        spec,
+        (selected,),
+        reference_scenarios=(excluded, selected),
+    )
+    duplicate = _requirement(
+        selected_report, BehavioralDimension.DUPLICATE_ACTION, "tool:act"
+    )
+    assert duplicate.status is BehavioralCoverageStatus.MISSING
+    assert selected_report.scenario_count == 1
+    assert not _family(
+        analyze_behavioral_coverage(spec, (selected,)),
+        BehavioralDimension.DUPLICATE_ACTION,
+    ).requirements
+
+    with pytest.raises(ValueError, match="must be contained"):
+        analyze_behavioral_coverage(
+            spec,
+            (selected,),
+            reference_scenarios=(excluded,),
+        )
+    with pytest.raises(ValueError, match="must be contained"):
+        analyze_behavioral_coverage(
+            spec,
+            (selected, selected),
+            reference_scenarios=(selected,),
+        )
+
+
+def test_source_binding_and_content_integrity_fail_closed() -> None:
+    tool = _tool("act")
+    spec = _spec((tool, True))
+    scenario = _scenario(
+        "bound",
+        fixtures=(_fixture("act", SimulatedToolStatus.SUCCESS),),
+        required=(_required("act"),),
+    )
+    report = analyze_behavioral_coverage(
+        spec, (scenario,), suite_fingerprint="sha256:suite"
+    )
+
+    verify_behavioral_coverage_binding(report, spec, (scenario,))
+    verify_behavioral_coverage_binding(
+        report, spec, (scenario,), suite_fingerprint="sha256:suite"
+    )
+    with pytest.raises(ValueError, match="suite_fingerprint"):
+        verify_behavioral_coverage_binding(
+            report, spec, (scenario,), suite_fingerprint=None
+        )
+    with pytest.raises(ValueError, match="suite_fingerprint"):
+        verify_behavioral_coverage_binding(
+            report, spec, (scenario,), suite_fingerprint="sha256:wrong"
+        )
+    with pytest.raises(ValueError, match="spec_id"):
+        verify_behavioral_coverage_binding(
+            report, spec.model_copy(update={"spec_id": "other"}), (scenario,)
+        )
+    with pytest.raises(ValueError, match="scenario_count"):
+        verify_behavioral_coverage_binding(report, spec, ())
+
+    relabelled = scenario.model_copy(
+        update={"scenario_id": "renamed", "title": "Renamed display identity"}
+    )
+    assert relabelled.fingerprint == scenario.fingerprint
+    with pytest.raises(ValueError, match="scenario_digest"):
+        verify_behavioral_coverage_binding(report, spec, (relabelled,))
+
+    corrupt_memory = report.model_copy(update={"scenario_count": 99})
+    with pytest.raises(ValueError, match="fingerprint"):
+        verify_behavioral_coverage_binding(corrupt_memory, spec, (scenario,))
+
+    payload = report.model_dump(mode="json")
+    success_family = next(
+        family
+        for family in payload["families"]
+        if family["dimension"] == BehavioralDimension.SUCCESS_PATH.value
+    )
+    success_family["requirements"][0]["status"] = BehavioralCoverageStatus.PARTIAL.value
+    success_family["covered"] = 0
+    success_family["partial"] = 1
+    with pytest.raises(ValidationError, match="fingerprint does not match"):
+        BehavioralCoverage.model_validate_json(json.dumps(payload))
+
+
+def test_contract_round_trip_ordering_and_strictness_are_deterministic() -> None:
+    alpha = _tool("alpha")
+    beta = _tool("beta")
+    first = _scenario(
+        "first",
+        fixtures=(_fixture("alpha", SimulatedToolStatus.SUCCESS),),
+        required=(_required("alpha"),),
+        seed=1,
+    )
+    second = _scenario(
+        "second",
+        fixtures=(_fixture("beta", SimulatedToolStatus.SUCCESS),),
+        required=(_required("beta"),),
+        seed=2,
+    )
+    forward = analyze_behavioral_coverage(
+        _spec((alpha, True), (beta, True)), (first, second)
+    )
+    reverse = analyze_behavioral_coverage(
+        _spec((beta, True), (alpha, True)), (second, first)
+    )
+
+    assert forward == reverse
+    assert forward.fingerprint == forward.expected_fingerprint()
+    assert BehavioralCoverage.from_json(forward.canonical_json()) == forward
+    payload = forward.model_dump(mode="json")
+    payload["extra"] = True
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        BehavioralCoverage.model_validate(payload)
+
+
+def test_analysis_never_invokes_gateway_or_mutates_scenario_or_frozen_suite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = _tool("mutate", state_changing=True)
+    spec = _spec((tool, True))
+    scenario = _scenario(
+        "integrity",
+        fixtures=(
+            _fixture(
+                "mutate",
+                SimulatedToolStatus.SUCCESS,
+                state_effects=(
+                    WorldStateEffect(
+                        path="records.one.status",
+                        before="unchanged",
+                        after="changed",
+                    ),
+                ),
+            ),
+        ),
+        required=(_required("mutate"),),
+    )
+    suite = FrozenSuite(
+        spec_id=spec.spec_id,
+        seed=17,
+        provenance=GeneratorProvenance(
+            generator="coverage-test",
+            generator_version="1",
+            sources=("tests/target.py",),
+        ),
+        coverage=SuiteCoverage(tools=("mutate",)),
+        cases=(
+            FrozenCase(
+                scenario=scenario,
+                lineage=CaseLineage(origin=CaseOrigin.BUILT_IN),
+            ),
+        ),
+    )
+    scenario_json = scenario.model_dump_json()
+    scenario_fingerprint = scenario.fingerprint
+    suite_json = suite.model_dump_json()
+    suite_fingerprint = suite.fingerprint
+    world = deepcopy(scenario.initial_world_state)
+
+    def explode(*args: object, **kwargs: object) -> None:
+        raise AssertionError("coverage analysis must not invoke the gateway")
+
+    monkeypatch.setattr(ToolGateway, "invoke", explode)
+    analyze_behavioral_coverage(
+        spec,
+        suite.scenarios,
+        suite_fingerprint=suite.fingerprint,
+    )
+
+    assert scenario.model_dump_json() == scenario_json
+    assert scenario.fingerprint == scenario_fingerprint
+    assert scenario.initial_world_state == world
+    assert suite.model_dump_json() == suite_json
+    assert suite.fingerprint == suite_fingerprint
+    assert suite.expected_fingerprint() == suite_fingerprint
+
+
+def test_high_cardinality_details_are_globally_bounded_and_redaction_safe() -> None:
+    many_tools = tuple((_tool(f"tool-{index:02d}"), True) for index in range(30))
+    missing_report = analyze_behavioral_coverage(_spec(*many_tools), ())
+    success = _family(missing_report, BehavioralDimension.SUCCESS_PATH)
+    assert success.missing == 30
+    assert len(success.requirements) == MAX_COVERAGE_DETAILS
+    assert success.omitted == 30 - MAX_COVERAGE_DETAILS
+
+    tool = _tool("observed")
+    scenarios = tuple(
+        _scenario(
+            f"evidence-{index:02d}",
+            fixtures=(
+                _fixture(
+                    "observed",
+                    SimulatedToolStatus.SUCCESS,
+                    fixture_id=f"fixture-{index:02d}",
+                ),
+            ),
+            required=(
+                _required("observed", criterion_id=f"required-{index:02d}"),
+            ),
+            seed=index,
+        )
+        for index in range(30)
+    )
+    evidence_report = analyze_behavioral_coverage(_spec((tool, True)), scenarios)
+    requirement = _requirement(
+        evidence_report, BehavioralDimension.SUCCESS_PATH, "tool:observed"
+    )
+    assert len(requirement.evidence) == MAX_COVERAGE_DETAILS
+    assert requirement.omitted_evidence > 0
+    assert all(
+        len(family.requirements) <= MAX_COVERAGE_DETAILS
+        for family in evidence_report.families
+    )
+    assert all(
+        len(item.evidence) <= MAX_COVERAGE_DETAILS
+        for family in evidence_report.families
+        for item in family.requirements
+    )
+
+    redacted = redact_artifact(evidence_report)
+    encoded = json.dumps(redacted, sort_keys=True)
+    assert "[TRUNCATED" not in encoded
+    assert len(encoded.encode("utf-8")) < 8 * 1024 * 1024
+    assert BehavioralCoverage.model_validate_json(encoded) == evidence_report
+
+
+def _stored_coverage_round_trip(
+    tmp_path: Path,
+    report: BehavioralCoverage,
+    *,
+    run_id: str,
+) -> tuple[BehavioralCoverage, str]:
+    path = ArtifactStore(tmp_path, ".agentcheck", run_id).write_json(
+        "coverage.json", report
+    )
+    encoded = path.read_text(encoding="utf-8")
+    return BehavioralCoverage.model_validate_json(encoded), encoded
+
+
+def test_secret_spec_id_remains_verifiable_after_safe_normalization() -> None:
+    spec = _spec((_tool("read"), True), spec_id="sk-secretvalue123")
+    report = analyze_behavioral_coverage(spec, ())
+
+    verify_behavioral_coverage_binding(report, spec, ())
+    assert "secretvalue123" not in report.canonical_json()
+
+
+def test_redacted_subject_collisions_are_omitted_and_round_trip(
+    tmp_path: Path,
+) -> None:
+    first = _tool("sk-secretvalue123")
+    second = _tool("sk-differentsecret456")
+
+    report = analyze_behavioral_coverage(
+        _spec((first, True), (second, True)),
+        (),
+    )
+    success = _family(report, BehavioralDimension.SUCCESS_PATH)
+
+    assert success.unknown == 2
+    assert success.requirements == ()
+    assert success.omitted == 2
+    restored, encoded = _stored_coverage_round_trip(
+        tmp_path, report, run_id="subject-collision"
+    )
+    assert restored == report
+    assert "secretvalue123" not in encoded
+    assert "differentsecret456" not in encoded
+
+
+def test_redacted_evidence_collisions_are_counted_and_round_trip(
+    tmp_path: Path,
+) -> None:
+    tool = _tool("read")
+    scenarios = (
+        _scenario(
+            "sk-secretvalue123",
+            fixtures=(
+                _fixture(
+                    "read",
+                    SimulatedToolStatus.SUCCESS,
+                    fixture_id="sk-secretvalue123",
+                ),
+            ),
+            required=(_required("read", criterion_id="required-first"),),
+        ),
+        _scenario(
+            "sk-differentsecret456",
+            fixtures=(
+                _fixture(
+                    "read",
+                    SimulatedToolStatus.SUCCESS,
+                    fixture_id="sk-differentsecret456",
+                ),
+            ),
+            required=(_required("read", criterion_id="required-second"),),
+            seed=2,
+        ),
+    )
+
+    report = analyze_behavioral_coverage(_spec((tool, True)), scenarios)
+    requirement = _requirement(
+        report, BehavioralDimension.SUCCESS_PATH, "tool:read"
+    )
+    assert requirement.omitted_evidence > 0
+    restored, encoded = _stored_coverage_round_trip(
+        tmp_path, report, run_id="evidence-collision"
+    )
+    assert restored == report
+    assert "secretvalue123" not in encoded
+    assert "differentsecret456" not in encoded
+
+
+def test_spec_digest_rejects_changed_authoritativeness_and_schema() -> None:
+    original_tool = _tool(
+        "act",
+        input_schema={
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        },
+    )
+    spec = _spec((original_tool, True))
+    report = analyze_behavioral_coverage(spec, ())
+
+    with pytest.raises(ValueError, match="spec_digest"):
+        verify_behavioral_coverage_binding(
+            report,
+            _spec((original_tool, False)),
+            (),
+        )
+
+    changed_schema = original_tool.model_copy(
+        update={
+            "input_schema": {
+                "type": "object",
+                "properties": {"id": {"type": "integer"}},
+                "required": ["id"],
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="spec_digest"):
+        verify_behavioral_coverage_binding(
+            report,
+            _spec((changed_schema, True)),
+            (),
+        )
+
+
+def test_user_truncation_marker_cannot_collide_in_spec_binding() -> None:
+    original_tool = _tool(
+        "act",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "[TRUNCATED_ITEMS]": {"type": "string"},
+                "x": {"type": "string"},
+            },
+            "required": ["x"],
+            "additionalProperties": False,
+        },
+    )
+    changed_tool = original_tool.model_copy(
+        update={
+            "input_schema": {
+                **original_tool.input_schema,
+                "properties": {
+                    "[TRUNCATED_ITEMS]": {"type": "string"},
+                    "x": {"type": "integer"},
+                },
+            }
+        }
+    )
+    scenario = _scenario(
+        "marker-property",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                arguments_match={"x": "ok"},
+            ),
+        ),
+        required=(_required("act", arguments_match={"x": "ok"}),),
+    )
+
+    report = analyze_behavioral_coverage(
+        _spec((original_tool, True)), (scenario,)
+    )
+    assert _family(report, BehavioralDimension.SUCCESS_PATH).covered == 1
+    with pytest.raises(ValueError, match="spec_digest|derived_coverage"):
+        verify_behavioral_coverage_binding(
+            report,
+            _spec((changed_tool, True)),
+            (scenario,),
+        )
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "input_schema", "arguments"),
+    (
+        ("sk-secretvalue123", {"type": "object"}, {}),
+        (
+            "act",
+            {
+                "type": "object",
+                "properties": {"sk-secretvalue123": {"type": "string"}},
+                "required": ["sk-secretvalue123"],
+            },
+            {"sk-secretvalue123": "value"},
+        ),
+    ),
+)
+def test_redaction_lossy_tool_bindings_are_unknown(
+    tool_name: str,
+    input_schema: dict[str, Any],
+    arguments: dict[str, Any],
+) -> None:
+    tool = _tool(tool_name, input_schema=input_schema)
+    scenario = _scenario(
+        "lossy-binding",
+        fixtures=(
+            _fixture(
+                tool_name,
+                SimulatedToolStatus.SUCCESS,
+                arguments_match=arguments,
+            ),
+        ),
+        required=(_required(tool_name, arguments_match=arguments),),
+    )
+
+    report = analyze_behavioral_coverage(_spec((tool, True)), (scenario,))
+    success = _family(report, BehavioralDimension.SUCCESS_PATH)
+    assert success.covered == 0
+    assert success.unknown == 1
+    verify_behavioral_coverage_binding(report, _spec((tool, True)), (scenario,))
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "input_schema"),
+    (
+        ("sk-secretvalue123", {"type": "object"}),
+        (
+            "act",
+            {
+                "type": "object",
+                "properties": {"sk-secretvalue123": {"type": "string"}},
+                "required": ["sk-secretvalue123"],
+            },
+        ),
+    ),
+)
+def test_redaction_lossy_tool_binding_survives_spec_and_coverage_artifact_round_trip(
+    tmp_path: Path,
+    tool_name: str,
+    input_schema: dict[str, Any],
+) -> None:
+    spec = _spec((_tool(tool_name, input_schema=input_schema), True))
+    report = analyze_behavioral_coverage(spec, ())
+    path = ArtifactStore(tmp_path, ".agentcheck", "lossy-binding").write_json(
+        "binding.json",
+        {"spec": spec, "coverage": report},
+    )
+    encoded = path.read_text(encoding="utf-8")
+    assert "secretvalue123" not in encoded
+    payload = json.loads(encoded)
+    stored_spec = AgentSpec.model_validate_json(json.dumps(payload["spec"]))
+    stored_report = BehavioralCoverage.model_validate_json(
+        json.dumps(payload["coverage"])
+    )
+
+    verify_behavioral_coverage_binding(stored_report, stored_spec, ())
+    success = _family(stored_report, BehavioralDimension.SUCCESS_PATH)
+    assert success.covered == 0
+    assert success.unknown == 1
+
+
+@pytest.mark.parametrize(
+    "schema_kind",
+    ("long-leaf", "deep-schema"),
+)
+def test_truncated_tool_schema_survives_spec_and_coverage_artifact_round_trip(
+    tmp_path: Path,
+    schema_kind: str,
+) -> None:
+    if schema_kind == "long-leaf":
+        input_schema: dict[str, Any] = {
+            "type": "object",
+            "description": "x" * 9_000,
+        }
+        expected_marker = "...[TRUNCATED]"
+    else:
+        nested: dict[str, Any] = {"type": "string"}
+        for _ in range(24):
+            nested = {"nested": nested}
+        input_schema = {"type": "object", "properties": nested}
+        expected_marker = "[MAX_DEPTH]"
+
+    spec = _spec((_tool("act", input_schema=input_schema), True))
+    report = analyze_behavioral_coverage(spec, ())
+    success = _family(report, BehavioralDimension.SUCCESS_PATH)
+    assert success.covered == 0
+    assert success.unknown == 1
+    path = ArtifactStore(
+        tmp_path,
+        ".agentcheck",
+        f"lossy-{schema_kind}",
+    ).write_json(
+        "binding.json",
+        {"spec": spec, "coverage": report},
+    )
+    encoded = path.read_text(encoding="utf-8")
+    assert expected_marker in encoded
+    payload = json.loads(encoded)
+    stored_spec = AgentSpec.model_validate_json(json.dumps(payload["spec"]))
+    stored_report = BehavioralCoverage.model_validate_json(
+        json.dumps(payload["coverage"])
+    )
+
+    assert stored_report == report
+    verify_behavioral_coverage_binding(stored_report, stored_spec, ())
+    restored_success = _family(stored_report, BehavioralDimension.SUCCESS_PATH)
+    assert restored_success.covered == 0
+    assert restored_success.unknown == 1
+
+
+def test_wide_schema_spec_and_coverage_survive_artifact_round_trip(
+    tmp_path: Path,
+) -> None:
+    properties = {
+        f"field_{index:03d}": {"type": "string"} for index in range(120)
+    }
+    spec = _spec(
+        (
+            _tool(
+                "wide",
+                input_schema={"type": "object", "properties": properties},
+            ),
+            True,
+        )
+    )
+    report = analyze_behavioral_coverage(spec, ())
+    path = ArtifactStore(tmp_path, ".agentcheck", "wide-schema").write_json(
+        "binding.json",
+        {"spec": spec, "coverage": report},
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    stored_spec = AgentSpec.model_validate_json(
+        json.dumps(payload["spec"])
+    )
+    stored_report = BehavioralCoverage.model_validate_json(
+        json.dumps(payload["coverage"])
+    )
+
+    verify_behavioral_coverage_binding(stored_report, stored_spec, ())
+
+
+def test_reference_universe_is_bound_and_verifiable() -> None:
+    tool = _tool("act")
+    spec = _spec((tool, True))
+    selected = _scenario(
+        "selected",
+        fixtures=(_fixture("act", SimulatedToolStatus.SUCCESS),),
+        required=(_required("act"),),
+    )
+    excluded = _scenario(
+        "excluded",
+        fixtures=(
+            _fixture("act", SimulatedToolStatus.SUCCESS, invocation_index=1),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(
+            _trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "act"),
+        ),
+        seed=2,
+    )
+    other_reference = _scenario(
+        "other-reference",
+        fixtures=(_fixture("act", SimulatedToolStatus.ERROR, error_code="failed"),),
+        required=(_required("act"),),
+        seed=3,
+    )
+
+    report = analyze_behavioral_coverage(
+        spec,
+        (selected,),
+        reference_scenarios=(selected, excluded),
+    )
+    assert report.reference_scope is BehavioralCoverageReferenceScope.COMPLETE
+    assert report.scenario_count == 1
+    assert report.reference_scenario_count == 2
+    assert report.reference_scenario_digest != report.scenario_digest
+    verify_behavioral_coverage_binding(
+        report,
+        spec,
+        (selected,),
+        reference_scenarios=(excluded, selected),
+    )
+    with pytest.raises(ValueError, match="reference"):
+        verify_behavioral_coverage_binding(
+            report,
+            spec,
+            (selected,),
+            reference_scenarios=(selected, other_reference),
+        )
+    with pytest.raises(ValueError, match="reference"):
+        verify_behavioral_coverage_binding(
+            report,
+            spec,
+            (selected,),
+            reference_scenarios=(excluded,),
+        )
+
+
+def test_reference_scope_contract_rejects_impossible_bindings() -> None:
+    scenario = _scenario("one")
+    report = analyze_behavioral_coverage(_spec(), (scenario,))
+    payload = report.model_dump(mode="json")
+    payload["fingerprint"] = ""
+    payload["reference_scenario_digest"] = "sha256:different"
+    with pytest.raises(ValidationError, match="reference.*digest"):
+        BehavioralCoverage.model_validate_json(json.dumps(payload))
+
+    payload = report.model_dump(mode="json")
+    payload["fingerprint"] = ""
+    payload["reference_scope"] = (
+        BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY.value
+    )
+    payload["reference_scenario_count"] = 2
+    with pytest.raises(ValidationError, match="reference.*count"):
+        BehavioralCoverage.model_validate_json(json.dumps(payload))
+
+
+def test_reference_subset_validation_preserves_multiplicity() -> None:
+    scenario = _scenario("repeated")
+    report = analyze_behavioral_coverage(
+        _spec(),
+        (scenario, scenario),
+        reference_scenarios=(scenario, scenario, scenario),
+    )
+    verify_behavioral_coverage_binding(
+        report,
+        _spec(),
+        (scenario, scenario),
+        reference_scenarios=(scenario, scenario, scenario),
+    )
+    with pytest.raises(ValueError, match="reference"):
+        verify_behavioral_coverage_binding(
+            report,
+            _spec(),
+            (scenario, scenario),
+            reference_scenarios=(scenario,),
+        )
+
+
+def test_generated_cases_do_not_launder_nonauthoritative_risk_metadata() -> None:
+    tool = _tool(
+        "mutate",
+        state_changing=True,
+        destructive=True,
+        input_schema={
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+            "additionalProperties": False,
+        },
+    )
+    authoritative_spec = _spec((tool, True))
+    scenarios = build_outcome_variant_cases(
+        authoritative_spec,
+        seed=7,
+        representative_inputs={"mutate": {"id": "one"}},
+    )
+    spec = _spec((tool, False))
+
+    assert scenarios
+    report = analyze_behavioral_coverage(spec, scenarios)
+    for dimension in (
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+        BehavioralDimension.DUPLICATE_ACTION,
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        BehavioralDimension.RETRY_CONTROL,
+    ):
+        assert _requirement(report, dimension, "tool:mutate").status is (
+            BehavioralCoverageStatus.UNKNOWN
+        )
+
+
+def test_confirmation_wrong_polarity_never_counts_as_covered() -> None:
+    tool = _tool("change", state_changing=True)
+    policy = ToolPolicy(
+        policy_id="confirmation",
+        tool_name="change",
+        description="Require explicit confirmation.",
+        confirmation_required=True,
+    )
+    spec = _spec((tool, True), policies=((policy, True),))
+    confirmed_but_forbidden = _scenario(
+        "confirmed-but-forbidden",
+        fixtures=(_fixture("change", SimulatedToolStatus.SUCCESS),),
+        forbidden=(_forbidden("change", confirmation=True),),
+        confirmed=True,
+    )
+    unconfirmed_but_required = _scenario(
+        "unconfirmed-but-required",
+        fixtures=(_fixture("change", SimulatedToolStatus.SUCCESS),),
+        required=(_required("change", confirmation=True),),
+        seed=2,
+    )
+
+    report = analyze_behavioral_coverage(
+        spec, (confirmed_but_forbidden, unconfirmed_but_required)
+    )
+    assert _requirement(
+        report,
+        BehavioralDimension.CONFIRMATION_WITH_CONSENT,
+        "tool:change",
+    ).status is not BehavioralCoverageStatus.COVERED
+    assert _requirement(
+        report,
+        BehavioralDimension.CONFIRMATION_WITHOUT_CONSENT,
+        "tool:change",
+    ).status is not BehavioralCoverageStatus.COVERED
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "action_arguments", "fixture_arguments"),
+    (
+        ("fixture-mismatch", {"id": "expected"}, {"id": "other"}),
+        ("schema-invalid", {"id": 1}, {"id": 1}),
+    ),
+)
+def test_success_requires_schema_valid_matching_selected_fixture(
+    scenario_id: str,
+    action_arguments: dict[str, Any],
+    fixture_arguments: dict[str, Any],
+) -> None:
+    tool = _tool(
+        "act",
+        input_schema={
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+            "additionalProperties": False,
+        },
+    )
+    scenario = _scenario(
+        scenario_id,
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                arguments_match=fixture_arguments,
+            ),
+        ),
+        required=(_required("act", arguments_match=action_arguments),),
+    )
+
+    report = analyze_behavioral_coverage(_spec((tool, True)), (scenario,))
+    assert _requirement(
+        report, BehavioralDimension.SUCCESS_PATH, "tool:act"
+    ).status is not BehavioralCoverageStatus.COVERED
+
+
+def test_fixture_priority_ties_and_exact_ambiguity_slot_are_conservative() -> None:
+    tool = _tool("act", state_changing=True, destructive=True)
+    spec = _spec((tool, True))
+    priority = _scenario(
+        "priority",
+        fixtures=(
+            _fixture("act", SimulatedToolStatus.SUCCESS, priority=0),
+            _fixture(
+                "act",
+                SimulatedToolStatus.ERROR,
+                fixture_id="higher",
+                error_code="selected",
+                priority=10,
+            ),
+        ),
+        required=(_required("act"),),
+    )
+    tie = _scenario(
+        "tie",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="tie-one",
+                invocation_index=1,
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="tie-two",
+                invocation_index=1,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(
+            _trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "act"),
+        ),
+        seed=2,
+    )
+    unreachable_ambiguous = _scenario(
+        "unreachable-ambiguous-next",
+        fixtures=(
+            _fixture("act", SimulatedToolStatus.SUCCESS, invocation_index=1),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.TIMEOUT,
+                fixture_id="third-ambiguous",
+                invocation_index=3,
+                error_code="ambiguous_timeout",
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(
+            _trajectory(
+                TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT,
+                "act",
+            ),
+        ),
+        seed=3,
+    )
+    reachable_ambiguous = _scenario(
+        "reachable-ambiguous-next",
+        fixtures=(
+            *unreachable_ambiguous.tool_fixtures,
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="fourth",
+                invocation_index=4,
+            ),
+        ),
+        required=unreachable_ambiguous.required_tool_behavior,
+        trajectory=unreachable_ambiguous.trajectory_constraints,
+        seed=4,
+    )
+
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (priority,)),
+        BehavioralDimension.SUCCESS_PATH,
+        "tool:act",
+    ).status is not BehavioralCoverageStatus.COVERED
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (tie,)),
+        BehavioralDimension.DUPLICATE_ACTION,
+        "tool:act",
+    ).status is BehavioralCoverageStatus.PARTIAL
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (unreachable_ambiguous,)),
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        "tool:act",
+    ).status is BehavioralCoverageStatus.PARTIAL
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (reachable_ambiguous,)),
+        BehavioralDimension.AMBIGUOUS_OUTCOME,
+        "tool:act",
+    ).status is BehavioralCoverageStatus.COVERED
+
+
+def test_state_changing_timeout_normalization_matches_gateway_for_fixture_and_fault() -> None:
+    tool = _tool("act", state_changing=True, destructive=True)
+    spec = _spec((tool, True))
+    constraint = _trajectory(
+        TrajectoryConstraintKind.NO_RETRY_AFTER_AMBIGUOUS_TIMEOUT,
+        "act",
+    )
+    ordinary = _scenario(
+        "ordinary-timeout",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.TIMEOUT,
+                invocation_index=1,
+                error_code="timeout",
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="ordinary-next",
+                invocation_index=2,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(constraint,),
+    )
+    injected = _scenario(
+        "injected-timeout",
+        fixtures=(
+            _fixture("act", SimulatedToolStatus.SUCCESS, invocation_index=1),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="fault-next",
+                invocation_index=2,
+            ),
+        ),
+        injected_faults=(
+            InjectedFault(
+                fault_id="timeout-fault",
+                tool_name="act",
+                fault_type=FaultType.TIMEOUT,
+                invocation_index=1,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(constraint,),
+        seed=2,
+    )
+
+    for scenario in (ordinary, injected):
+        report = analyze_behavioral_coverage(spec, (scenario,))
+        assert _requirement(
+            report,
+            BehavioralDimension.AMBIGUOUS_OUTCOME,
+            "tool:act",
+        ).status is BehavioralCoverageStatus.COVERED
+        assert _requirement(
+            report,
+            BehavioralDimension.RETRY_CONTROL,
+            "tool:act",
+        ).status is BehavioralCoverageStatus.COVERED
+
+
+def test_duplicate_reachability_obeys_tool_budget_latency_and_state_effects() -> None:
+    tool = _tool("act", state_changing=True)
+    spec = _spec((tool, True))
+    trajectory = (
+        _trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "act"),
+    )
+    two = (
+        _fixture("act", SimulatedToolStatus.SUCCESS, invocation_index=1),
+        _fixture(
+            "act",
+            SimulatedToolStatus.SUCCESS,
+            fixture_id="second",
+            invocation_index=2,
+        ),
+    )
+    budget_limited = _scenario(
+        "budget-limited",
+        fixtures=two,
+        required=(_required("act"),),
+        trajectory=trajectory,
+        resource_budgets=ResourceBudgets(max_tool_calls=1),
+    )
+    latency_limited = _scenario(
+        "latency-limited",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                invocation_index=1,
+                latency_ms=600,
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+                latency_ms=600,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=trajectory,
+        resource_budgets=ResourceBudgets(wall_clock_seconds=1),
+        seed=2,
+    )
+    state_effect_limited = _scenario(
+        "state-effect-limited",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                invocation_index=1,
+                state_effects=(
+                    WorldStateEffect(
+                        path="records.one.status",
+                        before="unchanged",
+                        after="changed",
+                    ),
+                ),
+            ),
+            two[1],
+        ),
+        required=(_required("act"),),
+        trajectory=trajectory,
+        seed=3,
+    )
+
+    for scenario in (budget_limited, latency_limited, state_effect_limited):
+        assert _requirement(
+            analyze_behavioral_coverage(spec, (scenario,)),
+            BehavioralDimension.DUPLICATE_ACTION,
+            "tool:act",
+        ).status is BehavioralCoverageStatus.PARTIAL
+
+
+@pytest.mark.parametrize("maximum", (True, "1", -1, None))
+def test_malformed_max_retries_never_counts_as_coverage(maximum: Any) -> None:
+    tool = _tool("act", state_changing=True, destructive=True)
+    scenario = _scenario(
+        f"invalid-retries-{type(maximum).__name__}",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.TIMEOUT,
+                invocation_index=1,
+                error_code="timeout",
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="third",
+                invocation_index=3,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(
+            _trajectory(
+                TrajectoryConstraintKind.MAX_RETRIES,
+                "act",
+                extra={"max_retries": maximum},
+            ),
+        ),
+    )
+    report = analyze_behavioral_coverage(_spec((tool, True)), (scenario,))
+
+    for dimension in (
+        BehavioralDimension.RETRY_CONTROL,
+        BehavioralDimension.TIMEOUT_HANDLING,
+    ):
+        assert _requirement(
+            report, dimension, "tool:act"
+        ).status is not BehavioralCoverageStatus.COVERED
+
+
+@pytest.mark.parametrize(
+    "success_terms",
+    ("succeeded", [""], [1], {"term": "succeeded"}),
+)
+def test_malformed_success_terms_never_count_as_supported_oracle(
+    success_terms: Any,
+) -> None:
+    tool = _tool("act", state_changing=True)
+    scenario = _scenario(
+        f"invalid-success-terms-{type(success_terms).__name__}",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.ERROR,
+                error_code="failed",
+            ),
+        ),
+        required=(_required("act"),),
+        outputs=(
+            _output(
+                OutputCriterionKind.NO_FABRICATED_SUCCESS,
+                parameters={"success_terms": success_terms},
+            ),
+        ),
+    )
+    report = analyze_behavioral_coverage(_spec((tool, True)), (scenario,))
+
+    for dimension in (
+        BehavioralDimension.FAILURE_HANDLING,
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+    ):
+        assert _requirement(
+            report, dimension, "tool:act"
+        ).status is not BehavioralCoverageStatus.COVERED
+
+
+def test_global_oracles_do_not_cover_multiple_focal_tools() -> None:
+    alpha = _tool("alpha", state_changing=True)
+    beta = _tool("beta", state_changing=True)
+    required = (
+        _required("alpha", criterion_id="require-alpha"),
+        _required("beta", criterion_id="require-beta"),
+    )
+    failures = _scenario(
+        "multi-focal-failures",
+        fixtures=(
+            _fixture(
+                "alpha",
+                SimulatedToolStatus.ERROR,
+                fixture_id="alpha-error",
+                error_code="failed",
+            ),
+            _fixture(
+                "beta",
+                SimulatedToolStatus.ERROR,
+                fixture_id="beta-error",
+                error_code="failed",
+            ),
+        ),
+        required=required,
+        outputs=(
+            _output(
+                OutputCriterionKind.ACKNOWLEDGES_TOOL_ERROR,
+                criterion_id="global-ack",
+            ),
+            _output(
+                OutputCriterionKind.NO_FABRICATED_SUCCESS,
+                criterion_id="global-no-fabrication",
+                parameters={"success_terms": ["succeeded"]},
+            ),
+        ),
+    )
+    timeouts = _scenario(
+        "multi-focal-timeouts",
+        fixtures=(
+            _fixture(
+                "alpha",
+                SimulatedToolStatus.TIMEOUT,
+                fixture_id="alpha-timeout",
+                error_code="timeout",
+            ),
+            _fixture(
+                "beta",
+                SimulatedToolStatus.TIMEOUT,
+                fixture_id="beta-timeout",
+                error_code="timeout",
+            ),
+        ),
+        required=required,
+        outputs=(
+            _output(
+                OutputCriterionKind.ACKNOWLEDGES_TOOL_ERROR,
+                criterion_id="global-timeout-ack",
+            ),
+        ),
+        seed=2,
+    )
+    report = analyze_behavioral_coverage(
+        _spec((alpha, True), (beta, True)),
+        (failures, timeouts),
+    )
+
+    for tool_name in ("alpha", "beta"):
+        for dimension in (
+            BehavioralDimension.FAILURE_HANDLING,
+            BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+            BehavioralDimension.TIMEOUT_HANDLING,
+        ):
+            assert _requirement(
+                report, dimension, f"tool:{tool_name}"
+            ).status is not BehavioralCoverageStatus.COVERED
+
+
+def test_prerequisite_fixture_prefix_requires_unambiguous_generator_lineage() -> None:
+    lookup = _tool("lookup")
+    act = _tool("act", state_changing=True)
+    other = _tool("other", state_changing=True)
+    prerequisite_fixture = _fixture(
+        "lookup",
+        SimulatedToolStatus.SUCCESS,
+        fixture_id="prerequisite-lookup",
+    )
+    no_source = _scenario(
+        "no-generator-source",
+        fixtures=(prerequisite_fixture,),
+        required=(
+            _required("lookup", criterion_id="lookup"),
+            _required("act", criterion_id="act"),
+        ),
+    )
+    multi_focal = _scenario(
+        "multi-focal-generator-shape",
+        fixtures=(
+            prerequisite_fixture,
+            _fixture("act", SimulatedToolStatus.SUCCESS, fixture_id="act"),
+            _fixture("other", SimulatedToolStatus.SUCCESS, fixture_id="other"),
+        ),
+        required=(
+            _required("lookup", criterion_id="lookup"),
+            _required("act", criterion_id="act"),
+            _required("other", criterion_id="other"),
+        ),
+        dimension_tags=(
+            "source:positive_path",
+            "tool:act",
+            "tool:other",
+        ),
+        seed=2,
+    )
+    report = analyze_behavioral_coverage(
+        _spec((lookup, True), (act, True), (other, True)),
+        (no_source, multi_focal),
+    )
+
+    for dimension in (
+        BehavioralDimension.PREREQUISITE_SUCCESS,
+        BehavioralDimension.PREREQUISITE_FAILURE,
+    ):
+        assert _family(report, dimension).requirements == ()
+        assert _family(report, dimension).applicable == 0
+
+
+def test_duplicate_declared_tool_names_are_unknown_not_covered() -> None:
+    # ToolGateway refuses to execute an ambiguous declared name. Derived
+    # coverage is report metadata, so it must not abort generation either;
+    # every subject bound to the ambiguous name stays unknown.
+    duplicate = _tool("duplicate", state_changing=True, destructive=True)
+    unique = _tool("unique")
+    spec = _spec((duplicate, True), (duplicate, True), (unique, True))
+
+    report = analyze_behavioral_coverage(spec, ())
+
+    for dimension in BehavioralDimension:
+        family = _family(report, dimension)
+        ambiguous = [
+            item for item in family.requirements if item.subject == "tool:duplicate"
+        ]
+        for item in ambiguous:
+            assert item.status is BehavioralCoverageStatus.UNKNOWN
+            assert item.reason_code == "declared_tool_name_is_ambiguous"
+        assert len(ambiguous) <= 1
+
+    success = _requirement(
+        report, BehavioralDimension.SUCCESS_PATH, "tool:duplicate"
+    )
+    assert success.status is BehavioralCoverageStatus.UNKNOWN
+    # An unambiguous sibling keeps its ordinary applicable requirement.
+    assert (
+        _requirement(report, BehavioralDimension.SUCCESS_PATH, "tool:unique").status
+        is BehavioralCoverageStatus.MISSING
+    )
+    assert _family(report, BehavioralDimension.SUCCESS_PATH).applicable == 1
+
+
+def test_a_simulated_mutation_still_covers_its_own_controlled_outcome() -> None:
+    # A state-changing success fixture is the ordinary shape of a mutating
+    # action. Its own outcome is controlled and observable, so excluding it
+    # would report the most important tools as having no success path at all.
+    tool = _tool("act", state_changing=True)
+    spec = _spec((tool, True))
+    mutation = (
+        WorldStateEffect(path="records.one.status", before="unchanged", after="changed"),
+    )
+    scenario = _scenario(
+        "mutating-success",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                invocation_index=1,
+                state_effects=mutation,
+            ),
+        ),
+        required=(_required("act"),),
+    )
+
+    requirement = _requirement(
+        analyze_behavioral_coverage(spec, (scenario,)),
+        BehavioralDimension.SUCCESS_PATH,
+        "tool:act",
+    )
+
+    assert requirement.status is BehavioralCoverageStatus.COVERED
+    assert requirement.reason_code == "required_success_with_controlled_fixture"
+
+
+def test_a_simulated_mutation_still_bounds_the_next_invocation() -> None:
+    # The mutation makes the following invocation depend on world state this
+    # analysis does not evaluate, so a duplicate attempt remains unproven even
+    # though a second fixture exists.
+    tool = _tool("act", state_changing=True)
+    spec = _spec((tool, True))
+    scenario = _scenario(
+        "mutating-duplicate",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                invocation_index=1,
+                state_effects=(
+                    WorldStateEffect(
+                        path="records.one.status", before="unchanged", after="changed"
+                    ),
+                ),
+            ),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(_trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "act"),),
+    )
+
+    requirement = _requirement(
+        analyze_behavioral_coverage(spec, (scenario,)),
+        BehavioralDimension.DUPLICATE_ACTION,
+        "tool:act",
+    )
+
+    assert requirement.status is BehavioralCoverageStatus.PARTIAL
+    assert requirement.reason_code == "duplicate_oracle_lacks_second_fixture"
+
+
+def _untooled_duplicate_constraint() -> TrajectoryConstraint:
+    return TrajectoryConstraint(
+        criterion_id="untooled-duplicate",
+        kind=TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT,
+        description="A duplicate constraint that declares no tool signature.",
+        parameters={},
+        oracle_ids=(ORACLE_ID,),
+    )
+
+
+def test_scenario_scoped_requirement_never_borrows_another_scenario() -> None:
+    # A constraint without a tool signature yields a scenario-scoped subject.
+    # It must not draw evidence from a different scenario, and a tool-scoped
+    # constraint elsewhere is not evidence that this signature is undeclared.
+    tool = _tool("act", state_changing=True)
+    spec = _spec((tool, True))
+    untooled = _scenario(
+        "untooled",
+        trajectory=(_untooled_duplicate_constraint(),),
+    )
+    tooled = _scenario(
+        "tooled",
+        fixtures=(
+            _fixture("act", SimulatedToolStatus.SUCCESS, invocation_index=1),
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                fixture_id="second",
+                invocation_index=2,
+            ),
+        ),
+        required=(_required("act"),),
+        trajectory=(_trajectory(TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT, "act"),),
+        seed=2,
+    )
+
+    report = analyze_behavioral_coverage(spec, (untooled, tooled))
+    scoped = _requirement(
+        report, BehavioralDimension.DUPLICATE_ACTION, "scenario:untooled"
+    )
+
+    assert scoped.status is BehavioralCoverageStatus.PARTIAL
+    assert scoped.reason_code == "duplicate_oracle_without_declared_tool_signature"
+    assert "scenario:tooled" not in scoped.evidence
+    assert "scenario:untooled" in scoped.evidence
+    # The tool-scoped constraint still belongs to its own tool requirement.
+    assert (
+        _requirement(
+            report, BehavioralDimension.DUPLICATE_ACTION, "tool:act"
+        ).status
+        is BehavioralCoverageStatus.COVERED
+    )
+
+
+def test_scenario_scoped_requirement_excluded_by_selection_is_missing() -> None:
+    # Selection dropped the only scenario that declared this subject, so its
+    # behavior is missing rather than partially covered by a survivor.
+    tool = _tool("act", state_changing=True)
+    spec = _spec((tool, True))
+    untooled = _scenario(
+        "untooled",
+        trajectory=(_untooled_duplicate_constraint(),),
+    )
+    survivor = _scenario(
+        "survivor",
+        trajectory=(
+            TrajectoryConstraint(
+                criterion_id="other-untooled",
+                kind=TrajectoryConstraintKind.NO_DUPLICATE_SIDE_EFFECT,
+                description="Another constraint without a tool signature.",
+                parameters={},
+                oracle_ids=(ORACLE_ID,),
+            ),
+        ),
+        seed=2,
+    )
+
+    report = analyze_behavioral_coverage(
+        spec, (survivor,), reference_scenarios=(survivor, untooled)
+    )
+    scoped = _requirement(
+        report, BehavioralDimension.DUPLICATE_ACTION, "scenario:untooled"
+    )
+
+    assert scoped.status is BehavioralCoverageStatus.MISSING
+    assert scoped.reason_code == "duplicate_action_case_missing"
+    assert scoped.evidence == ()
+
+
+def test_an_unevaluable_input_schema_never_claims_controlled_reach() -> None:
+    # An unresolvable local reference only fails while validating arguments,
+    # not while building the validator. Coverage is derived report metadata,
+    # so it fails closed instead of aborting the run.
+    tool = ToolDefinition(
+        name="act",
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"$ref": "#/$defs/absent"}},
+        },
+        state_changing=True,
+        replaceable=True,
+    )
+    spec = _spec((tool, True))
+    scenario = _scenario(
+        "unevaluable-schema",
+        fixtures=(
+            _fixture(
+                "act",
+                SimulatedToolStatus.SUCCESS,
+                invocation_index=1,
+                arguments_match={"value": "x"},
+            ),
+        ),
+        required=(_required("act", arguments_match={"value": "x"}),),
+    )
+
+    requirement = _requirement(
+        analyze_behavioral_coverage(spec, (scenario,)),
+        BehavioralDimension.SUCCESS_PATH,
+        "tool:act",
+    )
+
+    assert requirement.status is BehavioralCoverageStatus.MISSING
+    assert requirement.reason_code == "success_path_missing"

--- a/tests/agentcheck/test_cli_diagnostics.py
+++ b/tests/agentcheck/test_cli_diagnostics.py
@@ -8,11 +8,30 @@ from types import SimpleNamespace
 import pytest
 
 import agentcheck.cli as cli
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageFamily,
+    BehavioralCoverageReferenceScope,
+    BehavioralCoverageRequirement,
+    BehavioralCoverageStatus,
+    BehavioralDimension,
+)
 from agentcheck.domain import Scenario, Verdict
 from agentcheck.evaluate import infrastructure_evaluation
 from agentcheck.errors import ConfigurationError
 from agentcheck.generate import build_account_support_suite
 from agentcheck.initialize import write_initial_config
+
+
+def _empty_behavioral_coverage() -> BehavioralCoverage:
+    return BehavioralCoverage(
+        spec_id="test-spec",
+        spec_digest="sha256:test-spec",
+        scenario_count=1,
+        scenario_digest="sha256:test-scenarios",
+        reference_scenario_count=1,
+        reference_scenario_digest="sha256:test-scenarios",
+    )
 
 
 def _infra_execution(
@@ -39,6 +58,7 @@ def _infra_execution(
         runs=(),
         findings=(),
         report_path=Path("report.html"),
+        behavioral_coverage=_empty_behavioral_coverage(),
         replay_manifest_path=None,
     )
 
@@ -70,6 +90,7 @@ def _execution_for_verdict(
         runs=(),
         findings=(),
         report_path=Path("report.html"),
+        behavioral_coverage=_empty_behavioral_coverage(),
         replay_manifest_path=None,
     )
 
@@ -107,6 +128,146 @@ def _execute_with_progress(execution: SimpleNamespace):
         return execution
 
     return execute
+
+
+def test_declared_behavioral_coverage_prints_counts_and_exact_open_subjects(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    requirements = tuple(
+        BehavioralCoverageRequirement(
+            subject=subject,
+            status=status,
+            reason_code=f"reason_{status.value}",
+        )
+        for subject, status in (
+            ("tool:covered", BehavioralCoverageStatus.COVERED),
+            ("tool:partial", BehavioralCoverageStatus.PARTIAL),
+            ("tool:missing", BehavioralCoverageStatus.MISSING),
+            ("tool:unknown", BehavioralCoverageStatus.UNKNOWN),
+            ("tool:unsupported", BehavioralCoverageStatus.UNSUPPORTED),
+        )
+    )
+    coverage = BehavioralCoverage(
+        spec_id="test-spec",
+        spec_digest="sha256:test-spec",
+        scenario_count=5,
+        scenario_digest="sha256:test-scenarios",
+        reference_scenario_count=7,
+        reference_scenario_digest="sha256:test-reference-scenarios",
+        families=(
+            BehavioralCoverageFamily(dimension=BehavioralDimension.SUCCESS_PATH),
+            BehavioralCoverageFamily(
+                dimension=BehavioralDimension.FAILURE_HANDLING,
+                covered=1,
+                partial=1,
+                missing=1,
+                unknown=1,
+                unsupported=1,
+                requirements=requirements,
+            ),
+        ),
+    )
+
+    cli._print_declared_behavioral_coverage(coverage)
+
+    output = capsys.readouterr().out
+    assert "Declared behavioral coverage:" in output
+    assert "Evidence scenarios: 5 / 7 reference scenarios" in output
+    assert (
+        "Failure handling: 1 covered / 3 applicable; partial 1; missing 1; "
+        "unknown 1; unsupported 1"
+    ) in output
+    assert "partial: tool:partial [reason_partial]" in output
+    assert "missing: tool:missing [reason_missing]" in output
+    assert "unknown: tool:unknown [reason_unknown]" in output
+    assert "unsupported: tool:unsupported [reason_unsupported]" in output
+    assert "tool:covered" not in output
+    assert "Success path:" not in output
+    assert "%" not in output
+    assert "complete coverage" not in output.casefold()
+
+
+def test_declared_behavioral_coverage_redacts_bounded_requirement_identifiers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    raw_subject_secret = "sk-secretvalue123"
+    secret_subject = f"tool:{raw_subject_secret}"
+    secret_reason = "sk-reasonsecret123"
+    coverage = BehavioralCoverage(
+        spec_id="test-spec",
+        spec_digest="sha256:test-spec",
+        scenario_count=1,
+        scenario_digest="sha256:test-scenarios",
+        reference_scenario_count=1,
+        reference_scenario_digest="sha256:test-scenarios",
+        families=(
+            BehavioralCoverageFamily(
+                dimension=BehavioralDimension.RETRY_CONTROL,
+                unknown=1,
+                requirements=(
+                    BehavioralCoverageRequirement(
+                        subject=secret_subject,
+                        status=BehavioralCoverageStatus.UNKNOWN,
+                        reason_code=secret_reason,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    cli._print_declared_behavioral_coverage(coverage)
+
+    output = capsys.readouterr().out
+    assert secret_subject not in output
+    assert raw_subject_secret not in output
+    assert secret_reason not in output
+    assert "[REDACTED]" in output
+
+
+def test_declared_behavioral_coverage_collapses_all_empty_families(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    coverage = BehavioralCoverage(
+        spec_id="test-spec",
+        spec_digest="sha256:test-spec",
+        scenario_count=0,
+        scenario_digest="sha256:test-scenarios",
+        reference_scenario_count=0,
+        reference_scenario_digest="sha256:test-scenarios",
+        families=(
+            BehavioralCoverageFamily(dimension=BehavioralDimension.SUCCESS_PATH),
+            BehavioralCoverageFamily(dimension=BehavioralDimension.ORDERING),
+        ),
+    )
+
+    cli._print_declared_behavioral_coverage(coverage)
+
+    output = capsys.readouterr().out
+    assert "No declared behavioral requirements were identified." in output
+    assert "Success path:" not in output
+    assert "Ordering:" not in output
+
+
+def test_declared_behavioral_coverage_warns_when_reference_scope_is_incomplete(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    coverage = BehavioralCoverage(
+        spec_id="test-spec",
+        spec_digest="sha256:test-spec",
+        scenario_count=1,
+        scenario_digest="sha256:test-scenarios",
+        reference_scenario_count=1,
+        reference_scenario_digest="sha256:test-scenarios",
+        reference_scope=BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY,
+    )
+
+    cli._print_declared_behavioral_coverage(coverage)
+
+    output = capsys.readouterr().out
+    assert "Evidence scenarios: 1 / 1 reference scenarios" in output
+    assert "reference scope contains available scenarios only" in output
+    assert "unavailable scenario contracts may add behavioral requirements" in output
+    assert "%" not in output
 
 
 @pytest.mark.parametrize(
@@ -207,6 +368,7 @@ def test_test_progress_renders_each_verdict_without_changing_exit_semantics(
     output = capsys.readouterr().out
     result_line = next(line for line in output.splitlines() if line.startswith("[1/1]"))
     assert result_line.endswith(verdict.value)
+    assert "Declared behavioral coverage:" in output
 
 
 def test_test_progress_heartbeat_is_readable_without_a_tty() -> None:

--- a/tests/agentcheck/test_cli_e2e.py
+++ b/tests/agentcheck/test_cli_e2e.py
@@ -11,6 +11,7 @@ from collections import Counter
 from html.parser import HTMLParser
 from pathlib import Path
 
+from agentcheck.coverage import BehavioralCoverage
 from agentcheck.domain import (
     AgentSpec,
     CanonicalRun,
@@ -224,6 +225,11 @@ def test_offline_cli_runs_complete_phase1_flow_with_intercepted_tools(
     assert "Failed:        5" in execution.stdout
     assert "Inconclusive:  0" in execution.stdout
     assert "Infra errors:  0" in execution.stdout
+    assert "Declared behavioral coverage:" in execution.stdout
+    coverage_output = execution.stdout.split("Declared behavioral coverage:", 1)[1]
+    coverage_output = coverage_output.split("High-confidence failures discovered:", 1)[0]
+    assert "%" not in coverage_output
+    assert "complete coverage" not in coverage_output.casefold()
 
     run_root = target / ".agentcheck" / "runs" / RUN_ID
     assert {path.name for path in run_root.iterdir()} == EXPECTED_ARTIFACTS
@@ -323,6 +329,13 @@ def test_offline_cli_runs_complete_phase1_flow_with_intercepted_tools(
     assert len(set(worker_pids)) == 14
 
     summary = json.loads((run_root / "summary.json").read_text(encoding="utf-8"))
+    behavioral_coverage = BehavioralCoverage.model_validate_json(
+        json.dumps(summary.pop("behavioral_coverage"))
+    )
+    assert behavioral_coverage.spec_id == inspected_spec.spec_id
+    assert behavioral_coverage.scenario_count == len(scenarios)
+    assert behavioral_coverage.suite_fingerprint is None
+    assert behavioral_coverage.families
     assert summary == {
         "schema_version": "agentcheck.summary.v1",
         "run_id": RUN_ID,

--- a/tests/agentcheck/test_generate.py
+++ b/tests/agentcheck/test_generate.py
@@ -50,6 +50,7 @@ from agentcheck.generate import (
     FROZEN_SUITE_CONTRACT_VERSION,
     CaseOrigin,
     FrozenSuite,
+    SelectionPlan,
     build_boundary_cases,
     build_frozen_suite,
     configured_frozen_suite,
@@ -59,7 +60,9 @@ from agentcheck.generate import (
     write_frozen_suite,
 )
 from agentcheck.generate.boundaries import BoundaryKind
+from agentcheck.generate.selection import SelectionDecision
 from agentcheck.inspect import load_target
+from agentcheck.report import load_stored_run, render_stored_run
 from agentcheck.runner import ToolGateway
 from agentcheck.runner.orchestrator import ProcessResult
 
@@ -206,6 +209,27 @@ def test_frozen_suite_round_trips_and_keeps_stable_identity() -> None:
         for case in first.cases
         if case.lineage.origin is CaseOrigin.SCHEMA_BOUNDARY
     )
+
+
+def test_frozen_suite_rejects_selection_not_bound_to_cases() -> None:
+    suite = build_frozen_suite(_example_spec(), AgentCheckConfig(), seed=SEED)
+    selected_id = suite.cases[0].scenario.scenario_id
+    selection = SelectionPlan(
+        max_cases=1,
+        selected_ids=(selected_id,),
+        decisions=(
+            SelectionDecision(
+                scenario_id=selected_id,
+                selected=True,
+                reason="selected for malformed fixture",
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        ValidationError, match="cases must match selection plan selected IDs"
+    ):
+        _reissue(suite, selection=selection.model_dump(mode="json"))
 
 
 def test_same_seed_same_suite_and_different_seed_changes_identity() -> None:
@@ -422,6 +446,115 @@ def test_lint_failure_rejects_a_frozen_suite_before_execution(
     assert called == []
 
 
+def test_selected_lint_invalid_frozen_case_loads_and_renders(
+    tmp_path: Path,
+) -> None:
+    target = _copy_example(tmp_path)
+    generation = application.generate_suite(target, seed=SEED, force=True)
+    suite = generation.suite
+    valid_case = next(
+        case for case in suite.cases if case.scenario.scenario_id == "happy_lookup"
+    )
+    invalid_case = next(
+        case for case in suite.cases if case.scenario.scenario_id != "happy_lookup"
+    )
+    invalid_data = invalid_case.scenario.model_dump(mode="json")
+    invalid_data["scenario_id"] = "lint-invalid-frozen-case"
+    for group in (
+        "tool_fixtures",
+        "required_tool_behavior",
+        "allowed_tool_behavior",
+        "forbidden_tool_behavior",
+    ):
+        for item in invalid_data[group]:
+            item["tool_name"] = "missing_tool"
+    invalid_data["fingerprint"] = ""
+    invalid_scenario = Scenario.model_validate_json(json.dumps(invalid_data))
+    excluded_case = next(
+        case
+        for case in suite.cases
+        if case.scenario.scenario_id
+        not in {valid_case.scenario.scenario_id, invalid_case.scenario.scenario_id}
+    )
+    selection = SelectionPlan(
+        max_cases=2,
+        selected_ids=(
+            valid_case.scenario.scenario_id,
+            invalid_scenario.scenario_id,
+        ),
+        excluded_ids=(excluded_case.scenario.scenario_id,),
+        decisions=(
+            SelectionDecision(
+                scenario_id=valid_case.scenario.scenario_id,
+                selected=True,
+                reason="selected before lint",
+            ),
+            SelectionDecision(
+                scenario_id=invalid_scenario.scenario_id,
+                selected=True,
+                reason="selected before lint",
+            ),
+            SelectionDecision(
+                scenario_id=excluded_case.scenario.scenario_id,
+                selected=False,
+                reason="excluded before lint",
+            ),
+        ),
+    )
+    partial = _reissue(
+        suite,
+        cases=[
+            json.loads(valid_case.model_dump_json()),
+            {
+                "scenario": json.loads(invalid_scenario.model_dump_json()),
+                "lineage": json.loads(invalid_case.lineage.model_dump_json()),
+            },
+        ],
+        selection=selection.model_dump(mode="json"),
+    )
+    write_frozen_suite(target / DEFAULT_SUITE_FILENAME, partial, force=True)
+
+    execution = application.execute_suite(
+        target,
+        run_id="partial-invalid-frozen",
+        persist_store=False,
+    )
+
+    assert tuple(scenario.scenario_id for scenario in execution.scenarios) == (
+        "happy_lookup",
+    )
+    assert len(execution.invalid_scenarios) == 1
+    assert execution.behavioral_coverage.scenario_count == 1
+    assert execution.behavioral_coverage.reference_scenario_count == 1
+    assert execution.report_path.is_file()
+    assert "Declared behavioral coverage" in execution.report_path.read_text(
+        encoding="utf-8"
+    )
+    assert execution.selection == selection
+    loaded = load_stored_run(target, run_id=execution.run_id)
+    assert loaded.selection == selection
+    assert loaded.behavioral_coverage == execution.behavioral_coverage
+
+    invalid_path = execution.artifact_directory / "invalid-scenarios.json"
+    original_invalid = json.loads(invalid_path.read_text(encoding="utf-8"))
+    duplicate_invalid = json.loads(json.dumps(original_invalid))
+    duplicate_invalid["items"].append(duplicate_invalid["items"][0])
+    invalid_path.write_text(json.dumps(duplicate_invalid), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="scenario IDs must be unique"):
+        load_stored_run(target, run_id=execution.run_id)
+
+    unexpected_invalid = json.loads(json.dumps(original_invalid))
+    unexpected_invalid["items"][0]["scenario"]["scenario_id"] = (
+        "unexpected-invalid-id"
+    )
+    invalid_path.write_text(json.dumps(unexpected_invalid), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="selection binding"):
+        load_stored_run(target, run_id=execution.run_id)
+
+    invalid_path.write_text(json.dumps(original_invalid), encoding="utf-8")
+    stored = render_stored_run(target, run_id=execution.run_id)
+    assert stored.report_path.is_file()
+
 def test_suite_path_config_selects_the_frozen_file(tmp_path: Path) -> None:
     target = _copy_example(tmp_path)
     spec = _example_spec()
@@ -466,6 +599,11 @@ def test_cli_generate_writes_a_suite_and_honors_force(
     assert str(target / DEFAULT_SUITE_FILENAME) in output.out
     assert "Cases:" in output.out
     assert "Rejected:     0" in output.out
+    assert "Declared behavioral coverage:" in output.out
+    coverage_output = output.out.split("Declared behavioral coverage:", 1)[1]
+    coverage_output = coverage_output.split("Action-path coverage:", 1)[0]
+    assert "%" not in coverage_output
+    assert "complete coverage" not in coverage_output.casefold()
     assert f"- agentcheck test {target}" in output.out
 
     assert main(["generate", str(target)]) == 2

--- a/tests/agentcheck/test_report.py
+++ b/tests/agentcheck/test_report.py
@@ -9,6 +9,11 @@ from typing import TypeVar
 import pytest
 
 from agentcheck.artifacts import ArtifactStore
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+    analyze_behavioral_coverage,
+)
 from agentcheck.cli import main
 from agentcheck.domain import (
     AgentProperty,
@@ -42,7 +47,9 @@ from agentcheck.generate import (
     FrozenSuite,
     build_account_support_suite,
 )
+from agentcheck.report.render import _behavioral_coverage_html
 from agentcheck.generate.suite import GeneratorProvenance, SuiteCoverage
+from agentcheck.generate.selection import SelectionDecision, SelectionPlan
 from agentcheck.report import load_stored_run, render_report, render_stored_run
 from agentcheck.store import SqliteEvaluationStore, StoredRun
 
@@ -82,6 +89,74 @@ def test_report_escapes_xss_and_hides_system_prompt() -> None:
     assert "<script" not in report.casefold()
     assert "https://" not in report
     assert "Content-Security-Policy" in report
+
+
+def test_declared_behavioral_coverage_suppresses_all_zero_families() -> None:
+    report = render_report(
+        run_id="run",
+        target="target",
+        git_revision=None,
+        spec=_spec("agent"),
+        scenarios=(),
+        runs=(),
+        evaluations=(),
+        findings=(),
+    )
+
+    assert "Declared behavioral coverage" in report
+    assert "No declared behavioral coverage requirements were derived." in report
+    assert "<h4>Success path</h4>" not in report
+    assert "Unknown and unsupported requirements remain explicit." in report
+
+
+def test_declared_behavioral_coverage_is_escaped_and_avoids_a_percentage() -> None:
+    hostile = '<script>coverage</script><img src=x onerror="alert(1)">'
+    spec = _spec("agent")
+    payload = analyze_behavioral_coverage(spec, ()).model_dump(mode="json")
+    payload["families"] = [
+        {
+            "dimension": "failure_handling",
+            "missing": 1,
+            "requirements": [
+                {
+                    "subject": hostile,
+                    "status": "missing",
+                    "reason_code": hostile,
+                }
+            ],
+        }
+    ]
+    payload.pop("fingerprint")
+    coverage = BehavioralCoverage.model_validate_json(json.dumps(payload))
+
+    subsection = _behavioral_coverage_html(coverage)
+    assert hostile not in subsection
+    assert "&lt;script&gt;coverage&lt;/script&gt;" in subsection
+    assert "Applicable: 1" in subsection
+    assert "Missing: 1" in subsection
+    assert "%" not in subsection
+    assert "does not prove that the agent exercised an action path" in subsection
+    assert "complete coverage of real-world behavioral risks" in subsection
+
+
+def test_render_report_rejects_coverage_bound_to_another_spec() -> None:
+    spec = _spec("agent")
+    coverage = analyze_behavioral_coverage(spec, ()).model_copy(
+        update={"spec_id": "different-spec"}
+    )
+
+    with pytest.raises(ValueError):
+        render_report(
+            run_id="run",
+            target="target",
+            git_revision=None,
+            spec=spec,
+            scenarios=(),
+            runs=(),
+            evaluations=(),
+            findings=(),
+            behavioral_coverage=coverage,
+        )
 
 
 def test_report_redacts_secrets_in_instructions_and_structured_state() -> None:
@@ -244,6 +319,207 @@ def _write_run(
     return artifacts.root
 
 
+def _selection_plan(selected_id: str, excluded_id: str) -> SelectionPlan:
+    return SelectionPlan(
+        selected_ids=(selected_id,),
+        excluded_ids=(excluded_id,),
+        decisions=(
+            SelectionDecision(
+                scenario_id=selected_id,
+                selected=True,
+                reason="selected for coverage",
+            ),
+            SelectionDecision(
+                scenario_id=excluded_id,
+                selected=False,
+                reason="excluded by coverage selection",
+            ),
+        ),
+    )
+
+
+def test_old_summary_derives_behavioral_coverage_from_stored_artifacts(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    _write_run(root, "run-old-summary")
+
+    loaded = load_stored_run(root, run_id="run-old-summary")
+
+    assert loaded.behavioral_coverage == analyze_behavioral_coverage(
+        loaded.spec, loaded.scenarios
+    )
+    generated = render_stored_run(root, run_id="run-old-summary")
+    report = generated.report_path.read_text(encoding="utf-8")
+    assert "Declared behavioral coverage" in report
+    assert "structural suite-design analysis" in report
+
+
+def test_old_selected_summary_marks_available_denominator_incomplete(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    reference = build_account_support_suite(seed=SEED)[:2]
+    directory = _write_run(
+        root,
+        "run-old-selected-summary",
+        scenario=reference[0],
+    )
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["selection"] = _selection_plan(
+        reference[0].scenario_id, reference[1].scenario_id
+    ).model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    loaded = load_stored_run(root, run_id="run-old-selected-summary")
+
+    assert (
+        loaded.behavioral_coverage.reference_scope
+        is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+    )
+    generated = render_stored_run(root, run_id="run-old-selected-summary")
+    report = generated.report_path.read_text(encoding="utf-8")
+    assert "Incomplete denominator" in report
+    assert "reference scope is available scenarios only" in report
+    assert "may undercount missing risks" in report
+
+    summary["selection"] = _selection_plan(
+        reference[1].scenario_id, reference[0].scenario_id
+    ).model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="selection binding"):
+        load_stored_run(root, run_id="run-old-selected-summary")
+
+
+def test_stored_complete_coverage_is_not_downgraded_by_selection(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    spec = _spec("Account Support Agent")
+    reference = build_account_support_suite(seed=SEED)[:2]
+    selected = (reference[0],)
+    directory = _write_run(
+        root,
+        "run-complete-selected-summary",
+        spec=spec,
+        scenario=selected[0],
+    )
+    coverage = analyze_behavioral_coverage(
+        spec,
+        selected,
+        reference_scenarios=reference,
+    )
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["selection"] = _selection_plan(
+        reference[0].scenario_id, reference[1].scenario_id
+    ).model_dump(mode="json")
+    summary["behavioral_coverage"] = coverage.model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    loaded = load_stored_run(root, run_id="run-complete-selected-summary")
+
+    assert (
+        loaded.behavioral_coverage.reference_scope
+        is BehavioralCoverageReferenceScope.COMPLETE
+    )
+    generated = render_stored_run(root, run_id="run-complete-selected-summary")
+    report = generated.report_path.read_text(encoding="utf-8")
+    assert "Incomplete denominator" not in report
+    assert "tool:update_email" in report
+
+    coverage_document = summary["behavioral_coverage"]
+    coverage_document["reference_scenario_count"] = 1
+    coverage_document["reference_scenario_digest"] = coverage_document[
+        "scenario_digest"
+    ]
+    coverage_document.pop("fingerprint")
+    rebound = BehavioralCoverage.model_validate_json(json.dumps(coverage_document))
+    summary["behavioral_coverage"] = rebound.model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="behavioral coverage|selection binding"):
+        load_stored_run(root, run_id="run-complete-selected-summary")
+
+
+def test_stored_summary_rejects_explicit_null_behavioral_coverage(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    directory = _write_run(root, "run-null-coverage")
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["behavioral_coverage"] = None
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="behavioral coverage"):
+        load_stored_run(root, run_id="run-null-coverage")
+
+
+def test_stored_summary_loads_bound_behavioral_coverage(tmp_path: Path) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    directory = _write_run(root, "run-with-coverage")
+    legacy = load_stored_run(root, run_id="run-with-coverage")
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["behavioral_coverage"] = legacy.behavioral_coverage.model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    loaded = load_stored_run(root, run_id="run-with-coverage")
+
+    assert loaded.behavioral_coverage == legacy.behavioral_coverage
+
+
+def test_stored_summary_rejects_behavioral_coverage_bound_to_another_spec(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    directory = _write_run(root, "run-mismatched-coverage")
+    legacy = load_stored_run(root, run_id="run-mismatched-coverage")
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["behavioral_coverage"] = legacy.behavioral_coverage.model_dump(mode="json")
+    summary["behavioral_coverage"]["spec_id"] = "different-spec"
+    summary["behavioral_coverage"].pop("fingerprint")
+    rebound = BehavioralCoverage.model_validate_json(
+        json.dumps(summary["behavioral_coverage"])
+    )
+    summary["behavioral_coverage"] = rebound.model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="behavioral coverage"):
+        load_stored_run(root, run_id="run-mismatched-coverage")
+
+
+def test_stored_summary_rejects_behavioral_coverage_bound_to_other_scenarios(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    directory = _write_run(root, "run-mismatched-scenarios")
+    legacy = load_stored_run(root, run_id="run-mismatched-scenarios")
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["behavioral_coverage"] = legacy.behavioral_coverage.model_dump(mode="json")
+    summary["behavioral_coverage"]["scenario_digest"] = "sha256:different"
+    summary["behavioral_coverage"]["reference_scenario_digest"] = "sha256:different"
+    summary["behavioral_coverage"].pop("fingerprint")
+    rebound = BehavioralCoverage.model_validate_json(
+        json.dumps(summary["behavioral_coverage"])
+    )
+    summary["behavioral_coverage"] = rebound.model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="behavioral coverage"):
+        load_stored_run(root, run_id="run-mismatched-scenarios")
+
+
 def _index_run(root: Path, run_id: str, *, recorded_at: str) -> None:
     SqliteEvaluationStore(root / ".agentcheck" / "agentcheck.sqlite").record_run(
         StoredRun(
@@ -346,6 +622,142 @@ def test_render_report_shows_lineage_coverage_and_policy_when_available() -> Non
     assert "Seed 1729" in report
 
 
+def test_direct_report_uses_frozen_suite_as_behavioral_requirement_universe() -> None:
+    reference = build_account_support_suite(seed=SEED)[:2]
+    selected = (reference[0],)
+    spec = _spec("Account Support Agent")
+    frozen = FrozenSuite(
+        spec_id=spec.spec_id,
+        seed=SEED,
+        provenance=GeneratorProvenance(
+            generator="test",
+            generator_version="1",
+            sources=("test",),
+        ),
+        cases=tuple(
+            FrozenCase(
+                scenario=scenario,
+                lineage=CaseLineage(origin=CaseOrigin.BUILT_IN),
+            )
+            for scenario in reference
+        ),
+    )
+
+    report = render_report(
+        run_id="run",
+        target="target",
+        git_revision=None,
+        spec=spec,
+        scenarios=selected,
+        runs=(),
+        evaluations=(),
+        findings=(),
+        seed=SEED,
+        frozen_suite=frozen,
+        _coverage_reference_scenarios=reference,
+    )
+
+    subsection = report.split("<h3>Declared behavioral coverage</h3>", 1)[1].split(
+        "<p>1 valid scenario", 1
+    )[0]
+    assert "<h4>Fabricated success after failure</h4>" in subsection
+    assert "Evidence scenarios: 1 · Reference scenarios: 2" in subsection
+    assert "Applicable: 1 · Covered: 0 · Partial: 0 · Missing: 1" in subsection
+    assert "tool:update_email" in subsection
+
+    conservative_report = render_report(
+        run_id="run",
+        target="target",
+        git_revision=None,
+        spec=spec,
+        scenarios=selected,
+        runs=(),
+        evaluations=(),
+        findings=(),
+        seed=SEED,
+        frozen_suite=frozen,
+    )
+    conservative_subsection = conservative_report.split(
+        "<h3>Declared behavioral coverage</h3>", 1
+    )[1].split("<p>1 valid scenario", 1)[0]
+    assert "Incomplete denominator" in conservative_subsection
+    assert "Evidence scenarios: 1 · Reference scenarios: 1" in conservative_subsection
+    assert "tool:update_email" not in conservative_subsection
+
+    other_denominator = analyze_behavioral_coverage(
+        spec,
+        selected,
+        reference_scenarios=selected,
+        suite_fingerprint=frozen.fingerprint,
+    )
+    with pytest.raises(ValueError, match="reference_scenario"):
+        render_report(
+            run_id="run",
+            target="target",
+            git_revision=None,
+            spec=spec,
+            scenarios=selected,
+            runs=(),
+            evaluations=(),
+            findings=(),
+            seed=SEED,
+            frozen_suite=frozen,
+            behavioral_coverage=other_denominator,
+        )
+
+
+def test_direct_selected_report_caveats_unavailable_requirement_universe() -> None:
+    reference = build_account_support_suite(seed=SEED)[:2]
+    selected = (reference[0],)
+    plan = _selection_plan(reference[0].scenario_id, reference[1].scenario_id)
+
+    report = render_report(
+        run_id="run",
+        target="target",
+        git_revision=None,
+        spec=_spec("Account Support Agent"),
+        scenarios=selected,
+        runs=(),
+        evaluations=(),
+        findings=(),
+        seed=SEED,
+        selection_plan=plan,
+    )
+
+    subsection = report.split("<h3>Declared behavioral coverage</h3>", 1)[1].split(
+        "<p>1 valid scenario", 1
+    )[0]
+    assert "Incomplete denominator" in subsection
+    assert "Evidence scenarios: 1 · Reference scenarios: 1" in subsection
+    assert "reference scope is available scenarios only" in subsection
+    assert "may undercount missing risks" in subsection
+    assert "tool:update_email" not in subsection
+
+
+def test_direct_report_without_frozen_suite_rejects_suite_bound_coverage() -> None:
+    scenario = build_account_support_suite(seed=SEED)[0]
+    spec = _spec("Account Support Agent")
+    coverage = analyze_behavioral_coverage(
+        spec,
+        (scenario,),
+        suite_fingerprint="sha256:unavailable-suite",
+    )
+
+    with pytest.raises(ValueError, match="suite_fingerprint"):
+        render_report(
+            run_id="run",
+            target="target",
+            git_revision=None,
+            spec=spec,
+            scenarios=(scenario,),
+            runs=(),
+            evaluations=(),
+            findings=(),
+            seed=SEED,
+            behavioral_coverage=coverage,
+        )
+
+
 def test_report_cli_help_discloses_read_only_behavior(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -390,6 +802,7 @@ def test_explicit_run_report_does_not_execute_the_target(
     assert "Content-Security-Policy" in report
     assert "<script" not in report.casefold()
     assert "Account Support Agent" in report
+    assert "Declared behavioral coverage" in report
     assert "Seed 1729" in report
 
 

--- a/tests/agentcheck/test_selection.py
+++ b/tests/agentcheck/test_selection.py
@@ -12,6 +12,10 @@ import agentcheck.application as application
 from agentcheck.adapters import OpenAIAgentsAdapter
 from agentcheck.cli import main
 from agentcheck.config import AgentCheckConfig, load_config
+from agentcheck.coverage import (
+    BehavioralCoverage,
+    BehavioralCoverageReferenceScope,
+)
 from agentcheck.domain import Verdict
 from agentcheck.errors import ConfigurationError
 from agentcheck.generate import (
@@ -249,6 +253,44 @@ def test_generate_max_cases_records_lineage_and_same_seed_identity() -> None:
     )
 
 
+def test_max_cases_coverage_keeps_or_discloses_reference_universe(
+    tmp_path: Path,
+) -> None:
+    target = _copy_example(tmp_path)
+    generation = application.generate_suite(
+        target,
+        seed=SEED,
+        max_cases=8,
+        force=True,
+    )
+    selection = generation.suite.selection
+    assert selection is not None
+    selected_count = len(selection.selected_ids)
+    candidate_count = len(selection.decisions)
+    assert candidate_count == selected_count + len(selection.excluded_ids)
+    assert candidate_count > selected_count
+
+    generated = generation.behavioral_coverage
+    assert generated.reference_scope is BehavioralCoverageReferenceScope.COMPLETE
+    assert generated.scenario_count == selected_count
+    assert generated.reference_scenario_count == candidate_count
+    assert generated.reference_scenario_digest != generated.scenario_digest
+
+    execution = application.execute_suite(
+        target,
+        run_id="bounded-coverage-scope",
+        persist_store=False,
+    )
+    executed = execution.behavioral_coverage
+    assert executed.scenario_count == selected_count
+    assert (
+        executed.reference_scope
+        is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+    )
+    assert executed.reference_scenario_count == selected_count
+    assert executed.reference_scenario_digest == executed.scenario_digest
+
+
 def test_config_max_cases_is_optional_and_keeps_v1(tmp_path: Path) -> None:
     (tmp_path / "agent.py").write_text("agent = object()\n", encoding="utf-8")
     (tmp_path / "agentcheck.json").write_text(
@@ -290,6 +332,14 @@ def test_cli_generate_max_cases_and_test_select_coverage(tmp_path: Path) -> None
     assert summary["excluded_by_selection"] > 0
     assert "selection" in summary
     assert "coverage" in summary
+    behavioral = BehavioralCoverage.model_validate_json(
+        json.dumps(summary["behavioral_coverage"])
+    )
+    assert behavioral == execution.behavioral_coverage
+    assert behavioral.scenario_count == len(execution.scenarios)
+    assert behavioral.suite_fingerprint == generation.suite.fingerprint
+    assert generation.behavioral_coverage.suite_fingerprint == generation.suite.fingerprint
+    assert generation.suite.fingerprint == generation.suite.expected_fingerprint()
     excluded = set(summary["selection"]["excluded_ids"])
     evaluated = {item.scenario_id for item in execution.evaluations}
     assert excluded.isdisjoint(evaluated)

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -44,6 +44,7 @@ COMPATIBILITY_SUITE: dict[str, dict[str, object]] = {
             "tests/agentcheck/test_domain.py",
             "tests/agentcheck/test_artifacts.py",
             "tests/agentcheck/test_suite_compatibility.py",
+            "tests/agentcheck/test_behavioral_coverage.py",
         ),
         "symbols": ("fingerprint", "model_dump", "IncompatibleSuiteError", "redact"),
     },


### PR DESCRIPTION
## What

Adds **declared behavioral coverage**: a derived, independently versioned
analysis (`agentcheck.behavioral_coverage.v1`) that answers one bounded
question about suite design —

> Given this inspected specification and these scenarios, which explicitly
> represented behaviors have both a controlled stimulus and an executable
> oracle?

Twelve behavioral families (success, failure, timeout, fabricated success,
ambiguous outcome, retry control, duplicate action, confirmation with and
without consent, prerequisite success and failure, ordering) each report
`COVERED` / `PARTIAL` / `MISSING` / `UNKNOWN` / `UNSUPPORTED` per declared tool
or explicitly represented tool relationship.

Surfaces: `agentcheck generate` and `agentcheck test` console output,
`summary.json` under `behavioral_coverage`, and the offline HTML report.

## Why the verdict stays trustworthy

- The analyzer is **pure contract inspection**. It never imports a target,
  builds a gateway, applies a fixture effect, or mutates a real or simulated
  world.
- **No semantics are inferred from names.** A tool called `delete_user` is not
  destructive because of its name. Non-authoritative risk metadata produces
  `UNKNOWN`, never `COVERED`.
- **The denominator is honest.** Only `COVERED + PARTIAL + MISSING` is
  applicable; `UNKNOWN` and `UNSUPPORTED` stay visible and outside it. There is
  no combined percentage anywhere in the CLI, HTML, or docs.
- **Excluding a case makes its behavior missing**, never a smaller denominator.
  Requirements come from a reference scenario set; evidence comes only from the
  executed set. A persisted pruned suite cannot supply the cases it discarded,
  so it is reported as `AVAILABLE_SCENARIOS_ONLY` and the report says the
  denominator is incomplete.
- **Coverage never touches a verdict.** `PASS` / `FAIL` / `INCONCLUSIVE` /
  `INFRA_ERROR` are unchanged, and structural coverage is explicitly documented
  as *not* evidence that the agent took a branch.
- Identifiers and schemas that cannot survive mandatory artifact redaction or
  truncation losslessly are reported `UNKNOWN`, never `COVERED`.

## Compatibility

- Coverage is **derived report metadata**. It adds no field to `Scenario`,
  `FrozenSuite`, replay manifests, baselines, or review records.
- **Existing frozen-suite bytes and fingerprints are unchanged**, and replay
  semantics are untouched. Replay remains source-bound re-execution.
- `summary.json` gains one key without a contract-version bump. Summaries
  written before this change still load; coverage is then derived from that
  run's own stored artifacts.
- `FrozenSuite` now rejects a selection plan whose selected IDs do not match its
  cases. Validation only — the fingerprint is unaffected.

## Validation

- `python -m pytest tests -q -n 2` — full suite green
- `python -m ruff check agentcheck tests scripts` — clean
- `python -m mypy agentcheck` — clean
- New: `tests/agentcheck/test_behavioral_coverage.py` (56 cases), plus
  additions to the report, generate, selection, CLI diagnostics, and e2e
  suites, and an entry in the cross-version compatibility manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
