### PR TITLE
feat: compare two stored runs for behavioral regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,12 @@ Breaking any of these is a correctness bug, not a style issue:
 | `agentcheck/adapters/` | The only layer allowed to import a framework SDK. |
 | `agentcheck/inspect/` | Import a target and extract an `AgentSpec` without running a turn. |
 | `agentcheck/generate/` | Derive, lint, select, and freeze suites. |
+| `agentcheck/coverage/` | Derived behavioral coverage over a spec and a scenario set. Pure contract analysis; imports no target. |
 | `agentcheck/runner/` | Orchestrator, worker, tool gateway, simulated world, budgets, network guard. |
 | `agentcheck/evaluate/` | Oracle evaluation and verdict assignment. |
 | `agentcheck/replay/` | Manifests, source binding, filesets. |
 | `agentcheck/report/`, `agentcheck/baseline/`, `agentcheck/review/` | Reporting, CI gating, human decisions on findings. |
+| `agentcheck/regression/` | Run-to-run behavioral comparison over stored artifacts. Executes nothing. |
 | `agentcheck/redaction.py`, `agentcheck/privacy.py` | Credential redaction for artifacts and logs. |
 | `agentcheck/cli.py` | The `agentcheck` command. |
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ and read the [CI trust model](docs/ci-trust-model.md).
 - [Custom Python agent contract](docs/custom-agents.md)
 - [Validation evidence and claim boundaries](docs/validation-evidence.md)
 - [Declared behavioral coverage](docs/behavioral-coverage.md)
+- [Behavioral regression comparison](docs/behavioral-regression.md)
 - [CI trust model](docs/ci-trust-model.md)
 - [PyPI package](https://pypi.org/project/agentcheck-ai/)
 

--- a/agentcheck/cli.py
+++ b/agentcheck/cli.py
@@ -52,6 +52,7 @@ from agentcheck.generate.selection import MAX_CASES
 from agentcheck.initialize import DEFAULT_ADAPTER, SUPPORTED_ADAPTERS, write_initial_config
 from agentcheck.inspect.capabilities import ExtractedCapability, extract_capabilities
 from agentcheck.privacy import redact_artifact, redact_log_text
+from agentcheck.regression import compare_stored_runs, encode_run_comparison
 from agentcheck.report import render_stored_run
 from agentcheck.review import HUMAN_DECISIONS, HumanDecision
 from agentcheck.review.service import record_finding_review
@@ -497,6 +498,43 @@ def _parser() -> argparse.ArgumentParser:
         help="replace an existing fixtures file instead of refusing",
     )
     _add_python_option(fixtures_init)
