### PR TITLE
fix: bind a stored run to the suite it recorded executing

### DIFF
--- a/agentcheck/report/load.py
+++ b/agentcheck/report/load.py
@@ -7,6 +7,7 @@ never makes a network call.
 
 from __future__ import annotations
 
+import hmac
 import json
 import os
 import re
@@ -174,7 +175,15 @@ def load_stored_run(
         filename="runs.jsonl",
     )
     findings = _load_findings(directory / "findings.json")
-    frozen = _optional_frozen_suite(root, config, spec)
+    frozen = _optional_frozen_suite(
+        root,
+        config,
+        spec,
+        # The run's own record of which suite it executed. A run that used no
+        # frozen suite, and a run written before that identity was recorded,
+        # both leave this None and stay unbound.
+        recorded_fingerprint=behavioral_coverage.suite_fingerprint,
+    )
     return LoadedRun(
         root=root,
         config=config,
@@ -202,9 +211,11 @@ def render_stored_run(
 ) -> StoredReport:
     loaded = load_stored_run(target, run_id=run_id, latest=latest)
     reviews = load_reviews_for_run(loaded.root, loaded.config, loaded.run_id)
-    # This configured frozen suite may postdate the stored run. It remains
-    # useful display metadata, but must not become a new source binding after
-    # the loader has verified coverage against the persisted artifacts.
+    # The loader has already verified coverage against the persisted artifacts,
+    # and any attached frozen suite is the one this run recorded executing.
+    # What a stored run cannot supply is the cases selection discarded before
+    # persistence, so the complete requirement universe is not reconstructable
+    # here and must not be demanded again.
     html = render_report(
         run_id=loaded.run_id,
         target=str(loaded.root),
@@ -327,9 +338,34 @@ def _report_destination(loaded: LoadedRun, out: str | None) -> Path:
     return destination
 
 
+def _digest_equal(left: str, right: str) -> bool:
+    left_bytes = left.encode("utf-8")
+    right_bytes = right.encode("utf-8")
+    if len(left_bytes) != len(right_bytes):
+        hmac.compare_digest(left_bytes, left_bytes)
+        return False
+    return hmac.compare_digest(left_bytes, right_bytes)
+
+
 def _optional_frozen_suite(
-    root: Path, config: AgentCheckConfig, spec: AgentSpec
+    root: Path,
+    config: AgentCheckConfig,
+    spec: AgentSpec,
+    *,
+    recorded_fingerprint: str | None,
 ) -> FrozenSuite | None:
+    """Return the configured suite only when this run recorded executing it.
+
+    The configured file can postdate the run: regenerating a suite keeps the
+    same ``spec_id`` while changing its cases, seed, and policy packs. Binding
+    on ``spec_id`` alone let a baseline claim suite provenance the run never
+    had, and attached another suite's case lineage to this run's scenarios.
+    A run whose suite identity is unrecorded is left unbound rather than
+    matched to whatever happens to be on disk.
+    """
+
+    if recorded_fingerprint is None:
+        return None
     try:
         configured = configured_frozen_suite(root, config)
     except ConfigurationError:
@@ -338,6 +374,8 @@ def _optional_frozen_suite(
         return None
     _, frozen = configured
     if frozen.spec_id != spec.spec_id:
+        return None
+    if not _digest_equal(frozen.fingerprint, recorded_fingerprint):
         return None
     return frozen
 

--- a/docs/behavioral-coverage.md
+++ b/docs/behavioral-coverage.md
@@ -151,6 +151,16 @@ The CLI prints the same family counts and uncovered subjects after `generate`
 and `test`. Collections are bounded before they reach the artifact boundary;
 omitted-item counts remain explicit.
 
+## Suite identity is a source binding
+
+The recorded `suite_fingerprint` is the run's own record of which frozen suite
+it executed. AgentCheck binds a stored run to a suite file only when that
+fingerprint matches: regenerating a suite keeps the same `spec_id` while
+changing its cases, seed, and policy packs, so matching on `spec_id` alone
+would let a later document inherit provenance the run never had. A run whose
+suite identity is unrecorded is left unbound rather than matched to whatever
+happens to be on disk.
+
 ## Compatibility
 
 Behavioral coverage is derived report metadata. It adds no field to `Scenario`,

--- a/tests/agentcheck/test_baseline.py
+++ b/tests/agentcheck/test_baseline.py
@@ -14,6 +14,16 @@ from agentcheck.baseline import (
     format_comparison,
 )
 from agentcheck.baseline.build import baseline_from_loaded
+from agentcheck.coverage import analyze_behavioral_coverage
+from agentcheck.generate import (
+    DEFAULT_SUITE_FILENAME,
+    CaseLineage,
+    CaseOrigin,
+    FrozenCase,
+    FrozenSuite,
+    write_frozen_suite,
+)
+from agentcheck.generate.suite import GeneratorProvenance
 from agentcheck.baseline.service import check_baseline, create_baseline
 from agentcheck.cli import main
 from agentcheck.domain import (
@@ -1103,3 +1113,81 @@ def test_cli_help_documents_no_execution(capsys: pytest.CaptureFixture[str]) -> 
     assert "never import the target" in help_text
     assert "never spawn a worker" in help_text
     assert "never implicitly accepted" in help_text
+
+
+def _write_frozen_suite(
+    root: Path, spec: AgentSpec, scenario: Scenario, *, seed: int
+) -> str:
+    suite = FrozenSuite(
+        spec_id=spec.spec_id,
+        seed=seed,
+        provenance=GeneratorProvenance(
+            generator="test", generator_version="1", sources=("test",)
+        ),
+        cases=(
+            FrozenCase(
+                scenario=scenario, lineage=CaseLineage(origin=CaseOrigin.BUILT_IN)
+            ),
+        ),
+    )
+    write_frozen_suite(root / DEFAULT_SUITE_FILENAME, suite, force=True)
+    return suite.fingerprint
+
+
+def test_a_regenerated_suite_never_supplies_another_runs_provenance(
+    tmp_path: Path,
+) -> None:
+    # Regenerating a suite keeps the same spec_id while changing its cases and
+    # seed. A baseline is a trusted CI document, so it must never inherit the
+    # identity of a suite the run it snapshots did not execute.
+    root = tmp_path / "target"
+    root.mkdir()
+    scenario = build_account_support_suite(seed=SEED)[0]
+    spec = _spec()
+    directory = _write_run(
+        root, "run-a", [(scenario, _pass_evaluation(scenario.scenario_id, "r1"))]
+    )
+    executed = _write_frozen_suite(root, spec, scenario, seed=SEED)
+
+    summary_path = directory / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["behavioral_coverage"] = analyze_behavioral_coverage(
+        spec, (scenario,), suite_fingerprint=executed
+    ).model_dump(mode="json")
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    bound = baseline_from_loaded(load_stored_run(root, run_id="run-a"))
+    assert bound.suite_fingerprint == executed
+
+    # The same run, after the suite on disk was regenerated.
+    replaced = _write_frozen_suite(root, spec, scenario, seed=SEED + 1)
+    assert replaced != executed
+
+    unbound = baseline_from_loaded(load_stored_run(root, run_id="run-a"))
+    assert unbound.suite_fingerprint is None
+    assert unbound.suite_id is None
+    assert unbound.suite_fingerprint != replaced
+    # The snapshot itself is unchanged; only the unearned provenance is gone.
+    assert unbound.cases == bound.cases
+
+
+def test_a_run_without_recorded_suite_identity_stays_unbound(
+    tmp_path: Path,
+) -> None:
+    # A summary written before suite identity was recorded cannot show which
+    # suite ran, so it is left unbound rather than matched to whatever happens
+    # to be on disk.
+    root = tmp_path / "target"
+    root.mkdir()
+    scenario = build_account_support_suite(seed=SEED)[0]
+    spec = _spec()
+    _write_run(
+        root, "run-legacy", [(scenario, _pass_evaluation(scenario.scenario_id, "r1"))]
+    )
+    _write_frozen_suite(root, spec, scenario, seed=SEED)
+
+    loaded = load_stored_run(root, run_id="run-legacy")
+
+    assert loaded.behavioral_coverage.suite_fingerprint is None
+    assert loaded.frozen_suite is None
+    assert baseline_from_loaded(loaded).suite_fingerprint is None


### PR DESCRIPTION
## The bug

A stored run was matched to whatever frozen suite happened to be on disk, keyed
on `spec_id` alone. Regenerating a suite keeps the same `spec_id` while changing
its cases, seed, and policy packs — so the loader attached a suite the run had
never executed.

`baseline_from_loaded` reads `suite_id`, `suite_fingerprint`, and
`policy_pack_ids` from that suite. An **evaluation baseline is a document whose
entire purpose is to be trusted in CI**, and it could be stamped with source
bindings the run never had.

Reproduced on the bundled example:

```bash
agentcheck generate examples/evaluation/account_agent --seed 1729   # suite A
agentcheck test    examples/evaluation/account_agent --run-id run-on-suite-a
agentcheck generate examples/evaluation/account_agent --seed 999 --force  # suite B
agentcheck baseline create examples/evaluation/account_agent --run-id run-on-suite-a
```

Before this change the baseline records:

```
created_from_run_id: run-on-suite-a
suite_id           : frozensuite-b9aa5e7f2e3e5258ef52d974   <- suite B
suite_fingerprint  : sha256:b9aa5e7f2e3e5258e…              <- suite B
seed               : 1729                                    <- the real run
```

The document contradicts itself: suite B was generated with seed 999.

The HTML report was affected too — another suite's case lineage, policy packs,
and suite coverage were rendered against this run's scenarios.

## The fix

Bind on the run's own recorded suite fingerprint. #28 records that identity per
run, so the loader can now check it instead of guessing from disk.

A run that used no frozen suite, and a run written before that identity was
recorded, both stay **unbound** rather than being matched to whatever is
present. The report already prints `not recorded in this run` for that case,
which is the honest answer; a baseline now omits suite identity rather than
claiming an unearned one.

The snapshot content is unchanged — `cases` are byte-identical before and after.
Only provenance the run did not earn is removed.

Also corrects the comment on `render_stored_run`'s coverage-binding exemption.
It claimed the suite may postdate the run, which this change makes false; what a
stored run genuinely cannot reconstruct is the cases selection discarded before
persistence.

## Compatibility

No serialized contract changes and no fingerprint moves. `EvaluationBaseline`
already declared `suite_id` and `suite_fingerprint` optional and omits them when
absent, so a baseline created from an unbindable run is a valid
`agentcheck.baseline.v1` document. `check_baseline` compares `spec_id`, not
suite identity, so existing gates behave the same.

## Validation

- `python -m pytest tests -q -n 2` — 1231 passed
- `python -m ruff check agentcheck tests scripts` / `python -m mypy agentcheck` — clean
- Two new tests in `tests/agentcheck/test_baseline.py`; both **fail without the
  fix** and pass with it
- Verified end to end against the repro above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