+
+    compare_parser = commands.add_parser(
+        "compare",
+        help="classify behavioral differences between two stored runs",
+        description=(
+            "Compare two stored runs of one target without executing anything. "
+            "Scenarios are matched by structural fingerprint, never by array "
+            "position. Exit 1 for an attributable behavioral regression, 2 for "
+            "an outcome AgentCheck could not certify, and 3 when the two runs "
+            "are incomparable. A verdict pair is evidence about two executions; "
+            "AgentCheck does not replay model output, so it is not proof that a "
+            "behavior is deterministic. This is not the baseline gate: it needs "
+            "nothing committed and accepts no curated failure list."
+        ),
+    )
+    compare_parser.add_argument("target", nargs="?", default=".")
+    compare_parser.add_argument(
+        "--base",
+        required=True,
+        type=_run_id,
+        help="stored run ID to compare from",
+    )
+    compare_parser.add_argument(
+        "--head",
+        type=_run_id,
+        help="stored run ID to compare to",
+    )
+    compare_parser.add_argument(
+        "--latest",
+        action="store_true",
+        help="compare to the most recently indexed run instead of --head",
+    )
+    compare_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="write agentcheck.run_comparison.v1 JSON to stdout",
+    )
 
     baseline_parser = commands.add_parser(
         "baseline",
@@ -1647,6 +1685,28 @@ def _baseline_check_command(
     return checked.exit_code
 
 
+def _compare_command(
+    target: str,
+    *,
+    base: str,
+    head: str | None,
+    latest: bool,
+    as_json: bool,
+) -> int:
+    checked = compare_stored_runs(
+        target,
+        base_run_id=base,
+        head_run_id=head,
+        latest=latest,
+    )
+    if as_json:
+        print(checked.summary, end="", file=sys.stderr)
+        print(encode_run_comparison(checked.comparison))
+    else:
+        print(checked.summary, end="")
+    return checked.exit_code
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
@@ -1727,6 +1787,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     force=args.force,
                     python_executable=args.python_executable,
                 )
+        if args.command == "compare":
+            return _compare_command(
+                args.target,
+                base=args.base,
+                head=args.head,
+                latest=args.latest,
+                as_json=args.json,
+            )
         if args.command == "baseline":
             if args.baseline_command == "create":
                 return _baseline_create_command(

--- a/agentcheck/regression/__init__.py
+++ b/agentcheck/regression/__init__.py
@@ -1,0 +1,32 @@
+"""Semantic run-to-run behavioral regression comparison."""
+
+from .compare import compare_runs, exit_code
+from .contract import (
+    RUN_COMPARISON_CONTRACT_VERSION,
+    Comparability,
+    ComparabilityCaveat,
+    IncomparableReason,
+    RunComparison,
+    RunComparisonItem,
+)
+from .service import (
+    CheckedRunComparison,
+    compare_stored_runs,
+    encode_run_comparison,
+    format_run_comparison,
+)
+
+__all__ = [
+    "RUN_COMPARISON_CONTRACT_VERSION",
+    "CheckedRunComparison",
+    "Comparability",
+    "ComparabilityCaveat",
+    "IncomparableReason",
+    "RunComparison",
+    "RunComparisonItem",
+    "compare_runs",
+    "compare_stored_runs",
+    "encode_run_comparison",
+    "exit_code",
+    "format_run_comparison",
+]

--- a/agentcheck/regression/compare.py
+++ b/agentcheck/regression/compare.py
@@ -1,0 +1,240 @@
+"""Compare two stored AgentCheck runs without executing a target.
+
+Scenarios are matched by structural fingerprint, then by display ID for a
+scenario whose content changed. Array position is never an identity: two runs
+of the same suite can order, select, or lint cases differently.
+"""
+
+from __future__ import annotations
+
+from agentcheck.baseline.build import baseline_from_loaded
+from agentcheck.baseline.compare import compare_baselines
+from agentcheck.baseline.contract import ComparisonItem, EvaluationBaseline
+from agentcheck.errors import ConfigurationError
+from agentcheck.report.load import LoadedRun
+
+from .contract import (
+    BLOCKING_CATEGORIES,
+    MAX_COMPARISON_ITEMS,
+    UNCERTIFIABLE_CATEGORIES,
+    Comparability,
+    ComparabilityCaveat,
+    IncomparableReason,
+    RunComparison,
+    RunComparisonCategory,
+    RunComparisonItem,
+)
+
+
+_CATEGORY_ORDER = (
+    "new_regression",
+    "changed_failure",
+    "uncertifiable_failure",
+    "unchanged_failure",
+    "resolved_failure",
+    "changed_scenario",
+    "new_scenario",
+    "removed_scenario",
+    "deselected_scenario",
+    "inconclusive_change",
+    "infra_change",
+    "unchanged",
+)
+
+
+def compare_runs(base: LoadedRun, head: LoadedRun) -> RunComparison:
+    """Classify behavioral differences between two stored runs of one target."""
+
+    if base.root != head.root:
+        raise ConfigurationError(
+            "run comparison requires two runs of the same target directory"
+        )
+    base_snapshot = baseline_from_loaded(base)
+    head_snapshot = baseline_from_loaded(head)
+    shared = _shared_scenario_count(base_snapshot, head_snapshot)
+
+    incomparable_reason = _incomparable_reason(
+        base, head, base_snapshot, head_snapshot, shared=shared
+    )
+    caveats = _caveats(base, head, base_snapshot, head_snapshot)
+    if incomparable_reason is not None:
+        return RunComparison(
+            base_run_id=base.run_id,
+            head_run_id=head.run_id,
+            comparability=Comparability.INCOMPARABLE,
+            incomparable_reason=incomparable_reason,
+            caveats=caveats,
+            base_scenario_count=len(base_snapshot.cases),
+            head_scenario_count=len(head_snapshot.cases),
+            shared_scenario_count=shared,
+            base_failure_count=_failure_count(base_snapshot),
+            head_failure_count=_failure_count(head_snapshot),
+            new_regression_count=0,
+            changed_failure_count=0,
+            resolved_count=0,
+            unchanged_failure_count=0,
+            uncertifiable_count=0,
+        )
+
+    classified = compare_baselines(base_snapshot, head_snapshot)
+    deselected = _deselected_ids(head)
+    items = tuple(
+        sorted(
+            (_item(entry, deselected) for entry in classified.items),
+            key=lambda item: (
+                _CATEGORY_ORDER.index(item.category),
+                item.fingerprint,
+                item.scenario_id,
+            ),
+        )
+    )
+    if any(item.category == "changed_scenario" for item in items):
+        caveats = (*caveats, ComparabilityCaveat.SCENARIO_IDENTITY_CHANGED)
+    visible = items[:MAX_COMPARISON_ITEMS]
+    return RunComparison(
+        base_run_id=base.run_id,
+        head_run_id=head.run_id,
+        comparability=Comparability.COMPARABLE,
+        caveats=caveats,
+        base_scenario_count=len(base_snapshot.cases),
+        head_scenario_count=len(head_snapshot.cases),
+        shared_scenario_count=shared,
+        base_failure_count=_failure_count(base_snapshot),
+        head_failure_count=_failure_count(head_snapshot),
+        new_regression_count=_count(items, "new_regression"),
+        changed_failure_count=_count(items, "changed_failure"),
+        resolved_count=_count(items, "resolved_failure"),
+        unchanged_failure_count=_count(items, "unchanged_failure"),
+        uncertifiable_count=sum(
+            _count(items, category) for category in UNCERTIFIABLE_CATEGORIES
+        ),
+        items=visible,
+        omitted_items=len(items) - len(visible),
+    )
+
+
+def exit_code(comparison: RunComparison) -> int:
+    """CI status for a completed comparison.
+
+    Mirrors ``agentcheck test``: 2 is an outcome AgentCheck could not certify,
+    1 is an attributable behavioral regression, 3 is weak or absent evidence,
+    and 0 is no detected regression. A comparison that cannot be made is never
+    reported as a clean result.
+    """
+
+    if comparison.comparability is Comparability.INCOMPARABLE:
+        return 3
+    if comparison.uncertifiable_count:
+        return 2
+    if any(item.blocking for item in comparison.items):
+        return 1
+    return 0
+
+
+def _incomparable_reason(
+    base: LoadedRun,
+    head: LoadedRun,
+    base_snapshot: EvaluationBaseline,
+    head_snapshot: EvaluationBaseline,
+    *,
+    shared: int,
+) -> IncomparableReason | None:
+    if base.run_id == head.run_id:
+        return IncomparableReason.SAME_RUN
+    if shared:
+        return None
+    shared_ids = {item.scenario_id for item in base_snapshot.cases}.intersection(
+        item.scenario_id for item in head_snapshot.cases
+    )
+    if shared_ids:
+        return None
+    # Nothing links the two runs, so every classification would describe the
+    # identity change rather than a behavior.
+    return IncomparableReason.NO_SHARED_SCENARIOS
+
+
+def _caveats(
+    base: LoadedRun,
+    head: LoadedRun,
+    base_snapshot: EvaluationBaseline,
+    head_snapshot: EvaluationBaseline,
+) -> tuple[ComparabilityCaveat, ...]:
+    caveats: list[ComparabilityCaveat] = []
+    # Every binding below comes from what each run recorded for itself. The
+    # configured spec and frozen suite files can postdate either run, so they
+    # are never comparison inputs.
+    if base_snapshot.spec_id != head_snapshot.spec_id or (
+        base.behavioral_coverage.spec_digest != head.behavioral_coverage.spec_digest
+    ):
+        caveats.append(ComparabilityCaveat.SPEC_CHANGED)
+    # The scenario digest is always recorded and hashes the evaluated
+    # (scenario_id, fingerprint) multiset, so it answers "same scenario set?"
+    # even for a run that used no frozen suite.
+    scenario_set_changed = (
+        base.behavioral_coverage.scenario_digest
+        != head.behavioral_coverage.scenario_digest
+    )
+    if scenario_set_changed:
+        caveats.append(ComparabilityCaveat.SCENARIO_SET_CHANGED)
+    base_suite = base.behavioral_coverage.suite_fingerprint
+    head_suite = head.behavioral_coverage.suite_fingerprint
+    if base_suite is not None and head_suite is not None and base_suite != head_suite:
+        caveats.append(ComparabilityCaveat.SUITE_FINGERPRINT_CHANGED)
+    if base.seed != head.seed:
+        caveats.append(ComparabilityCaveat.SEED_CHANGED)
+    if scenario_set_changed and (
+        base.selection is not None or head.selection is not None
+    ):
+        # Only meaningful when a scenario is actually absent from one side.
+        caveats.append(ComparabilityCaveat.SELECTION_ACTIVE)
+    if base.git_revision is None or head.git_revision is None:
+        caveats.append(ComparabilityCaveat.SOURCE_REVISION_UNRECORDED)
+    elif base.git_revision == head.git_revision:
+        caveats.append(ComparabilityCaveat.SOURCE_REVISION_UNCHANGED)
+    return tuple(caveats)
+
+
+def _deselected_ids(head: LoadedRun) -> frozenset[str]:
+    if head.selection is None:
+        return frozenset()
+    return frozenset(head.selection.excluded_ids)
+
+
+def _item(entry: ComparisonItem, deselected: frozenset[str]) -> RunComparisonItem:
+    category: RunComparisonCategory = entry.category
+    blocking = entry.blocking
+    if category == "removed_scenario" and entry.scenario_id in deselected:
+        # This scenario was excluded before execution, so the head run holds no
+        # evidence about it either way. Reporting it as removed would claim a
+        # suite change that did not happen.
+        category = "deselected_scenario"
+        blocking = False
+    return RunComparisonItem(
+        category=category,
+        scenario_id=entry.scenario_id,
+        fingerprint=entry.fingerprint,
+        base_verdict=entry.baseline_verdict,
+        head_verdict=entry.current_verdict,
+        base_failure_fingerprint=entry.baseline_failure_fingerprint,
+        head_failure_fingerprint=entry.current_failure_fingerprint,
+        blocking=blocking and category in BLOCKING_CATEGORIES,
+    )
+
+
+def _shared_scenario_count(
+    base: EvaluationBaseline, head: EvaluationBaseline
+) -> int:
+    base_fingerprints = {item.fingerprint for item in base.cases}
+    head_fingerprints = {item.fingerprint for item in head.cases}
+    return len(base_fingerprints.intersection(head_fingerprints))
+
+
+def _failure_count(snapshot: EvaluationBaseline) -> int:
+    return sum(1 for item in snapshot.cases if item.verdict == "FAIL")
+
+
+def _count(items: tuple[RunComparisonItem, ...], category: str) -> int:
+    return sum(1 for item in items if item.category == category)
+
+
+__all__ = ["compare_runs", "exit_code"]

--- a/agentcheck/regression/contract.py
+++ b/agentcheck/regression/contract.py
@@ -1,0 +1,173 @@
+"""Strict, independently versioned run-to-run behavioral comparison contracts.
+
+A comparison describes two stored runs. It never re-executes a target, never
+re-derives a verdict, and never asserts that a repeated verdict is
+deterministic: AgentCheck does not replay model output, so an unchanged pair is
+evidence about those two executions and nothing more.
+"""
+
+from __future__ import annotations
+
+import hmac
+from enum import Enum
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from agentcheck.baseline.contract import (
+    BLOCKING_CATEGORIES,
+    CERTIFICATION_FAILURE_CATEGORIES,
+    ComparisonCategory,
+)
+from agentcheck.domain import ContractModel, canonical_hash
+from agentcheck.privacy import redact_artifact, redact_log_text
+
+
+RUN_COMPARISON_CONTRACT_VERSION: Literal["agentcheck.run_comparison.v1"] = (
+    "agentcheck.run_comparison.v1"
+)
+
+# One bound below privacy's 100-item artifact limit, so the redacted view this
+# document hashes is lossless: a checksum must not be blind to a row the
+# document itself carries. Items are ordered with every blocking and
+# uncertifiable row first, so a larger suite omits only quiet detail, and the
+# counts are always computed over every item rather than the visible ones.
+MAX_COMPARISON_ITEMS = 100
+
+# The baseline vocabulary, plus the one distinction a run-to-run comparison can
+# make and a curated baseline cannot: a scenario absent because this run's
+# selection excluded it was never evaluated, so it is not a removed scenario.
+RunComparisonCategory = (
+    ComparisonCategory | Literal["deselected_scenario"]
+)
+
+# Re-exported, not restated: one repository must not be able to block on two
+# different definitions of "regression" or of "could not certify".
+UNCERTIFIABLE_CATEGORIES: tuple[str, ...] = CERTIFICATION_FAILURE_CATEGORIES
+
+
+class Comparability(str, Enum):
+    COMPARABLE = "comparable"
+    INCOMPARABLE = "incomparable"
+
+
+class IncomparableReason(str, Enum):
+    """Why no scenario-level classification was produced."""
+
+    SAME_RUN = "same_run"
+    NO_SHARED_SCENARIOS = "no_shared_scenarios"
+
+
+class ComparabilityCaveat(str, Enum):
+    """A binding that moved between the two runs, disclosed but not fatal."""
+
+    SPEC_CHANGED = "spec_changed"
+    SCENARIO_SET_CHANGED = "scenario_set_changed"
+    SUITE_FINGERPRINT_CHANGED = "suite_fingerprint_changed"
+    SEED_CHANGED = "seed_changed"
+    SELECTION_ACTIVE = "selection_active"
+    SOURCE_REVISION_UNRECORDED = "source_revision_unrecorded"
+    SOURCE_REVISION_UNCHANGED = "source_revision_unchanged"
+    SCENARIO_IDENTITY_CHANGED = "scenario_identity_changed"
+
+
+class RunComparisonItem(ContractModel):
+    """One scenario compared across two runs."""
+
+    category: RunComparisonCategory
+    scenario_id: str = Field(min_length=1, max_length=200)
+    fingerprint: str = Field(min_length=1, max_length=200)
+    base_verdict: str | None = Field(default=None, max_length=20)
+    head_verdict: str | None = Field(default=None, max_length=20)
+    base_failure_fingerprint: str | None = Field(default=None, max_length=200)
+    head_failure_fingerprint: str | None = Field(default=None, max_length=200)
+    blocking: bool = False
+
+    @model_validator(mode="after")
+    def normalize_identifiers(self) -> "RunComparisonItem":
+        object.__setattr__(self, "scenario_id", redact_log_text(self.scenario_id))
+        object.__setattr__(self, "fingerprint", redact_log_text(self.fingerprint))
+        return self
+
+
+class RunComparison(ContractModel):
+    """Behavioral differences between two stored runs of one target."""
+
+    schema_version: Literal["agentcheck.run_comparison.v1"] = (
+        RUN_COMPARISON_CONTRACT_VERSION
+    )
+    base_run_id: str = Field(min_length=1, max_length=120)
+    head_run_id: str = Field(min_length=1, max_length=120)
+    comparability: Comparability
+    incomparable_reason: IncomparableReason | None = None
+    caveats: tuple[ComparabilityCaveat, ...] = ()
+    base_scenario_count: int = Field(ge=0)
+    head_scenario_count: int = Field(ge=0)
+    shared_scenario_count: int = Field(ge=0)
+    base_failure_count: int = Field(ge=0)
+    head_failure_count: int = Field(ge=0)
+    new_regression_count: int = Field(ge=0)
+    changed_failure_count: int = Field(ge=0)
+    resolved_count: int = Field(ge=0)
+    unchanged_failure_count: int = Field(ge=0)
+    uncertifiable_count: int = Field(ge=0)
+    items: tuple[RunComparisonItem, ...] = Field(
+        default=(), max_length=MAX_COMPARISON_ITEMS
+    )
+    omitted_items: int = Field(default=0, ge=0)
+    fingerprint: str = Field(default="", max_length=200)
+
+    def expected_fingerprint(self) -> str:
+        """Return an unkeyed checksum over the redacted comparison content.
+
+        This detects stale or corrupted content. It is not authentication:
+        trust in a comparison comes from re-deriving it from the two stored
+        runs, which is exactly what producing it does.
+        """
+
+        payload = self.model_dump(mode="json", exclude={"fingerprint"})
+        return canonical_hash(redact_artifact(payload))
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> "RunComparison":
+        object.__setattr__(self, "base_run_id", redact_log_text(self.base_run_id))
+        object.__setattr__(self, "head_run_id", redact_log_text(self.head_run_id))
+        caveats = tuple(dict.fromkeys(self.caveats))
+        order = {caveat: index for index, caveat in enumerate(ComparabilityCaveat)}
+        object.__setattr__(
+            self, "caveats", tuple(sorted(caveats, key=lambda item: order[item]))
+        )
+        if self.comparability is Comparability.INCOMPARABLE:
+            if self.incomparable_reason is None:
+                raise ValueError("an incomparable result requires an explicit reason")
+            if self.items or self.omitted_items:
+                raise ValueError(
+                    "an incomparable result must not classify any scenario"
+                )
+        elif self.incomparable_reason is not None:
+            raise ValueError("a comparable result must not carry an incomparable reason")
+        blocking = [item for item in self.items if item.blocking]
+        if any(item.category not in BLOCKING_CATEGORIES for item in blocking):
+            raise ValueError(
+                "only new_regression and changed_failure may be marked blocking"
+            )
+        expected = self.expected_fingerprint()
+        if self.fingerprint and not hmac.compare_digest(self.fingerprint, expected):
+            raise ValueError("run comparison fingerprint does not match its contents")
+        if not self.fingerprint:
+            object.__setattr__(self, "fingerprint", expected)
+        return self
+
+
+__all__ = [
+    "BLOCKING_CATEGORIES",
+    "MAX_COMPARISON_ITEMS",
+    "RUN_COMPARISON_CONTRACT_VERSION",
+    "UNCERTIFIABLE_CATEGORIES",
+    "Comparability",
+    "ComparabilityCaveat",
+    "IncomparableReason",
+    "RunComparison",
+    "RunComparisonCategory",
+    "RunComparisonItem",
+]

--- a/agentcheck/regression/service.py
+++ b/agentcheck/regression/service.py
@@ -1,0 +1,221 @@
+"""Load two stored runs and report their behavioral differences."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from agentcheck.errors import ConfigurationError
+from agentcheck.report.load import load_stored_run
+
+from .compare import compare_runs, exit_code
+from .contract import (
+    ComparabilityCaveat,
+    IncomparableReason,
+    RunComparison,
+)
+
+
+# One sentence per disclosed binding change. Each says what the reader may no
+# longer conclude, not merely that something differed.
+_CAVEAT_TEXT: dict[ComparabilityCaveat, str] = {
+    ComparabilityCaveat.SPEC_CHANGED: (
+        "The inspected agent specification changed between these runs, so a "
+        "verdict difference may describe a different agent rather than a "
+        "behavioral regression in the same one."
+    ),
+    ComparabilityCaveat.SCENARIO_SET_CHANGED: (
+        "The two runs evaluated different scenario sets, so added and removed "
+        "scenarios are expected and are not by themselves evidence of lost "
+        "coverage."
+    ),
+    ComparabilityCaveat.SUITE_FINGERPRINT_CHANGED: (
+        "Both runs recorded a frozen suite fingerprint and they differ, so the "
+        "suite itself changed rather than only which cases ran."
+    ),
+    ComparabilityCaveat.SEED_CHANGED: (
+        "The generation seed changed, so scenario identities may differ for "
+        "reasons unrelated to the agent."
+    ),
+    ComparabilityCaveat.SELECTION_ACTIVE: (
+        "Coverage selection pruned at least one run, so an absent scenario may "
+        "have been excluded before execution rather than removed from the suite."
+    ),
+    ComparabilityCaveat.SOURCE_REVISION_UNRECORDED: (
+        "At least one run recorded no source revision, so a difference cannot "
+        "be attributed to a source change."
+    ),
+    ComparabilityCaveat.SOURCE_REVISION_UNCHANGED: (
+        "Both runs recorded the same source revision, so any difference is "
+        "run-to-run variation of a stochastic execution, not a source change."
+    ),
+    ComparabilityCaveat.SCENARIO_IDENTITY_CHANGED: (
+        "At least one scenario matched by display ID with a different "
+        "structural fingerprint, so its stimulus or oracle changed and its "
+        "verdicts describe different questions."
+    ),
+}
+
+_INCOMPARABLE_TEXT: dict[IncomparableReason, str] = {
+    IncomparableReason.SAME_RUN: (
+        "Both arguments resolved to the same stored run, so there is nothing "
+        "to compare."
+    ),
+    IncomparableReason.NO_SHARED_SCENARIOS: (
+        "The two runs share no scenario identity, so every classification "
+        "would describe the identity change rather than a behavior."
+    ),
+}
+
+# Printed on every comparison, not only on a suspicious one.
+_STOCHASTIC_NOTE = (
+    "A verdict pair is evidence about these two executions. AgentCheck "
+    "reproduces inputs and harness behavior, not model output, so an unchanged "
+    "verdict is not proof that a behavior is stable and a changed verdict is "
+    "not proof that the source caused it. Repeat runs to establish stability."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CheckedRunComparison:
+    comparison: RunComparison
+    exit_code: int
+    summary: str
+
+
+def compare_stored_runs(
+    target: str | Path,
+    *,
+    base_run_id: str,
+    head_run_id: str | None = None,
+    latest: bool = False,
+) -> CheckedRunComparison:
+    """Compare two stored runs of one target without executing anything."""
+
+    if head_run_id and latest:
+        raise ConfigurationError("pass only one of --head and --latest")
+    if not head_run_id and not latest:
+        raise ConfigurationError("pass one of --head or --latest")
+    base = load_stored_run(target, run_id=base_run_id)
+    head = load_stored_run(target, run_id=head_run_id, latest=latest)
+    comparison = compare_runs(base, head)
+    return CheckedRunComparison(
+        comparison=comparison,
+        exit_code=exit_code(comparison),
+        summary=format_run_comparison(comparison),
+    )
+
+
+def encode_run_comparison(comparison: RunComparison) -> str:
+    return json.dumps(
+        comparison.model_dump(mode="json"),
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def format_run_comparison(comparison: RunComparison) -> str:
+    lines = [
+        f"Base run: {comparison.base_run_id}",
+        f"Head run: {comparison.head_run_id}",
+        "",
+        f"Base: {comparison.base_scenario_count} scenarios, "
+        f"{comparison.base_failure_count} failures",
+        f"Head: {comparison.head_scenario_count} scenarios, "
+        f"{comparison.head_failure_count} failures",
+        f"Shared scenario identities: {comparison.shared_scenario_count}",
+    ]
+    reason = comparison.incomparable_reason
+    if reason is not None:
+        lines.extend(
+            [
+                "",
+                "Incomparable: no scenario was classified.",
+                _INCOMPARABLE_TEXT[reason],
+            ]
+        )
+        lines.extend(_caveat_lines(comparison))
+        lines.extend(["", _STOCHASTIC_NOTE])
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "",
+            f"New regressions:     {comparison.new_regression_count}",
+            f"Changed failures:    {comparison.changed_failure_count}",
+            f"Resolved:            {comparison.resolved_count}",
+            f"Unchanged failures:  {comparison.unchanged_failure_count}",
+            f"Uncertifiable:       {comparison.uncertifiable_count}",
+        ]
+    )
+    blocking = [item for item in comparison.items if item.blocking]
+    if blocking:
+        lines.extend(["", "Attributable regressions:"])
+        lines.extend(
+            f"- {item.scenario_id} ({item.fingerprint}) "
+            f"{item.base_verdict or 'absent'} -> {item.head_verdict or 'absent'} "
+            f"[{item.category}]"
+            for item in blocking
+        )
+    uncertifiable = [
+        item
+        for item in comparison.items
+        if item.category in {"infra_change", "uncertifiable_failure"}
+    ]
+    if uncertifiable:
+        lines.extend(
+            [
+                "",
+                "Outcomes AgentCheck could not certify:",
+            ]
+        )
+        lines.extend(
+            f"- {item.scenario_id} ({item.fingerprint}) "
+            f"{item.base_verdict or 'absent'} -> {item.head_verdict or 'absent'} "
+            f"[{item.category}]"
+            for item in uncertifiable
+        )
+    deselected = [
+        item for item in comparison.items if item.category == "deselected_scenario"
+    ]
+    if deselected:
+        lines.extend(
+            [
+                "",
+                f"Excluded before execution in the head run: {len(deselected)}",
+                "These scenarios were never evaluated, so this run holds no "
+                "evidence about them either way.",
+            ]
+        )
+    if comparison.omitted_items:
+        lines.extend(
+            [
+                "",
+                f"{comparison.omitted_items} further scenario detail(s) omitted "
+                "from the bounded comparison record; the counts above are complete.",
+            ]
+        )
+    lines.extend(_caveat_lines(comparison))
+    lines.extend(["", _STOCHASTIC_NOTE])
+    return "\n".join(lines) + "\n"
+
+
+def _caveat_lines(comparison: RunComparison) -> list[str]:
+    if not comparison.caveats:
+        return []
+    lines = ["", "Comparability caveats:"]
+    lines.extend(
+        f"- {caveat.value}: {_CAVEAT_TEXT[caveat]}" for caveat in comparison.caveats
+    )
+    return lines
+
+
+__all__ = [
+    "CheckedRunComparison",
+    "compare_stored_runs",
+    "encode_run_comparison",
+    "format_run_comparison",
+]

--- a/docs/behavioral-regression.md
+++ b/docs/behavioral-regression.md
@@ -1,0 +1,113 @@
+# Behavioral regression comparison
+
+`agentcheck compare` classifies the behavioral differences between two stored
+runs of one target. It reads only stored JSON/JSONL artifacts: it imports
+nothing, executes no target, invokes no tool, and re-derives no verdict.
+
+```bash
+agentcheck compare ./my-agent --base run-2024-06-01 --head run-2024-06-08
+agentcheck compare ./my-agent --base run-2024-06-01 --latest --json
+```
+
+This is not the same tool as `agentcheck baseline check`. A baseline is a
+curated, committed set of accepted failure identities for a CI gate. A run
+comparison answers a different question — *what changed between these two
+executions* — and needs nothing committed.
+
+## Scenario identity, not array position
+
+Scenarios are matched by structural fingerprint. A run can order, select, or
+lint its cases differently, so position is never an identity. A scenario whose
+fingerprint changed is matched by display ID instead and reported as
+`changed_scenario`, because its stimulus or oracle moved and its two verdicts
+answer different questions.
+
+## Categories
+
+| Category | Meaning | Blocks |
+|---|---|---|
+| `new_regression` | Head FAILs a scenario the base did not FAIL | yes |
+| `changed_failure` | Both FAIL, with different failure signatures | yes |
+| `unchanged_failure` | Both FAIL with the same failure signature | no |
+| `resolved_failure` | Base FAILed, head PASSes | no |
+| `uncertifiable_failure` | A FAIL whose identity could not be established | no, exits 2 |
+| `infra_change` | Either side is `INFRA_ERROR` | no, exits 2 |
+| `inconclusive_change` | A verdict moved into or out of `INCONCLUSIVE` | no |
+| `changed_scenario` | Matched by ID with a different fingerprint | no |
+| `new_scenario` / `removed_scenario` | Present on only one side | no |
+| `deselected_scenario` | Absent because the head run's selection excluded it | no |
+| `unchanged` | Same verdict, same identity | no |
+
+`INCONCLUSIVE` and `INFRA_ERROR` never collapse into `PASS`. A `FAIL` that
+became `INCONCLUSIVE` is not a resolved failure: weak evidence is not a pass.
+An `INFRA_ERROR` on either side is never a behavioral regression and never a
+behavioral pass; it exits 2 because AgentCheck could not certify the outcome.
+
+A scenario the head run excluded before execution is `deselected_scenario`, not
+`removed_scenario`: that run holds no evidence about it either way. The reverse
+direction has no separate category, because a scenario the *base* run excluded
+already reports as `new_scenario`, which never blocks and never claims lost
+coverage.
+
+Detail rows are bounded, and blocking and uncertifiable rows are ordered first,
+so a large suite omits only quiet detail. The counts are always computed over
+every scenario, never over the visible rows.
+
+## Comparability
+
+Two runs can differ in ways that change what a verdict difference means. Each
+such binding is reported as an explicit caveat rather than silently ignored:
+
+- `spec_changed` — the inspected specification changed, so a difference may
+  describe a different agent.
+- `scenario_set_changed` — the runs evaluated different scenario sets, so added
+  and removed scenarios are expected.
+- `suite_fingerprint_changed` — both runs recorded a frozen suite fingerprint
+  and they differ.
+- `seed_changed` — scenario identities may differ for reasons unrelated to the
+  agent.
+- `selection_active` — an absent scenario may have been excluded rather than
+  removed.
+- `source_revision_unrecorded` — a difference cannot be attributed to a source
+  change.
+- `source_revision_unchanged` — both runs came from the same source revision,
+  so any difference is run-to-run variation.
+- `scenario_identity_changed` — at least one scenario matched by ID with a
+  different fingerprint.
+
+A comparison is refused outright, with exit code 3 and no scenario
+classification, only when there is nothing to compare: both arguments resolved
+to the same run, or the two runs share no scenario identity at all. Refusing is
+not a clean result.
+
+## Stochastic executions are not deterministic
+
+Every comparison states this, and it is the most important sentence in the
+output:
+
+> A verdict pair is evidence about these two executions. AgentCheck reproduces
+> inputs and harness behavior, not model output, so an unchanged verdict is not
+> proof that a behavior is stable and a changed verdict is not proof that the
+> source caused it. Repeat runs to establish stability.
+
+Replay is source-bound re-execution, not deterministic provider replay. A
+single pair of executions of a stochastic agent cannot establish that a
+behavior is deterministic, and `agentcheck compare` never claims that it does.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Comparison completed with no attributable regression |
+| 1 | At least one `new_regression` or `changed_failure` |
+| 2 | An outcome AgentCheck could not certify (`infra_change`, `uncertifiable_failure`) |
+| 3 | The runs are incomparable |
+
+## Compatibility
+
+`agentcheck.run_comparison.v1` is a new derived contract. It adds no field to
+`Scenario`, `FrozenSuite`, `agentcheck.baseline.v1`,
+`agentcheck.baseline_comparison.v1`, replay manifests, or review records, so no
+existing fingerprint moves. The per-scenario classifier is the one the baseline
+gate already uses, so a repository cannot block on two different definitions of
+"regression".

--- a/tests/agentcheck/test_behavioral_regression.py
+++ b/tests/agentcheck/test_behavioral_regression.py
@@ -1,0 +1,828 @@
+"""Run-to-run behavioral regression comparison.
+
+Every fixture writes ordinary stored artifacts. No test executes a target,
+invokes a tool, or calls a provider.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence, TypeVar
+
+import pytest
+
+from agentcheck.artifacts import ArtifactStore
+from agentcheck.cli import main
+from agentcheck.coverage import (
+    BehavioralCoverageReferenceScope,
+    analyze_behavioral_coverage,
+)
+from agentcheck.domain import (
+    AgentProperty,
+    AgentSpec,
+    AssertionResult,
+    CanonicalRun,
+    CapabilitiesSpec,
+    CaseEvaluation,
+    Evidence,
+    EvidenceKind,
+    IdentitySpec,
+    InfrastructureError,
+    InspectionProvenance,
+    InstructionsSpec,
+    InterfaceSpec,
+    ObservabilitySpec,
+    RunTermination,
+    RuntimeSpec,
+    Scenario,
+    SourceKind,
+    SourceReference,
+    SpecEvidence,
+    ToolsSpec,
+    Verdict,
+    utc_now,
+)
+from agentcheck.errors import ConfigurationError
+from agentcheck.generate import build_account_support_suite
+from agentcheck.generate.selection import SelectionDecision, SelectionPlan
+from agentcheck.regression import (
+    Comparability,
+    ComparabilityCaveat,
+    IncomparableReason,
+    RunComparison,
+    compare_stored_runs,
+)
+from agentcheck.regression.contract import RunComparisonItem
+from agentcheck.report.load import load_stored_run
+
+
+SEED = 1729
+
+
+T = TypeVar("T")
+
+
+def _property(value: T) -> AgentProperty[T]:
+    return AgentProperty(
+        value=value,
+        source=SourceReference(
+            kind=SourceKind.RUNTIME_INTROSPECTION, locator="test"
+        ),
+        confidence=1,
+        evidence=(SpecEvidence(evidence_id="e", summary="test"),),
+    )
+
+
+def _spec(name: str = "Account Support Agent", *, spec_id: str = "spec") -> AgentSpec:
+    return AgentSpec(
+        spec_id=spec_id,
+        identity=IdentitySpec(
+            name=_property(name),
+            framework=_property("OpenAI Agents SDK"),
+            framework_version=_property("0.20.0"),
+            provider=_property(None),
+            model=_property(None),
+        ),
+        interface=InterfaceSpec(
+            entrypoint=_property("agent.py:agent"),
+            input_modalities=_property(("text",)),
+            output_modalities=_property(("text",)),
+            input_schema=_property(None),
+            output_schema=_property(None),
+            interactive=_property(True),
+        ),
+        instructions=InstructionsSpec(
+            system=_property("system"), developer=_property(None)
+        ),
+        capabilities=CapabilitiesSpec(),
+        tools=ToolsSpec(),
+        runtime=RuntimeSpec(
+            max_model_turns=_property(None),
+            max_tool_calls=_property(None),
+            timeout_seconds=_property(None),
+            token_budget=_property(None),
+            cost_budget_usd=_property(None),
+        ),
+        observability=ObservabilitySpec(
+            supported_event_types=_property(("final_output",)),
+            usage_metrics=_property(()),
+            provider_request_ids=_property(False),
+            source_event_links=_property(True),
+        ),
+        provenance=InspectionProvenance(
+            inspector="test",
+            inspector_version="1",
+            inspected_at=utc_now(),
+            target="test",
+            sources=(
+                SourceReference(kind=SourceKind.RUNTIME_INTROSPECTION, locator="test"),
+            ),
+        ),
+    )
+
+
+def _evaluation(
+    scenario_id: str,
+    run_id: str,
+    verdict: Verdict,
+    *,
+    assertion_id: str = "a1",
+) -> CaseEvaluation:
+    now = utc_now()
+    evidence: tuple[Evidence, ...] = ()
+    if verdict is Verdict.FAIL:
+        evidence = (
+            Evidence(
+                evidence_id="evidence-1",
+                kind=EvidenceKind.OUTPUT,
+                summary="Recorded final output.",
+                source_ids=("output-1",),
+            ),
+        )
+        assertions = (
+            AssertionResult(
+                assertion_id=assertion_id,
+                criterion="declared behavior",
+                result=Verdict.FAIL,
+                oracle_ids=("oracle-1",),
+                contradicting_evidence_ids=("evidence-1",),
+                rationale="The declared behavior did not hold.",
+            ),
+        )
+    else:
+        assertions = (
+            AssertionResult(
+                assertion_id=assertion_id,
+                criterion="declared behavior",
+                result=verdict,
+                oracle_ids=("oracle-1",),
+                missing_evidence=(
+                    ("tool_outcome",) if verdict is Verdict.INCONCLUSIVE else ()
+                ),
+                rationale="Recorded outcome.",
+            ),
+        )
+    infrastructure_error = (
+        InfrastructureError(
+            code="worker_timeout",
+            message="The worker exceeded its wall-clock budget.",
+            phase="execute",
+        )
+        if verdict is Verdict.INFRA_ERROR
+        else None
+    )
+    return CaseEvaluation(
+        evaluation_id=f"eval-{scenario_id}",
+        scenario_id=scenario_id,
+        run_id=run_id,
+        verdict=verdict,
+        assertions=assertions,
+        evidence=evidence,
+        started_at=now,
+        completed_at=now,
+        summary=verdict.value,
+        infrastructure_error=infrastructure_error,
+    )
+
+
+def _write_run(
+    root: Path,
+    run_id: str,
+    cases: Sequence[tuple[Scenario, Verdict]],
+    *,
+    spec: AgentSpec | None = None,
+    seed: int = SEED,
+    git_revision: str | None = "revision-a",
+    selection: SelectionPlan | None = None,
+    assertion_id: str = "a1",
+) -> Path:
+    spec = spec or _spec()
+    scenarios = tuple(scenario for scenario, _ in cases)
+    runs = tuple(
+        CanonicalRun(
+            run_id=f"{run_id}-case-{index:03d}",
+            scenario_id=scenario.scenario_id,
+            target_id=spec.spec_id,
+            started_at=utc_now(),
+            ended_at=utc_now(),
+            termination=RunTermination.COMPLETED,
+        )
+        for index, (scenario, _) in enumerate(cases)
+    )
+    evaluations = tuple(
+        _evaluation(
+            scenario.scenario_id,
+            runs[index].run_id,
+            verdict,
+            assertion_id=assertion_id,
+        )
+        for index, (scenario, verdict) in enumerate(cases)
+    )
+    counts = {verdict.value: 0 for verdict in Verdict}
+    for _, verdict in cases:
+        counts[verdict.value] += 1
+    reference_scope = (
+        BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+        if selection is not None and selection.excluded_ids
+        else BehavioralCoverageReferenceScope.COMPLETE
+    )
+    coverage = analyze_behavioral_coverage(
+        spec, scenarios, reference_scope=reference_scope
+    )
+    artifacts = ArtifactStore(root, ".agentcheck", run_id)
+    artifacts.write_json("agent-spec.json", spec)
+    artifacts.write_json(
+        "suite.json",
+        {
+            "schema_version": "agentcheck.suite.v1",
+            "run_id": run_id,
+            "seed": seed,
+            "scenarios": list(scenarios),
+        },
+    )
+    artifacts.write_json(
+        "invalid-scenarios.json",
+        {"schema_version": "agentcheck.invalid_scenarios.v1", "items": []},
+    )
+    artifacts.write_jsonl("runs.jsonl", runs)
+    artifacts.write_jsonl("evaluations.jsonl", evaluations)
+    artifacts.write_json("findings.json", ())
+    summary: dict[str, object] = {
+        "schema_version": "agentcheck.summary.v1",
+        "run_id": run_id,
+        "target": str(root),
+        "git_revision": git_revision,
+        "suite_size": len(scenarios),
+        "invalid_scenarios": 0,
+        "observed_suite_pass_rate": (
+            counts["PASS"] / len(cases) if cases else None
+        ),
+        "counts": counts,
+        "finding_count": 0,
+        "seed": seed,
+        "behavioral_coverage": coverage.model_dump(mode="json"),
+    }
+    if selection is not None:
+        summary["selection"] = selection.model_dump(mode="json")
+        summary["excluded_by_selection"] = len(selection.excluded_ids)
+    artifacts.write_json("summary.json", summary)
+    artifacts.write_text("report.html", "<html><body>placeholder</body></html>")
+    return artifacts.root
+
+
+def _selection_for(selected: Sequence[str], excluded: Sequence[str]) -> SelectionPlan:
+    return SelectionPlan(
+        selected_ids=tuple(selected),
+        excluded_ids=tuple(excluded),
+        decisions=(
+            *(
+                SelectionDecision(
+                    scenario_id=scenario_id, selected=True, reason="selected"
+                )
+                for scenario_id in selected
+            ),
+            *(
+                SelectionDecision(
+                    scenario_id=scenario_id, selected=False, reason="excluded"
+                )
+                for scenario_id in excluded
+            ),
+        ),
+    )
+
+
+def _compare(root: Path, base: str, head: str) -> RunComparison:
+    return compare_stored_runs(root, base_run_id=base, head_run_id=head).comparison
+
+
+def _item(comparison: RunComparison, scenario_id: str) -> RunComparisonItem:
+    return next(
+        item for item in comparison.items if item.scenario_id == scenario_id
+    )
+
+
+@pytest.fixture
+def suite() -> tuple[Scenario, ...]:
+    return build_account_support_suite(seed=SEED)[:3]
+
+
+def test_identical_runs_report_no_regression(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases)
+    _write_run(tmp_path, "head", cases)
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert checked.comparison.comparability is Comparability.COMPARABLE
+    assert checked.comparison.new_regression_count == 0
+    assert checked.comparison.shared_scenario_count == len(suite)
+    assert all(item.category == "unchanged" for item in checked.comparison.items)
+    assert checked.exit_code == 0
+    # Identical scenario digests mean the same scenario set ran, so no
+    # denominator caveat is warranted.
+    assert ComparabilityCaveat.SCENARIO_SET_CHANGED not in checked.comparison.caveats
+
+
+def test_pass_to_fail_on_the_same_identity_is_an_attributable_regression(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+        git_revision="revision-b",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+    item = _item(checked.comparison, suite[0].scenario_id)
+
+    assert item.category == "new_regression"
+    assert item.blocking is True
+    assert item.base_verdict == "PASS"
+    assert item.head_verdict == "FAIL"
+    assert checked.comparison.new_regression_count == 1
+    assert checked.exit_code == 1
+
+
+def test_fail_to_pass_is_resolved_and_does_not_block(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(
+        tmp_path,
+        "base",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+    )
+    _write_run(
+        tmp_path,
+        "head",
+        tuple((s, Verdict.PASS) for s in suite),
+        git_revision="revision-b",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert _item(checked.comparison, suite[0].scenario_id).category == "resolved_failure"
+    assert checked.comparison.resolved_count == 1
+    assert checked.exit_code == 0
+
+
+def test_infra_error_is_never_a_regression_and_never_a_pass(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.INFRA_ERROR), *((s, Verdict.PASS) for s in suite[1:])),
+        git_revision="revision-b",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+    item = _item(checked.comparison, suite[0].scenario_id)
+
+    assert item.category == "infra_change"
+    assert item.blocking is False
+    assert checked.comparison.new_regression_count == 0
+    assert checked.comparison.resolved_count == 0
+    # An outcome AgentCheck could not certify is neither clean nor a regression.
+    assert checked.exit_code == 2
+
+
+def test_fail_to_inconclusive_does_not_resolve_a_failure(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(
+        tmp_path,
+        "base",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+    )
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.INCONCLUSIVE), *((s, Verdict.PASS) for s in suite[1:])),
+        git_revision="revision-b",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert (
+        _item(checked.comparison, suite[0].scenario_id).category
+        == "inconclusive_change"
+    )
+    assert checked.comparison.resolved_count == 0
+    assert checked.exit_code == 0
+
+
+def test_scenarios_match_by_fingerprint_not_array_position(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    reordered = tuple(reversed(suite))
+    _write_run(
+        tmp_path,
+        "head",
+        tuple((s, Verdict.PASS) for s in reordered),
+        git_revision="revision-b",
+    )
+
+    comparison = _compare(tmp_path, "base", "head")
+
+    assert comparison.comparability is Comparability.COMPARABLE
+    assert {item.category for item in comparison.items} == {"unchanged"}
+    assert comparison.shared_scenario_count == len(suite)
+
+
+def test_changed_failure_signature_is_reported_separately(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(
+        tmp_path,
+        "base",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+        assertion_id="assertion-one",
+    )
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+        git_revision="revision-b",
+        assertion_id="assertion-two",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+    item = _item(checked.comparison, suite[0].scenario_id)
+
+    assert item.category == "changed_failure"
+    assert item.blocking is True
+    assert item.base_failure_fingerprint != item.head_failure_fingerprint
+    assert checked.exit_code == 1
+
+
+def test_unchanged_failure_signature_does_not_block(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    cases = ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:]))
+    _write_run(tmp_path, "base", cases)
+    _write_run(tmp_path, "head", cases, git_revision="revision-b")
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert (
+        _item(checked.comparison, suite[0].scenario_id).category
+        == "unchanged_failure"
+    )
+    assert checked.comparison.unchanged_failure_count == 1
+    assert checked.exit_code == 0
+
+
+def test_added_and_removed_scenarios_are_reported_without_blocking(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite[:2]))
+    _write_run(
+        tmp_path,
+        "head",
+        tuple((s, Verdict.PASS) for s in suite[1:]),
+        git_revision="revision-b",
+    )
+
+    comparison = _compare(tmp_path, "base", "head")
+
+    assert _item(comparison, suite[0].scenario_id).category == "removed_scenario"
+    assert _item(comparison, suite[2].scenario_id).category == "new_scenario"
+    assert not any(item.blocking for item in comparison.items)
+    assert ComparabilityCaveat.SCENARIO_SET_CHANGED in comparison.caveats
+
+
+def test_a_scenario_excluded_by_selection_is_deselected_not_removed(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    # The head run never evaluated this scenario, so reporting it as removed
+    # would claim a suite change that did not happen.
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite[:2]))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[1], Verdict.PASS),),
+        git_revision="revision-b",
+        selection=_selection_for(
+            (suite[1].scenario_id,), (suite[0].scenario_id,)
+        ),
+    )
+
+    comparison = _compare(tmp_path, "base", "head")
+    item = _item(comparison, suite[0].scenario_id)
+
+    assert item.category == "deselected_scenario"
+    assert item.blocking is False
+    assert ComparabilityCaveat.SELECTION_ACTIVE in comparison.caveats
+
+
+def test_two_runs_without_a_shared_identity_are_incomparable(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", ((suite[0], Verdict.PASS),))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[1], Verdict.FAIL),),
+        git_revision="revision-b",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert checked.comparison.comparability is Comparability.INCOMPARABLE
+    assert (
+        checked.comparison.incomparable_reason
+        is IncomparableReason.NO_SHARED_SCENARIOS
+    )
+    assert checked.comparison.items == ()
+    # A comparison that could not be made is never a clean result.
+    assert checked.exit_code == 3
+    assert "Incomparable" in checked.summary
+
+
+def test_comparing_a_run_to_itself_is_incomparable(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="base")
+
+    assert checked.comparison.incomparable_reason is IncomparableReason.SAME_RUN
+    assert checked.comparison.items == ()
+    assert checked.exit_code == 3
+
+
+def test_an_unchanged_source_revision_discloses_stochastic_variation(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    # Same source, different verdict: this is run-to-run variation, and the
+    # comparison must not let a reader attribute it to a code change.
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+        git_revision="revision-a",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert (
+        ComparabilityCaveat.SOURCE_REVISION_UNCHANGED in checked.comparison.caveats
+    )
+    assert "run-to-run variation" in checked.summary
+    # It is still reported: disclosure is not suppression.
+    assert checked.comparison.new_regression_count == 1
+
+
+def test_a_missing_source_revision_is_disclosed(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        tuple((s, Verdict.PASS) for s in suite),
+        git_revision=None,
+    )
+
+    comparison = _compare(tmp_path, "base", "head")
+
+    assert ComparabilityCaveat.SOURCE_REVISION_UNRECORDED in comparison.caveats
+
+
+def test_a_changed_spec_is_disclosed_but_shared_identities_still_compare(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+        spec=_spec("Renamed Agent", spec_id="other-spec"),
+        git_revision="revision-b",
+    )
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert ComparabilityCaveat.SPEC_CHANGED in checked.comparison.caveats
+    # A scenario whose fingerprint is unchanged asked the same question of both
+    # runs, so its verdict change is still real evidence.
+    assert _item(checked.comparison, suite[0].scenario_id).category == "new_regression"
+    assert "different agent" in checked.summary
+
+
+def test_a_changed_seed_is_disclosed(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        tuple((s, Verdict.PASS) for s in suite),
+        seed=SEED + 1,
+        git_revision="revision-b",
+    )
+
+    comparison = _compare(tmp_path, "base", "head")
+
+    assert ComparabilityCaveat.SEED_CHANGED in comparison.caveats
+
+
+def test_every_summary_states_that_a_verdict_pair_is_not_determinism(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases)
+    _write_run(tmp_path, "head", cases)
+    _write_run(tmp_path, "unrelated", ((suite[0], Verdict.PASS),))
+
+    clean = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+    incomparable = compare_stored_runs(
+        tmp_path, base_run_id="base", head_run_id="base"
+    )
+
+    for summary in (clean.summary, incomparable.summary):
+        assert "not proof that a behavior is stable" in summary
+        assert "not model output" in summary
+
+
+def test_comparison_fingerprint_detects_altered_content(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases)
+    _write_run(tmp_path, "head", cases)
+    comparison = _compare(tmp_path, "base", "head")
+    document = comparison.model_dump(mode="json")
+    document["new_regression_count"] = 5
+
+    with pytest.raises(ValueError, match="fingerprint does not match"):
+        RunComparison.model_validate_json(json.dumps(document))
+
+
+def test_only_a_regression_category_may_block(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    with pytest.raises(ValueError, match="may be marked blocking"):
+        RunComparison(
+            base_run_id="base",
+            head_run_id="head",
+            comparability=Comparability.COMPARABLE,
+            base_scenario_count=1,
+            head_scenario_count=1,
+            shared_scenario_count=1,
+            base_failure_count=0,
+            head_failure_count=0,
+            new_regression_count=0,
+            changed_failure_count=0,
+            resolved_count=0,
+            unchanged_failure_count=0,
+            uncertifiable_count=0,
+            items=(
+                RunComparisonItem(
+                    category="unchanged",
+                    scenario_id="s",
+                    fingerprint="sha256:abc",
+                    blocking=True,
+                ),
+            ),
+        )
+
+
+def test_an_incomparable_result_classifies_nothing() -> None:
+    with pytest.raises(ValueError, match="must not classify any scenario"):
+        RunComparison(
+            base_run_id="base",
+            head_run_id="head",
+            comparability=Comparability.INCOMPARABLE,
+            incomparable_reason=IncomparableReason.SAME_RUN,
+            base_scenario_count=1,
+            head_scenario_count=1,
+            shared_scenario_count=1,
+            base_failure_count=0,
+            head_failure_count=0,
+            new_regression_count=0,
+            changed_failure_count=0,
+            resolved_count=0,
+            unchanged_failure_count=0,
+            uncertifiable_count=0,
+            items=(
+                RunComparisonItem(
+                    category="unchanged",
+                    scenario_id="s",
+                    fingerprint="sha256:abc",
+                ),
+            ),
+        )
+
+
+def test_credential_shaped_identifiers_are_redacted() -> None:
+    item = RunComparisonItem(
+        category="unchanged",
+        scenario_id="sk-secretvalue123",
+        fingerprint="sha256:abc",
+    )
+
+    assert "sk-secretvalue123" not in item.scenario_id
+    assert "[REDACTED]" in item.scenario_id
+
+
+def test_comparison_requires_exactly_one_head_selector(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+
+    with pytest.raises(ConfigurationError, match="one of --head or --latest"):
+        compare_stored_runs(tmp_path, base_run_id="base")
+    with pytest.raises(ConfigurationError, match="only one of --head and --latest"):
+        compare_stored_runs(
+            tmp_path, base_run_id="base", head_run_id="base", latest=True
+        )
+
+
+def test_cli_compare_reports_a_regression_and_emits_the_contract(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_run(tmp_path, "base", tuple((s, Verdict.PASS) for s in suite))
+    _write_run(
+        tmp_path,
+        "head",
+        ((suite[0], Verdict.FAIL), *((s, Verdict.PASS) for s in suite[1:])),
+        git_revision="revision-b",
+    )
+
+    code = main(
+        [
+            "compare",
+            str(tmp_path),
+            "--base",
+            "base",
+            "--head",
+            "head",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    # The human summary goes to stderr so stdout stays a clean contract stream.
+    document = json.loads(captured.out)
+    assert document["schema_version"] == "agentcheck.run_comparison.v1"
+    assert document["new_regression_count"] == 1
+    assert document["comparability"] == "comparable"
+    assert "New regressions:" in captured.err
+
+
+def test_cli_compare_exits_three_when_runs_are_incomparable(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_run(tmp_path, "base", ((suite[0], Verdict.PASS),))
+    _write_run(tmp_path, "head", ((suite[1], Verdict.PASS),))
+
+    code = main(["compare", str(tmp_path), "--base", "base", "--head", "head"])
+
+    assert code == 3
+    assert "Incomparable" in capsys.readouterr().out
+
+
+def test_cli_compare_accepts_latest_as_the_head_run(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases)
+    _write_run(tmp_path, "head", cases)
+
+    code = main(["compare", str(tmp_path), "--base", "base", "--latest"])
+
+    assert code == 0
+    assert "Base run: base" in capsys.readouterr().out
+
+
+def test_comparison_never_reads_the_configured_suite_file(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    # A frozen suite written after both runs must not become a comparison
+    # input; suite identity comes from what each run recorded for itself.
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases)
+    _write_run(tmp_path, "head", cases)
+    before = _compare(tmp_path, "base", "head")
+
+    loaded = load_stored_run(tmp_path, run_id="base")
+    assert loaded.frozen_suite is None
+
+    after = _compare(tmp_path, "base", "head")
+    assert after == before

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -45,6 +45,10 @@ COMPATIBILITY_SUITE: dict[str, dict[str, object]] = {
             "tests/agentcheck/test_artifacts.py",
             "tests/agentcheck/test_suite_compatibility.py",
             "tests/agentcheck/test_behavioral_coverage.py",
+            # The run comparison contract types one field as a union of
+            # Literals resolved from a string annotation, which is exactly the
+            # typing surface that can differ between interpreters.
+            "tests/agentcheck/test_behavioral_regression.py",
         ),
         "symbols": ("fingerprint", "model_dump", "IncompatibleSuiteError", "redact"),
     },


### PR DESCRIPTION
## What

Adds `agentcheck compare` — a semantic **run-to-run behavioral regression
comparison** over stored artifacts.

```bash
agentcheck compare ./my-agent --base run-2024-06-01 --head run-2024-06-08
agentcheck compare ./my-agent --base run-2024-06-01 --latest --json
```

It reads only stored JSON/JSONL run artifacts: it imports no target, executes
nothing, invokes no tool, and re-derives no verdict.

This is **not** the baseline gate. `agentcheck baseline check` compares a run to
a curated, committed set of accepted failure identities. This answers a
different question — *what changed between these two executions* — and needs
nothing committed.

## Identity, not position

Scenarios are matched by structural fingerprint, then by display ID for a
scenario whose content changed (reported as `changed_scenario`). Array position
is never an identity: two runs of the same suite can order, select, or lint
their cases differently. A test reverses the scenario order in one run and
asserts every case still classifies as `unchanged`.

## One definition of "regression"

The per-scenario classifier is the one `agentcheck baseline check` already uses,
and the blocking / uncertifiable category tuples are **imported** from the
baseline contract rather than restated, so a repository cannot block on two
competing definitions.

Run-to-run adds exactly one distinction a curated baseline cannot make:
`deselected_scenario`. A scenario the head run excluded before execution was
never evaluated, so reporting it as `removed_scenario` would claim a suite
change that did not happen.

## Verdict classes stay distinct

- `FAIL` → `INCONCLUSIVE` is **not** `resolved_failure`. Weak evidence is not a
  pass.
- `INFRA_ERROR` on either side is neither a behavioral regression nor a
  behavioral pass. It exits 2, because AgentCheck could not certify the outcome.
- A `FAIL` whose identity could not be established is `uncertifiable_failure`,
  not silently unchanged.

## Comparability is reported, not assumed

Bindings that change what a verdict difference *means* are disclosed as explicit
caveats: `spec_changed`, `scenario_set_changed`, `suite_fingerprint_changed`,
`seed_changed`, `selection_active`, `source_revision_unrecorded`,
`source_revision_unchanged`, `scenario_identity_changed`.

Every binding comes from **what each run recorded for itself**. The currently
configured spec and frozen suite files can postdate either run and are never
comparison inputs; suite identity uses the per-run behavioral-coverage scenario
digest, which is recorded even for a run that used no frozen suite.

A comparison is refused outright — exit 3, no classification — only when there
is nothing to compare: the same run twice, or no shared scenario identity.
Refusing is never reported as a clean result.

## Stochastic executions are not deterministic

Every comparison, including a refused one, ends with:

> A verdict pair is evidence about these two executions. AgentCheck reproduces
> inputs and harness behavior, not model output, so an unchanged verdict is not
> proof that a behavior is stable and a changed verdict is not proof that the
> source caused it. Repeat runs to establish stability.

A test asserts this sentence appears on both the comparable and the incomparable
path.

## Exit codes

`0` no attributable regression · `1` regression · `2` uncertifiable outcome ·
`3` incomparable. Same vocabulary as `agentcheck test`.

## Compatibility

`agentcheck.run_comparison.v1` is a new derived contract. It adds no field to
`Scenario`, `FrozenSuite`, `agentcheck.baseline.v1`,
`agentcheck.baseline_comparison.v1`, replay manifests, or review records, so no
existing fingerprint moves. Detail rows are bounded one below the artifact
redaction item limit, so the redacted view the document hashes is lossless —
a checksum is never blind to a row the document carries. Counts are always
computed over every scenario, never over the visible rows.

Also records `agentcheck/coverage/` and `agentcheck/regression/` in the AGENTS.md
layout table, and adds the new tests to the cross-version compatibility manifest.

## Validation

- `python -m pytest tests -q -n 2` — full suite green
- `python -m ruff check agentcheck tests scripts` — clean
- `python -m mypy agentcheck` — clean
- New: `tests/agentcheck/test_behavioral_regression.py` (26 cases)
- Verified against two real runs of the bundled example agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
