### PR TITLE
feat: make target identity portable across checkout locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Breaking any of these is a correctness bug, not a style issue:
 | `agentcheck/replay/` | Manifests, source binding, filesets. |
 | `agentcheck/report/`, `agentcheck/baseline/`, `agentcheck/review/` | Reporting, CI gating, human decisions on findings. |
 | `agentcheck/regression/` | Run-to-run behavioral comparison over stored artifacts. Executes nothing. |
+| `agentcheck/identity.py` | Portable target identity and its bounded legacy compatibility path. |
 | `agentcheck/redaction.py`, `agentcheck/privacy.py` | Credential redaction for artifacts and logs. |
 | `agentcheck/cli.py` | The `agentcheck` command. |
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ and read the [CI trust model](docs/ci-trust-model.md).
 - [PydanticAI setup and offline evaluation](docs/pydantic-ai.md)
 - [Custom Python agent contract](docs/custom-agents.md)
 - [Validation evidence and claim boundaries](docs/validation-evidence.md)
+- [Portable target identity](docs/portable-identity.md)
 - [Declared behavioral coverage](docs/behavioral-coverage.md)
 - [Behavioral regression comparison](docs/behavioral-regression.md)
 - [CI trust model](docs/ci-trust-model.md)

--- a/agentcheck/adapters/base.py
+++ b/agentcheck/adapters/base.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from importlib import metadata as importlib_metadata
 from typing import TYPE_CHECKING, Any, Awaitable, Protocol, runtime_checkable
 
+from agentcheck.domain import canonical_hash
+
 if TYPE_CHECKING:
     from agentcheck.domain.agent_spec import AgentSpec
     from agentcheck.domain.run import CanonicalRun
@@ -299,14 +301,60 @@ class PreparedTarget:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+def portable_identity(
+    fingerprint: dict[str, Any],
+    *,
+    location_locator: str | None,
+    identity_locator: str | None,
+) -> tuple[str, str | None]:
+    """Return ``(spec_id, legacy_spec_id)`` for one inspected fingerprint.
+
+    ``fingerprint`` arrives with every semantic input already populated: name,
+    framework version, model, instructions digest, declared tools, and any
+    handoff graph. Only the locator differs between the two identities, so the
+    legacy value is the same semantic surface hashed with the location-bound
+    locator restored.
+
+    Returning the legacy identity is what lets an artifact created before this
+    contract still be recognized at the location that produced it, without ever
+    treating a different location as equivalent. When no portable locator was
+    supplied there is no separate legacy identity to record.
+    """
+
+    if identity_locator is None:
+        return _spec_id(fingerprint, location_locator), None
+    portable = _spec_id(fingerprint, identity_locator)
+    legacy = _spec_id(fingerprint, location_locator)
+    return portable, (None if legacy == portable else legacy)
+
+
+def _spec_id(fingerprint: dict[str, Any], locator: str | None) -> str:
+    # canonical_hash sorts keys, so replacing the locator reproduces the exact
+    # bytes the location-bound contract hashed.
+    return f"agentspec-{canonical_hash({**fingerprint, 'source': locator}).split(':', 1)[1][:24]}"
+
+
 class FrameworkAdapter(ABC):
     """Contract implemented by every supported agent framework."""
 
     framework: str
 
     @abstractmethod
-    def inspect(self, target: Any, *, source: str | None = None) -> "AgentSpec":
-        """Extract an explicit, versioned specification without running the model."""
+    def inspect(
+        self,
+        target: Any,
+        *,
+        source: str | None = None,
+        identity_locator: str | None = None,
+    ) -> "AgentSpec":
+        """Extract an explicit, versioned specification without running the model.
+
+        ``source`` locates the target for evidence and diagnostics and may be an
+        absolute path. ``identity_locator`` is the portable entrypoint, relative
+        to the target root, and is the only locator allowed to influence
+        ``spec_id``. When it is omitted the caller has not established a target
+        root, so identity falls back to ``source`` and stays location-bound.
+        """
 
     @abstractmethod
     def preflight(self, target: Any) -> PreflightReport:
@@ -321,6 +369,7 @@ class FrameworkAdapter(ABC):
         world_state: Any = None,
         event_sink: EventSinkProtocol | None = None,
         source: str | None = None,
+        identity_locator: str | None = None,
         controlled_model: bool = False,
     ) -> PreparedTarget:
         """Return a sanitized runtime target or fail before model execution.

--- a/agentcheck/adapters/custom.py
+++ b/agentcheck/adapters/custom.py
@@ -89,6 +89,7 @@ from agentcheck.runner.tool_gateway import ToolCallBlockedError
 from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
 
 from .base import (
+    portable_identity,
     AdapterRuntimeError,
     EventSinkProtocol,
     FrameworkAdapter,
@@ -691,7 +692,13 @@ class CustomAgentAdapter(FrameworkAdapter):
 
     # -- inspection ---------------------------------------------------------
 
-    def inspect(self, target: Any, *, source: str | None = None) -> AgentSpec:
+    def inspect(
+        self,
+        target: Any,
+        *,
+        source: str | None = None,
+        identity_locator: str | None = None,
+    ) -> AgentSpec:
         """Describe the declared surface. Nothing on the target is executed.
 
         The declaration *is* the specification here, which is what makes this
@@ -761,10 +768,15 @@ class CustomAgentAdapter(FrameworkAdapter):
             ),
             "tools": fingerprint_tools,
         }
-        spec_id = f"agentspec-{canonical_hash(fingerprint).split(':', 1)[1][:24]}"
+        spec_id, legacy_spec_id = portable_identity(
+            fingerprint,
+            location_locator=locator,
+            identity_locator=identity_locator,
+        )
 
         return AgentSpec(
             spec_id=spec_id,
+            legacy_spec_id=legacy_spec_id,
             identity=IdentitySpec(
                 name=_property(
                     agent_name,
@@ -1122,6 +1134,7 @@ class CustomAgentAdapter(FrameworkAdapter):
         world_state: Any = None,
         event_sink: EventSinkProtocol | None = None,
         source: str | None = None,
+        identity_locator: str | None = None,
         controlled_model: bool = False,
     ) -> PreparedTarget:
         """Bind the declared agent to a gateway, or refuse before it runs.
@@ -1160,7 +1173,9 @@ class CustomAgentAdapter(FrameworkAdapter):
             )
         report = self.preflight(target)
         report.require_supported()
-        spec = self.inspect(target, source=source)
+        spec = self.inspect(
+            target, source=source, identity_locator=identity_locator
+        )
 
         tool_risks: dict[str, tuple[bool, bool]] = {}
         for item in spec.tools.items:

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -65,6 +65,7 @@ from agentcheck.runner.budgets import BudgetExceeded
 from agentcheck.runner.network_guard import denied_destinations
 
 from .base import (
+    portable_identity,
     AdapterDependencyError,
     AdapterRuntimeError,
     EventSinkProtocol,
@@ -1863,7 +1864,13 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
 
     framework = FRAMEWORK_NAME
 
-    def inspect(self, target: Any, *, source: str | None = None) -> AgentSpec:
+    def inspect(
+        self,
+        target: Any,
+        *,
+        source: str | None = None,
+        identity_locator: str | None = None,
+    ) -> AgentSpec:
         _require_sdk()
         source = source or "runtime:agent"
         if type(target) is not Agent:
@@ -2114,11 +2121,16 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
                     for edge in graph.edges
                 ],
             }
-        spec_id = f"agentspec-{canonical_hash(fingerprint).split(':', 1)[1][:24]}"
+        spec_id, legacy_spec_id = portable_identity(
+            fingerprint,
+            location_locator=source,
+            identity_locator=identity_locator,
+        )
         runtime_locator = f"{source}.agent.runtime"
 
         return AgentSpec(
             spec_id=spec_id,
+            legacy_spec_id=legacy_spec_id,
             identity=IdentitySpec(
                 name=_property(
                     target.name,
@@ -2511,11 +2523,14 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
         world_state: Any = None,
         event_sink: EventSinkProtocol | None = None,
         source: str | None = None,
+        identity_locator: str | None = None,
         controlled_model: bool = False,
     ) -> PreparedTarget:
         report = self.preflight(target)
         report.require_supported()
-        spec = self.inspect(target, source=source)
+        spec = self.inspect(
+            target, source=source, identity_locator=identity_locator
+        )
         graph = _reachable_graph(target)
         capture_holder: dict[str, _Capture | None] = {"capture": None}
         tool_risks: dict[str, tuple[bool, bool]] = {}

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -56,6 +56,7 @@ from agentcheck.domain.scenario import ConversationRole, ConversationTurn
 from agentcheck.inspect.capabilities import extract_capabilities
 
 from .base import (
+    portable_identity,
     AdapterDependencyError,
     EventSinkProtocol,
     FrameworkAdapter,
@@ -853,7 +854,13 @@ class PydanticAIAdapter(FrameworkAdapter):
 
     framework = FRAMEWORK_NAME
 
-    def inspect(self, target: Any, *, source: str | None = None) -> AgentSpec:
+    def inspect(
+        self,
+        target: Any,
+        *,
+        source: str | None = None,
+        identity_locator: str | None = None,
+    ) -> AgentSpec:
         _require_sdk()
         locator = source or f"{type(target).__module__}.{type(target).__name__}"
         framework_version = _sdk_version()
@@ -907,10 +914,15 @@ class PydanticAIAdapter(FrameworkAdapter):
             ),
             "tools": fingerprint_tools,
         }
-        spec_id = f"agentspec-{canonical_hash(fingerprint).split(':', 1)[1][:24]}"
+        spec_id, legacy_spec_id = portable_identity(
+            fingerprint,
+            location_locator=locator,
+            identity_locator=identity_locator,
+        )
 
         return AgentSpec(
             spec_id=spec_id,
+            legacy_spec_id=legacy_spec_id,
             identity=IdentitySpec(
                 name=_property(
                     getattr(target, "name", None) or "agent",
@@ -1226,12 +1238,15 @@ class PydanticAIAdapter(FrameworkAdapter):
         world_state: Any = None,
         event_sink: EventSinkProtocol | None = None,
         source: str | None = None,
+        identity_locator: str | None = None,
         controlled_model: bool = False,
     ) -> PreparedTarget:
         _require_sdk()
         report = self.preflight(target)
         report.require_supported()
-        spec = self.inspect(target, source=source)
+        spec = self.inspect(
+            target, source=source, identity_locator=identity_locator
+        )
 
         capture_holder: dict[str, _Capture | None] = {"capture": None}
         tool_risks: dict[str, tuple[bool, bool]] = {}

--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -41,6 +41,7 @@ from agentcheck.fixtures import (
     load_representative_inputs,
     load_scenario_requests,
 )
+from agentcheck.identity import identity_mismatch_hint, spec_identity_matches
 from agentcheck.errors import (
     ConfigurationError,
     IncompatibleSuiteError,
@@ -381,11 +382,12 @@ def execute_suite(
         )
     else:
         suite_path, frozen = configured
-        if frozen.spec_id != spec.spec_id:
+        if not spec_identity_matches(spec, frozen.spec_id):
             raise ConfigurationError(
                 f"frozen suite {suite_path.name} was generated for target "
                 f"{frozen.spec_id}, but this target inspects as {spec.spec_id}; "
                 "re-run agentcheck generate"
+                + identity_mismatch_hint(spec, frozen.spec_id)
             )
         if seed is not None and seed != frozen.seed:
             raise ConfigurationError(

--- a/agentcheck/baseline/service.py
+++ b/agentcheck/baseline/service.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from agentcheck.artifacts import create_private_file, replace_private_file
 from agentcheck.config import contained_path
 from agentcheck.errors import ConfigurationError
+from agentcheck.identity import identity_mismatch_hint, spec_identity_matches
 from agentcheck.privacy import redact_log_text
 from agentcheck.report.load import load_report_config, load_stored_run
 
@@ -77,9 +78,14 @@ def check_baseline(
     baseline = load_baseline(root, baseline_path)
     loaded = load_stored_run(target, run_id=run_id, latest=latest)
     current = baseline_from_loaded(loaded)
-    if baseline.spec_id != current.spec_id:
+    # `current.spec_id` comes from this run's stored agent-spec.json, so a
+    # baseline and a run recorded under the same identity contract compare
+    # directly. A baseline written before portable identity is recognized only
+    # when this run reproduces that location-bound identity.
+    if not spec_identity_matches(loaded.spec, baseline.spec_id):
         raise ConfigurationError(
             "baseline spec_id does not match the current run; refusing comparison"
+            + identity_mismatch_hint(loaded.spec, baseline.spec_id)
         )
     comparison = compare_baselines(baseline, current)
     return CheckedBaseline(

--- a/agentcheck/config.py
+++ b/agentcheck/config.py
@@ -274,6 +274,23 @@ def parse_entrypoint(value: str) -> ParsedEntrypoint:
     )
 
 
+def portable_entrypoint(root: Path, entrypoint: str) -> str:
+    """Return the entrypoint as a canonical target-relative POSIX locator.
+
+    Target identity must not move because a configuration spelled the same file
+    differently -- ``./src/agent.py`` and ``src//agent.py`` name one module --
+    or because the host uses another path separator. Resolving through
+    ``entrypoint_location`` and re-relativizing against the resolved root also
+    makes a symlinked checkout produce the same locator as the real directory.
+    """
+
+    resolved_root = root.resolve()
+    source, attribute = entrypoint_location(root, entrypoint)
+    relative = source.relative_to(resolved_root).as_posix()
+    suffix = "()" if parse_entrypoint(entrypoint).factory else ""
+    return f"{relative}:{attribute}{suffix}"
+
+
 def entrypoint_location(root: Path, entrypoint: str) -> tuple[Path, str]:
     """Resolve a contained entrypoint without requiring the source to exist.
 

--- a/agentcheck/domain/agent_spec.py
+++ b/agentcheck/domain/agent_spec.py
@@ -210,6 +210,12 @@ class AgentSpec(ContractModel):
 
     contract_version: Literal["agentcheck.agent_spec.v1"] = AGENT_SPEC_CONTRACT_VERSION
     spec_id: str = Field(min_length=1, max_length=200)
+    # The identity this same inspection would have produced under the
+    # pre-portable contract, where the absolute entrypoint path was hashed into
+    # spec_id. It exists only so an artifact created before portable identity
+    # can still be recognized at the location that produced it. It is never a
+    # new binding, and it is absent when no distinct legacy identity exists.
+    legacy_spec_id: str | None = Field(default=None, max_length=200)
     identity: IdentitySpec
     interface: InterfaceSpec
     instructions: InstructionsSpec

--- a/agentcheck/identity.py
+++ b/agentcheck/identity.py
@@ -1,0 +1,86 @@
+"""Portable target identity and its bounded legacy compatibility path.
+
+``spec_id`` names the agent under test: its declared name, framework version,
+model, instructions, tools and tool schemas, plus the entrypoint relative to the
+target root. It deliberately excludes the absolute checkout location, so the
+same unchanged agent inspects identically on a developer machine and on a CI
+runner.
+
+Before that contract existed the absolute entrypoint path was hashed into
+``spec_id``. Artifacts created then are bound to the location that produced
+them. They stay usable exactly there and nowhere else: recognizing one is proof
+that this inspection reproduces the recorded location-bound identity, which is
+the same evidence the old contract required. It is never proof that a different
+location is equivalent, so nothing is migrated and no equivalence is invented.
+"""
+
+from __future__ import annotations
+
+import hmac
+
+from agentcheck.domain import AgentSpec
+
+
+# A legacy artifact carried in from another directory and a genuine change to
+# the behavioral contract are indistinguishable from the recorded identity
+# alone, so this states the migration path conditionally instead of diagnosing
+# a cause it cannot observe.
+IDENTITY_MISMATCH_HINT = (
+    ". If this artifact predates portable target identity it is bound to the "
+    "directory that created it, and regenerating it from this checkout will "
+    "produce a portable identity."
+)
+
+
+def _equal(left: str, right: str) -> bool:
+    left_bytes = left.encode("utf-8")
+    right_bytes = right.encode("utf-8")
+    if len(left_bytes) != len(right_bytes):
+        hmac.compare_digest(left_bytes, left_bytes)
+        return False
+    return hmac.compare_digest(left_bytes, right_bytes)
+
+
+def spec_identity_matches(spec: AgentSpec, recorded_spec_id: str) -> bool:
+    """Return whether ``recorded_spec_id`` identifies this inspected target.
+
+    A portable match is the normal case. A legacy match is accepted only when
+    this very inspection reproduces the recorded location-bound identity, which
+    can happen only at the original path with an unchanged behavioral surface.
+    """
+
+    if _equal(spec.spec_id, recorded_spec_id):
+        return True
+    legacy = spec.legacy_spec_id
+    return legacy is not None and _equal(legacy, recorded_spec_id)
+
+
+def spec_identity_is_legacy(spec: AgentSpec, recorded_spec_id: str) -> bool:
+    """Return whether the match came only from the legacy identity."""
+
+    if _equal(spec.spec_id, recorded_spec_id):
+        return False
+    legacy = spec.legacy_spec_id
+    return legacy is not None and _equal(legacy, recorded_spec_id)
+
+
+def identity_mismatch_hint(spec: AgentSpec, recorded_spec_id: str) -> str:
+    """Offer the migration path on a refusal, without diagnosing its cause.
+
+    Nothing is added when this target has no separate location-bound identity,
+    because then no artifact of this target could have predated the portable
+    contract, or when the recorded identity is that legacy value, because the
+    caller has already accepted the match.
+    """
+
+    if spec.legacy_spec_id is None or _equal(spec.legacy_spec_id, recorded_spec_id):
+        return ""
+    return IDENTITY_MISMATCH_HINT
+
+
+__all__ = [
+    "IDENTITY_MISMATCH_HINT",
+    "identity_mismatch_hint",
+    "spec_identity_is_legacy",
+    "spec_identity_matches",
+]

--- a/agentcheck/inspect/extractor.py
+++ b/agentcheck/inspect/extractor.py
@@ -578,13 +578,28 @@ def load_target(target: str | Path) -> tuple[Any, str]:
     return value, f"{module_path}:{attribute}"
 
 
+def portable_locator(target: str | Path) -> str:
+    """Return the target-relative POSIX locator used for spec identity.
+
+    Resolution matches the evaluation pipeline, so a library caller and the CLI
+    derive the same identity for the same target instead of disagreeing because
+    one of them saw an absolute path.
+    """
+
+    module_path, attribute, root, factory = _resolve_target(target)
+    relative = module_path.relative_to(root).as_posix()
+    return f"{relative}:{attribute}{'()' if factory else ''}"
+
+
 def inspect_target(target: str | Path) -> Any:
     """Load and inspect a supported local agent through the OpenAI adapter."""
 
     from agentcheck.adapters.openai_agents import OpenAIAgentsAdapter
 
     agent, source = load_target(target)
-    return OpenAIAgentsAdapter().inspect(agent, source=source)
+    return OpenAIAgentsAdapter().inspect(
+        agent, source=source, identity_locator=portable_locator(target)
+    )
 
 
 __all__ = [
@@ -592,5 +607,6 @@ __all__ = [
     "enable_contained_target_imports",
     "inspect_target",
     "load_target",
+    "portable_locator",
     "resolve_entrypoint",
 ]

--- a/agentcheck/replay/bind.py
+++ b/agentcheck/replay/bind.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from agentcheck.config import AgentCheckConfig, resolve_entrypoint
 from agentcheck.domain import AgentSpec
 from agentcheck.errors import ConfigurationError
+from agentcheck.identity import identity_mismatch_hint, spec_identity_matches
 
 from .fileset import collect_source_file_set, describe_file_set_mismatch, git_command_env
 from .manifest import ReplayManifest
@@ -146,10 +147,11 @@ def verify_replay_spec_bindings(
     """Refuse replay when the inspected spec is not the bound surface."""
 
     binding = manifest.spec_binding
-    if spec.spec_id != binding.spec_id:
+    if not spec_identity_matches(spec, binding.spec_id):
         raise ConfigurationError(
             f"replay manifest was bound to spec {binding.spec_id}, "
             f"but this target inspects as {spec.spec_id}"
+            + identity_mismatch_hint(spec, binding.spec_id)
         )
     live_packs = tuple(sorted(set(policy_pack_ids)))
     bound_packs = tuple(sorted(set(binding.policy_pack_ids)))

--- a/agentcheck/report/load.py
+++ b/agentcheck/report/load.py
@@ -40,6 +40,7 @@ from agentcheck.domain import (
     Scenario,
 )
 from agentcheck.errors import ConfigurationError
+from agentcheck.identity import spec_identity_matches
 from agentcheck.generate.suite import FrozenSuite, configured_frozen_suite
 from agentcheck.generate.selection import SelectionPlan
 from agentcheck.store import (
@@ -373,7 +374,7 @@ def _optional_frozen_suite(
     if configured is None:
         return None
     _, frozen = configured
-    if frozen.spec_id != spec.spec_id:
+    if not spec_identity_matches(spec, frozen.spec_id):
         return None
     if not _digest_equal(frozen.fingerprint, recorded_fingerprint):
         return None

--- a/agentcheck/runner/worker.py
+++ b/agentcheck/runner/worker.py
@@ -19,7 +19,11 @@ from agentcheck.adapters import (
     PydanticAIAdapter,
     encode_preflight_report,
 )
-from agentcheck.config import AgentCheckConfig, resolve_entrypoint
+from agentcheck.config import (
+    AgentCheckConfig,
+    portable_entrypoint,
+    resolve_entrypoint,
+)
 from agentcheck.domain import (
     FaultType,
     InfrastructureError,
@@ -237,7 +241,13 @@ def _inspect(
 ) -> tuple[Any, dict[str, Any], dict[str, Any] | None]:
     target, source = _load_agent(root, config)
     adapter = _adapter_for(config)
-    spec = adapter.inspect(target, source=source)
+    # A canonical target-relative locator for the same module `source` points
+    # at, carrying no checkout location and no spelling of the same path.
+    spec = adapter.inspect(
+        target,
+        source=source,
+        identity_locator=portable_entrypoint(root, config.entrypoint),
+    )
     preflight = encode_preflight_report(adapter.preflight(target))
     topology = adapter.describe_topology(target, source=source)
     return spec, preflight, topology
@@ -246,7 +256,11 @@ def _inspect(
 def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) -> Any:
     target, source = _load_agent(root, config)
     adapter = _adapter_for(config)
-    spec = adapter.inspect(target, source=source)
+    spec = adapter.inspect(
+        target,
+        source=source,
+        identity_locator=portable_entrypoint(root, config.entrypoint),
+    )
     tools = tuple(item.value for item in spec.tools.items)
     world = WorldSimulator(scenario.initial_world_state)
     gateway = ToolGateway(
@@ -261,6 +275,7 @@ def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) 
         gateway,
         world_state=gateway.world,
         source=source,
+        identity_locator=portable_entrypoint(root, config.entrypoint),
         controlled_model=config.controlled_model,
     )
     return asyncio.run(

--- a/docs/portable-identity.md
+++ b/docs/portable-identity.md
@@ -1,0 +1,94 @@
+# Portable target identity
+
+`spec_id` names the agent under test. It must describe *what* is being tested,
+not *where the checkout happens to live*, so that a suite or baseline produced
+on a developer machine is still valid in CI.
+
+```
+/home/waseem/refund-agent          agentspec-9f2c…
+/home/runner/work/refund-agent/…   agentspec-9f2c…   same agent, same identity
+```
+
+## What identity is derived from
+
+Semantic inputs — a change here changes `spec_id`:
+
+- the declared agent name;
+- the framework and its verified version;
+- the declared model identity;
+- a digest of the authoritative instructions;
+- every declared tool, including its full input schema and its declared
+  `state_changing` / `destructive` / `replaceable` flags;
+- the handoff graph for a multi-agent target, by structural position;
+- the **entrypoint relative to the target root**, canonicalized.
+
+Location metadata — deliberately excluded:
+
+- the absolute checkout path, and therefore the username, the temporary
+  directory, the OS root, and the CI workspace root;
+- how the same relative path was spelled (`./agent.py`, `agent//agent.py`);
+- the host path separator, since the locator is normalized to POSIX form;
+- whether the checkout was reached through a symlink.
+
+Two files that share a basename under different relative directories remain
+different targets, so portability never collapses distinct agents together.
+
+Evidence keeps the real absolute location for diagnostics. Evidence never
+influences identity.
+
+## What is *not* part of identity
+
+Declared policy packs are not read out of the agent, so they are not part of
+`spec_id`. They are bound separately: the replay spec binding and the
+evaluation baseline each record `policy_pack_ids`, and a run whose declared
+packs differ is refused by that binding. Folding them into `spec_id` would
+claim the inspected agent had changed when it had not.
+
+## Artifacts created before this contract
+
+Earlier releases hashed the absolute entrypoint path into `spec_id`, so those
+artifacts are bound to the directory that produced them.
+
+An inspection records `legacy_spec_id`, the identity the *same* inspection
+would have produced under that older contract. A frozen suite, replay manifest
+or baseline carrying a legacy identity is accepted only when this inspection
+reproduces that value — which can happen only at the original path with an
+unchanged behavioral surface. That is precisely the evidence the old contract
+required, so nothing is weakened and no equivalence is invented.
+
+Carried to any other directory, a legacy artifact is refused. The refusal
+offers the migration path conditionally, because a relocated legacy artifact
+and a genuine change to the behavioral contract are indistinguishable from the
+recorded identity alone:
+
+> If this artifact predates portable target identity it is bound to the
+> directory that created it, and regenerating it from this checkout will
+> produce a portable identity.
+
+Regenerating from the current checkout produces a portable identity. Nothing is
+rewritten in place and no stored artifact is migrated silently.
+
+## Source integrity is unchanged
+
+Portable identity answers "is this the same agent contract?". It never answers
+"is this the same source?". Those bindings are untouched:
+
+- the replay manifest still records `entrypoint_digest` and the bounded
+  `file_set`, both content hashes, and still refuses a changed source;
+- frozen suites still verify their own fingerprint, so a hand-edited
+  `spec_id` invalidates the document;
+- declared policy packs are still bound explicitly;
+- `INCONCLUSIVE` and `INFRA_ERROR` remain distinct from `PASS`.
+
+Making identity portable widened *where* a trusted artifact may be used. It did
+not widen *what* counts as the same source.
+
+## Compatibility
+
+`spec_id` values produced by the evaluation pipeline change with this release,
+because the absolute path is no longer an input. `agentcheck.agent_spec.v1`
+gains one optional field, `legacy_spec_id`; specs written before it still load.
+No other serialized contract gains or loses a field, and no fingerprint
+algorithm changes. Suites, baselines, manifests and reports generated from this
+release forward are portable; earlier ones behave exactly as they do today, at
+the location that produced them.

--- a/tests/agentcheck/test_portable_identity.py
+++ b/tests/agentcheck/test_portable_identity.py
@@ -1,0 +1,960 @@
+"""Target identity must describe the agent, not where it happens to live.
+
+A developer generates a suite locally and CI validates it from a different
+absolute checkout. Those two locations are the same agent, so they must inspect
+to the same identity. A real change to the declared behavioral contract must
+still change it.
+
+Every test here is offline and executes no declared tool handler.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.application import inspect_target
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE = REPOSITORY_ROOT / "examples" / "evaluation" / "account_agent"
+
+
+def _copy_example(destination: Path) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(
+        EXAMPLE,
+        destination,
+        ignore=shutil.ignore_patterns(".agentcheck", "__pycache__"),
+    )
+    return destination
+
+
+def _agents_sdk() -> Any:
+    return pytest.importorskip("agents")
+
+
+def _weather_agent(agents: Any, *, instructions: str = "You report weather.") -> Any:
+    @agents.function_tool
+    def get_weather(city: str) -> str:
+        """Return weather."""
+
+        return "sunny"
+
+    return agents.Agent(
+        name="Pin Agent", instructions=instructions, tools=[get_weather]
+    )
+
+
+# --------------------------------------------------------------------------
+# Reproduction: identity currently depends on the absolute checkout location.
+# --------------------------------------------------------------------------
+
+
+def test_identical_agent_at_two_absolute_paths_inspects_identically(
+    tmp_path: Path,
+) -> None:
+    """The reported P1: same bytes, two checkouts, one identity.
+
+    ``/home/user/project`` and ``/home/runner/work/project`` are the same agent.
+    This asserts the property the product needs, so before the portable identity
+    contract existed it failed purely because the absolute path differed.
+    """
+
+    local = _copy_example(tmp_path / "home" / "developer" / "refund-agent")
+    ci = _copy_example(
+        tmp_path / "runner" / "work" / "refund-agent" / "refund-agent"
+    )
+
+    _, _, local_result = inspect_target(local)
+    _, _, ci_result = inspect_target(ci)
+
+    assert local_result.value.spec_id == ci_result.value.spec_id
+    # The difference under test really is location only.
+    assert local != ci
+    assert (
+        local_result.value.identity.name.value
+        == ci_result.value.identity.name.value
+    )
+
+
+def test_identity_survives_a_different_username_and_root(tmp_path: Path) -> None:
+    """A username, a temp root, and a CI workspace root are not the agent."""
+
+    first = _copy_example(tmp_path / "home" / "waseem" / "proj" / "agent-under-test")
+    second = _copy_example(tmp_path / "opt" / "ci" / "ws" / "agent-under-test")
+    third = _copy_example(tmp_path / "var" / "tmp" / "x1y2z3" / "agent-under-test")
+
+    ids = {
+        inspect_target(path)[2].value.spec_id for path in (first, second, third)
+    }
+
+    assert len(ids) == 1
+
+
+def test_the_difference_between_the_two_checkouts_is_only_location(
+    tmp_path: Path,
+) -> None:
+    """Prove the reproduction isolates path, not content."""
+
+    local = _copy_example(tmp_path / "a" / "refund-agent")
+    ci = _copy_example(tmp_path / "b" / "deep" / "refund-agent")
+
+    def surface(spec: Any) -> Any:
+        return (
+            spec.identity.name.value,
+            spec.identity.framework.value,
+            spec.identity.framework_version.value,
+            spec.instructions.system.value,
+            tuple(
+                (item.value.name, item.value.input_schema)
+                for item in spec.tools.items
+            ),
+        )
+
+    local_spec = inspect_target(local)[2].value
+    ci_spec = inspect_target(ci)[2].value
+
+    assert surface(local_spec) == surface(ci_spec)
+    assert local_spec.spec_id == ci_spec.spec_id
+    # Evidence keeps the real location for diagnostics; identity does not.
+    assert str(local) in local_spec.interface.entrypoint.value
+    assert str(ci) in ci_spec.interface.entrypoint.value
+    assert local_spec.interface.entrypoint.value != ci_spec.interface.entrypoint.value
+
+
+def test_portable_identity_is_deterministic_across_repeated_inspections(
+    tmp_path: Path,
+) -> None:
+    target = _copy_example(tmp_path / "repeat" / "agent")
+
+    ids = {inspect_target(target)[2].value.spec_id for _ in range(3)}
+
+    assert len(ids) == 1
+
+
+# --------------------------------------------------------------------------
+# Semantic changes must still move identity.
+# --------------------------------------------------------------------------
+
+
+def _identity(agents: Any, agent: Any) -> str:
+    return (
+        OpenAIAgentsAdapter()
+        .inspect(agent, source="/abs/a/agent.py:agent", identity_locator="agent.py:agent")
+        .spec_id
+    )
+
+
+def test_changed_system_instructions_change_identity() -> None:
+    agents = _agents_sdk()
+
+    baseline = _identity(agents, _weather_agent(agents))
+    changed = _identity(
+        agents, _weather_agent(agents, instructions="You report tides.")
+    )
+
+    assert baseline != changed
+
+
+def test_changed_tool_schema_changes_identity() -> None:
+    agents = _agents_sdk()
+
+    @agents.function_tool
+    def get_weather(city: str) -> str:
+        """Return weather."""
+
+        return "sunny"
+
+    @agents.function_tool
+    def get_weather_wider(city: str, unit: str) -> str:  # noqa: D401
+        """Return weather."""
+
+        return "sunny"
+
+    narrow = agents.Agent(
+        name="Pin Agent", instructions="You report weather.", tools=[get_weather]
+    )
+    wide = agents.Agent(
+        name="Pin Agent",
+        instructions="You report weather.",
+        tools=[get_weather_wider],
+    )
+
+    assert _identity(agents, narrow) != _identity(agents, wide)
+
+
+def test_added_or_removed_tool_changes_identity() -> None:
+    agents = _agents_sdk()
+
+    @agents.function_tool
+    def get_weather(city: str) -> str:
+        """Return weather."""
+
+        return "sunny"
+
+    @agents.function_tool
+    def get_tide(city: str) -> str:
+        """Return tide."""
+
+        return "high"
+
+    one = agents.Agent(
+        name="Pin Agent", instructions="You report weather.", tools=[get_weather]
+    )
+    two = agents.Agent(
+        name="Pin Agent",
+        instructions="You report weather.",
+        tools=[get_weather, get_tide],
+    )
+
+    assert _identity(agents, one) != _identity(agents, two)
+
+
+def test_a_different_relative_entrypoint_is_a_different_target() -> None:
+    """Two files with the same basename under different roots are not one target."""
+
+    agents = _agents_sdk()
+    agent = _weather_agent(agents)
+    adapter = OpenAIAgentsAdapter()
+
+    first = adapter.inspect(
+        agent, source="/abs/a/src/agent.py:agent", identity_locator="src/agent.py:agent"
+    )
+    second = adapter.inspect(
+        agent,
+        source="/abs/a/other/agent.py:agent",
+        identity_locator="other/agent.py:agent",
+    )
+
+    assert first.spec_id != second.spec_id
+
+
+# --------------------------------------------------------------------------
+# Every adapter derives identity the same way.
+# --------------------------------------------------------------------------
+
+
+def _two_locations(adapter: Any, agent: Any) -> tuple[Any, Any]:
+    """Inspect one agent as if it lived in two unrelated checkouts."""
+
+    local = adapter.inspect(
+        agent,
+        source="/home/developer/proj/agent.py:agent",
+        identity_locator="agent.py:agent",
+    )
+    ci = adapter.inspect(
+        agent,
+        source="/home/runner/work/proj/proj/agent.py:agent",
+        identity_locator="agent.py:agent",
+    )
+    return local, ci
+
+
+def test_openai_agents_adapter_identity_is_portable() -> None:
+    agents = _agents_sdk()
+
+    local, ci = _two_locations(OpenAIAgentsAdapter(), _weather_agent(agents))
+
+    assert local.spec_id == ci.spec_id
+    # Each side still records the location-bound identity it would have had.
+    assert local.legacy_spec_id is not None
+    assert ci.legacy_spec_id is not None
+    assert local.legacy_spec_id != ci.legacy_spec_id
+
+
+def test_custom_adapter_identity_is_portable() -> None:
+    from agentcheck.adapters import CustomAgentAdapter
+
+    from tests.agentcheck.test_custom_agent_adapter import SupportAgent
+
+    local, ci = _two_locations(CustomAgentAdapter(), SupportAgent())
+
+    assert local.spec_id == ci.spec_id
+    assert local.legacy_spec_id != ci.legacy_spec_id
+
+
+def test_pydantic_ai_adapter_identity_is_portable() -> None:
+    pytest.importorskip("pydantic_ai")
+    from agentcheck.adapters import PydanticAIAdapter
+    from pydantic_ai import Agent as PydanticAgent
+    from pydantic_ai.models.test import TestModel
+
+    agent = PydanticAgent(TestModel(), name="portable", instructions="Be brief.")
+
+    local, ci = _two_locations(PydanticAIAdapter(), agent)
+
+    assert local.spec_id == ci.spec_id
+    assert local.legacy_spec_id != ci.legacy_spec_id
+
+
+def test_identity_without_a_portable_locator_stays_location_bound() -> None:
+    """A caller that established no target root cannot claim portability."""
+
+    agents = _agents_sdk()
+    adapter = OpenAIAgentsAdapter()
+    agent = _weather_agent(agents)
+
+    first = adapter.inspect(agent, source="/home/a/agent.py:agent")
+    second = adapter.inspect(agent, source="/home/b/agent.py:agent")
+
+    assert first.spec_id != second.spec_id
+    # There is no separate legacy identity to record in that mode.
+    assert first.legacy_spec_id is None
+    assert second.legacy_spec_id is None
+
+
+def test_the_pinned_location_bound_identity_is_reproduced_exactly() -> None:
+    """The legacy identity must be the old contract's bytes, not an approximation."""
+
+    agents = _agents_sdk()
+    agent = _weather_agent(agents)
+
+    spec = OpenAIAgentsAdapter().inspect(
+        agent, source="pin:agent.py:agent", identity_locator="agent.py:agent"
+    )
+
+    # Same value the pre-portable contract produced for this exact input.
+    assert spec.legacy_spec_id == "agentspec-482269daa366d4ff8f81b74e"
+
+
+# --------------------------------------------------------------------------
+# End-to-end: generate in one checkout, validate from another.
+# --------------------------------------------------------------------------
+
+
+def _relocate(source_target: Path, destination: Path) -> Path:
+    """Copy a whole target, artifacts included, to a new absolute location."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_target, destination)
+    return destination
+
+
+def test_a_suite_generated_locally_is_accepted_from_a_ci_checkout(
+    tmp_path: Path,
+) -> None:
+    import agentcheck.application as application
+
+    local = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.generate_suite(local, seed=1729, force=True)
+
+    ci = _relocate(local, tmp_path / "runner" / "work" / "refund-agent" / "refund-agent")
+
+    # The suite travels with the checkout and is accepted at the new path.
+    execution = application.execute_suite(
+        ci, run_id="ci-portable", persist_store=False
+    )
+
+    assert execution.frozen_suite is not None
+    assert execution.scenarios
+
+
+def test_a_baseline_created_locally_gates_a_run_from_a_ci_checkout(
+    tmp_path: Path,
+) -> None:
+    import agentcheck.application as application
+    from agentcheck.baseline.service import check_baseline, create_baseline
+
+    local = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.execute_suite(local, run_id="local-run", persist_store=False)
+    create_baseline(local, run_id="local-run", out="agentcheck-baseline.json")
+
+    ci = _relocate(local, tmp_path / "runner" / "work" / "refund-agent" / "refund-agent")
+    application.execute_suite(ci, run_id="ci-run", persist_store=False)
+
+    checked = check_baseline(
+        ci, baseline_path="agentcheck-baseline.json", run_id="ci-run"
+    )
+
+    assert checked.comparison.baseline_scenario_count > 0
+    assert checked.exit_code == 0
+
+
+def test_a_relocated_checkout_still_rejects_modified_source(tmp_path: Path) -> None:
+    """Portability must not weaken what a suite is bound to."""
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+
+    local = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.generate_suite(local, seed=1729, force=True)
+    ci = _relocate(local, tmp_path / "runner" / "work" / "refund-agent" / "refund-agent")
+
+    # A real change to the authoritative instruction surface, at the new path.
+    agent_file = ci / "agent.py"
+    agent_file.write_text(
+        agent_file.read_text(encoding="utf-8").replace(
+            "Use only exact account identifiers.",
+            "Use approximate account identifiers.",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        application.execute_suite(ci, run_id="ci-tampered", persist_store=False)
+
+    message = str(excinfo.value)
+    assert "re-run agentcheck generate" in message
+    # The migration path is offered conditionally; it never claims to know
+    # whether the cause was a relocation or a real contract change.
+    assert "If this artifact predates portable target identity" in message
+
+
+# --------------------------------------------------------------------------
+# Legacy artifacts: usable where they were made, never elsewhere.
+# --------------------------------------------------------------------------
+
+
+def _rebind_suite_to(path: Path, spec_id: str) -> None:
+    """Rewrite a frozen suite as if the location-bound contract had made it."""
+
+    import json
+
+    from agentcheck.generate.suite import FrozenSuite, write_frozen_suite
+
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["spec_id"] = spec_id
+    document.pop("fingerprint", None)
+    document.pop("suite_id", None)
+    write_frozen_suite(
+        path, FrozenSuite.model_validate_json(json.dumps(document)), force=True
+    )
+
+
+def _legacy_spec_id(target: Path) -> str:
+    spec = inspect_target(target)[2].value
+    assert spec.legacy_spec_id is not None
+    return spec.legacy_spec_id
+
+
+def test_a_legacy_suite_is_accepted_at_the_location_that_created_it(
+    tmp_path: Path,
+) -> None:
+    """Recognizing it proves this inspection reproduces the recorded identity."""
+
+    import agentcheck.application as application
+    from agentcheck.generate.suite import DEFAULT_SUITE_FILENAME
+
+    target = _copy_example(tmp_path / "home" / "dev" / "legacy-agent")
+    application.generate_suite(target, seed=1729, force=True)
+    _rebind_suite_to(target / DEFAULT_SUITE_FILENAME, _legacy_spec_id(target))
+
+    execution = application.execute_suite(
+        target, run_id="legacy-same-path", persist_store=False
+    )
+
+    assert execution.frozen_suite is not None
+    assert execution.scenarios
+
+
+def test_a_legacy_suite_is_refused_from_a_different_location(tmp_path: Path) -> None:
+    """Its identity was never evidence about any other directory."""
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+    from agentcheck.generate.suite import DEFAULT_SUITE_FILENAME
+
+    target = _copy_example(tmp_path / "home" / "dev" / "legacy-agent")
+    application.generate_suite(target, seed=1729, force=True)
+    _rebind_suite_to(target / DEFAULT_SUITE_FILENAME, _legacy_spec_id(target))
+
+    moved = _relocate(target, tmp_path / "runner" / "work" / "legacy-agent")
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        application.execute_suite(moved, run_id="legacy-moved", persist_store=False)
+
+    assert "If this artifact predates portable target identity" in str(excinfo.value)
+
+
+def test_a_legacy_baseline_is_accepted_at_its_own_location(tmp_path: Path) -> None:
+    import json
+
+    import agentcheck.application as application
+    from agentcheck.baseline.contract import EvaluationBaseline
+    from agentcheck.baseline.service import check_baseline, create_baseline
+
+    target = _copy_example(tmp_path / "home" / "dev" / "legacy-agent")
+    application.execute_suite(target, run_id="legacy-run", persist_store=False)
+    created = create_baseline(
+        target, run_id="legacy-run", out="agentcheck-baseline.json"
+    )
+
+    document = json.loads(created.path.read_text(encoding="utf-8"))
+    document["spec_id"] = _legacy_spec_id(target)
+    document.pop("fingerprint", None)
+    document.pop("baseline_id", None)
+    rebound = EvaluationBaseline.model_validate_json(json.dumps(document))
+    created.path.write_text(
+        json.dumps(rebound.model_dump(mode="json")), encoding="utf-8"
+    )
+
+    checked = check_baseline(
+        target, baseline_path="agentcheck-baseline.json", run_id="legacy-run"
+    )
+
+    assert checked.exit_code == 0
+
+
+def test_a_legacy_baseline_is_refused_from_a_different_location(
+    tmp_path: Path,
+) -> None:
+    import json
+
+    import agentcheck.application as application
+    from agentcheck.baseline.contract import EvaluationBaseline
+    from agentcheck.baseline.service import check_baseline, create_baseline
+    from agentcheck.errors import ConfigurationError
+
+    target = _copy_example(tmp_path / "home" / "dev" / "legacy-agent")
+    application.execute_suite(target, run_id="legacy-run", persist_store=False)
+    created = create_baseline(
+        target, run_id="legacy-run", out="agentcheck-baseline.json"
+    )
+    document = json.loads(created.path.read_text(encoding="utf-8"))
+    document["spec_id"] = _legacy_spec_id(target)
+    document.pop("fingerprint", None)
+    document.pop("baseline_id", None)
+    rebound = EvaluationBaseline.model_validate_json(json.dumps(document))
+    created.path.write_text(
+        json.dumps(rebound.model_dump(mode="json")), encoding="utf-8"
+    )
+
+    moved = _relocate(target, tmp_path / "runner" / "work" / "legacy-agent")
+    application.execute_suite(moved, run_id="moved-run", persist_store=False)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        check_baseline(
+            moved, baseline_path="agentcheck-baseline.json", run_id="moved-run"
+        )
+
+    assert "does not match the current run" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# Locator canonicalization: separators, spellings, symlinks.
+# --------------------------------------------------------------------------
+
+
+def _write_config(target: Path, entrypoint: str) -> None:
+    import json
+
+    (target / "agentcheck.json").write_text(
+        json.dumps({"entrypoint": entrypoint, "adapter": "openai_agents"}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "entrypoint", ("./agent.py:agent", ".//agent.py:agent")
+)
+def test_equivalent_entrypoint_spellings_are_one_identity(
+    tmp_path: Path, entrypoint: str
+) -> None:
+    """Naming the same module differently is not a different agent."""
+
+    canonical = _copy_example(tmp_path / "canonical" / "agent")
+    _write_config(canonical, "agent.py:agent")
+    spelled = _copy_example(tmp_path / "spelled" / "agent")
+    _write_config(spelled, entrypoint)
+
+    assert (
+        inspect_target(canonical)[2].value.spec_id
+        == inspect_target(spelled)[2].value.spec_id
+    )
+
+
+def test_portable_entrypoint_is_posix_normalized(tmp_path: Path) -> None:
+    """The locator is separator-independent, so a Windows config agrees."""
+
+    from agentcheck.config import portable_entrypoint
+
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "agent.py").write_text("agent = object()\n", encoding="utf-8")
+
+    canonical = portable_entrypoint(root, "src/agent.py:agent")
+
+    assert canonical == "src/agent.py:agent"
+    assert "\\" not in canonical
+    assert portable_entrypoint(root, "./src/agent.py:agent") == canonical
+    assert portable_entrypoint(root, "src//agent.py:agent") == canonical
+    assert portable_entrypoint(root, "src/agent.py:agent()") == "src/agent.py:agent()"
+
+
+def test_a_symlinked_checkout_resolves_to_the_same_identity(tmp_path: Path) -> None:
+    real = _copy_example(tmp_path / "real" / "refund-agent")
+    link = tmp_path / "linked-agent"
+    link.symlink_to(real, target_is_directory=True)
+
+    assert (
+        inspect_target(real)[2].value.spec_id
+        == inspect_target(link)[2].value.spec_id
+    )
+
+
+def test_two_different_agents_sharing_a_filename_are_not_equivalent(
+    tmp_path: Path,
+) -> None:
+    """Identity is the contract, not the basename."""
+
+    first = _copy_example(tmp_path / "one" / "agent-a")
+    second = _copy_example(tmp_path / "two" / "agent-b")
+    agent_file = second / "agent.py"
+    agent_file.write_text(
+        agent_file.read_text(encoding="utf-8").replace(
+            "Use only exact account identifiers.",
+            "Use approximate account identifiers.",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        inspect_target(first)[2].value.spec_id
+        != inspect_target(second)[2].value.spec_id
+    )
+
+
+# --------------------------------------------------------------------------
+# Replay and containment are unchanged by portability.
+# --------------------------------------------------------------------------
+
+
+def test_replay_binds_across_checkouts_but_still_rejects_changed_source(
+    tmp_path: Path,
+) -> None:
+    """A portable spec binding must not become a weaker source binding."""
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+
+    local = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    execution = application.execute_suite(
+        local, run_id="replay-src", persist_store=False
+    )
+    assert execution.replay_manifest_path is not None
+    manifest_name = execution.replay_manifest_path.name
+
+    ci = _relocate(local, tmp_path / "runner" / "work" / "refund-agent")
+    manifest = f".agentcheck/replay/{manifest_name}"
+
+    replayed = application.replay_suite(
+        ci, manifest, run_id="replay-ci", persist_store=False
+    )
+    assert replayed.scenarios
+
+    # Same manifest, same new location, changed source: still refused.
+    agent_file = ci / "agent.py"
+    agent_file.write_text(
+        agent_file.read_text(encoding="utf-8").replace(
+            "Use only exact account identifiers.",
+            "Use approximate account identifiers.",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigurationError):
+        application.replay_suite(
+            ci, manifest, run_id="replay-bad", persist_store=False
+        )
+
+
+def test_inspection_across_locations_executes_no_declared_handler(
+    tmp_path: Path,
+) -> None:
+    """Portable identity is derived from the declared contract, never by running it."""
+
+    marker = tmp_path / "handler-ran"
+    target = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    agent_file = target / "agent.py"
+    agent_file.write_text(
+        agent_file.read_text(encoding="utf-8").replace(
+            "def lookup_account(",
+            f"def lookup_account(  # noqa\n"
+            f"    *_probe_args, **_probe_kwargs\n"
+            f") -> str:\n"
+            f"    open({str(marker)!r}, 'w').close()\n"
+            f"    raise AssertionError('handler executed')\n"
+            f"def _unused_lookup_account(",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        inspect_target(target)
+    except Exception:
+        # A malformed probe target is fine; the assertion under test is that no
+        # declared handler body ran during inspection.
+        pass
+
+    assert not marker.exists()
+
+
+def test_a_declared_policy_pack_is_bound_separately_from_spec_identity(
+    tmp_path: Path,
+) -> None:
+    """Packs are declared for a run, not read out of the agent.
+
+    No adapter populates ``tool_policies``, so the authoritative policy surface
+    today is the declared pack set. It is bound explicitly by the replay spec
+    binding rather than folded into ``spec_id``, and that binding is what
+    refuses a run whose packs changed.
+    """
+
+    from types import SimpleNamespace
+
+    from agentcheck.errors import ConfigurationError
+    from agentcheck.replay.bind import verify_replay_spec_bindings
+    from agentcheck.replay.manifest import SpecBinding
+
+    target = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    spec = inspect_target(target)[2].value
+    assert spec.tool_policies.items == ()
+
+    binding = SpecBinding(
+        spec_id=spec.spec_id,
+        adapter="openai_agents",
+        entrypoint="agent.py:agent",
+        policy_pack_ids=("declared-pack",),
+    )
+    manifest = SimpleNamespace(
+        spec_binding=binding,
+        source_binding=SimpleNamespace(
+            framework=spec.identity.framework.value,
+            framework_version=spec.identity.framework_version.value,
+        ),
+    )
+
+    # The portable identity matches, so only the pack binding can refuse this.
+    with pytest.raises(ConfigurationError, match="policy packs"):
+        verify_replay_spec_bindings(manifest, spec=spec, policy_pack_ids=())
+
+    verify_replay_spec_bindings(
+        manifest, spec=spec, policy_pack_ids=("declared-pack",)
+    )
+
+
+def test_editing_a_suite_identity_breaks_its_fingerprint(tmp_path: Path) -> None:
+    """Portable identity does not make a hand-edited artifact acceptable."""
+
+    import json
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+    from agentcheck.generate.suite import DEFAULT_SUITE_FILENAME
+
+    target = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.generate_suite(target, seed=1729, force=True)
+    suite_path = target / DEFAULT_SUITE_FILENAME
+
+    document = json.loads(suite_path.read_text(encoding="utf-8"))
+    document["spec_id"] = "agentspec-0000000000000000000000ff"
+    suite_path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(ConfigurationError):
+        application.execute_suite(target, run_id="tampered", persist_store=False)
+
+
+# --------------------------------------------------------------------------
+# Adversarial: the legacy bridge must never become a downgrade path.
+# --------------------------------------------------------------------------
+
+
+def _portable_and_legacy(**overrides: Any) -> tuple[str, str | None]:
+    from agentcheck.adapters.base import portable_identity
+
+    fingerprint: dict[str, Any] = {
+        "name": "agent",
+        "framework_version": "0.20.0",
+        "model": "scripted",
+        "instructions_hash": "sha256:aaa",
+        "tools": [
+            {
+                "name": "act",
+                "input_schema": {"type": "object"},
+                "output_schema": None,
+                "state_changing": True,
+                "destructive": False,
+                "replaceable": True,
+            }
+        ],
+    }
+    fingerprint.update(overrides)
+    return portable_identity(
+        fingerprint,
+        location_locator="/home/dev/proj/agent.py:agent",
+        identity_locator="agent.py:agent",
+    )
+
+
+def test_every_semantic_input_moves_portable_identity() -> None:
+    """Each declared input the fingerprint carries is load-bearing."""
+
+    base, _ = _portable_and_legacy()
+
+    changed = {
+        "framework_version": _portable_and_legacy(framework_version="0.21.0")[0],
+        "model": _portable_and_legacy(model="other")[0],
+        "name": _portable_and_legacy(name="renamed")[0],
+        "instructions": _portable_and_legacy(instructions_hash="sha256:bbb")[0],
+        "output_schema": _portable_and_legacy(
+            tools=[
+                {
+                    "name": "act",
+                    "input_schema": {"type": "object"},
+                    "output_schema": {"type": "string"},
+                    "state_changing": True,
+                    "destructive": False,
+                    "replaceable": True,
+                }
+            ]
+        )[0],
+        "destructive_flag": _portable_and_legacy(
+            tools=[
+                {
+                    "name": "act",
+                    "input_schema": {"type": "object"},
+                    "output_schema": None,
+                    "state_changing": True,
+                    "destructive": True,
+                    "replaceable": True,
+                }
+            ]
+        )[0],
+    }
+
+    for label, value in changed.items():
+        assert value != base, f"{label} did not move portable identity"
+    assert len(set(changed.values())) == len(changed)
+
+
+def test_the_legacy_identity_binds_the_same_semantic_surface() -> None:
+    """A legacy id is the stricter binding, never a looser one."""
+
+    _, legacy_base = _portable_and_legacy()
+    _, legacy_changed = _portable_and_legacy(instructions_hash="sha256:bbb")
+
+    assert legacy_base is not None
+    assert legacy_changed is not None
+    assert legacy_base != legacy_changed
+
+
+def test_a_forged_identity_in_a_suite_is_refused(tmp_path: Path) -> None:
+    """An attacker-chosen value matches neither identity."""
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+    from agentcheck.generate.suite import DEFAULT_SUITE_FILENAME
+
+    target = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.generate_suite(target, seed=1729, force=True)
+    _rebind_suite_to(
+        target / DEFAULT_SUITE_FILENAME, "agentspec-deadbeefdeadbeefdeadbeef"
+    )
+
+    with pytest.raises(ConfigurationError, match="re-run agentcheck generate"):
+        application.execute_suite(target, run_id="forged", persist_store=False)
+
+
+def test_a_legacy_suite_from_another_agent_at_this_path_is_refused(
+    tmp_path: Path,
+) -> None:
+    """The legacy bridge still binds the behavioral contract, not just the path."""
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+    from agentcheck.generate.suite import DEFAULT_SUITE_FILENAME
+
+    target = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.generate_suite(target, seed=1729, force=True)
+
+    # The legacy identity of a *different* contract at this very path.
+    from agentcheck.adapters.base import portable_identity
+    from agentcheck.config import portable_entrypoint
+
+    live = inspect_target(target)[2].value
+    _, foreign_legacy = portable_identity(
+        {
+            "name": "some other agent",
+            "framework_version": live.identity.framework_version.value,
+            "model": None,
+            "instructions_hash": "sha256:unrelated",
+            "tools": [],
+        },
+        location_locator=str(target / "agent.py") + ":agent",
+        identity_locator=portable_entrypoint(target, "agent.py:agent"),
+    )
+    assert foreign_legacy is not None
+    _rebind_suite_to(target / DEFAULT_SUITE_FILENAME, foreign_legacy)
+
+    with pytest.raises(ConfigurationError, match="re-run agentcheck generate"):
+        application.execute_suite(target, run_id="foreign-legacy", persist_store=False)
+
+
+def test_a_stale_legacy_identity_in_a_stored_spec_cannot_rescue_a_suite(
+    tmp_path: Path,
+) -> None:
+    """The suite gate inspects live, so a persisted legacy value is never consulted."""
+
+    import json
+
+    import agentcheck.application as application
+    from agentcheck.errors import ConfigurationError
+    from agentcheck.generate.suite import DEFAULT_SUITE_FILENAME
+
+    target = _copy_example(tmp_path / "home" / "dev" / "refund-agent")
+    application.generate_suite(target, seed=1729, force=True)
+    application.execute_suite(target, run_id="seed-run", persist_store=False)
+
+    forged = "agentspec-0123456789abcdef01234567"
+    spec_path = target / ".agentcheck" / "runs" / "seed-run" / "agent-spec.json"
+    document = json.loads(spec_path.read_text(encoding="utf-8"))
+    document["legacy_spec_id"] = forged
+    spec_path.write_text(json.dumps(document), encoding="utf-8")
+    _rebind_suite_to(target / DEFAULT_SUITE_FILENAME, forged)
+
+    with pytest.raises(ConfigurationError, match="re-run agentcheck generate"):
+        application.execute_suite(target, run_id="after-forgery", persist_store=False)
+
+
+def test_a_nested_entrypoint_is_portable_and_distinct(tmp_path: Path) -> None:
+    """A deeper relative entrypoint travels, and is not the same as a shallow one."""
+
+    import json
+
+    def build(root: Path, relative: str) -> Path:
+        module = root / relative
+        module.parent.mkdir(parents=True, exist_ok=True)
+        for parent in list(module.parents)[:-1]:
+            if parent == root:
+                break
+            (parent / "__init__.py").write_text("", encoding="utf-8")
+        shutil.copyfile(EXAMPLE / "agent.py", module)
+        (root / "agentcheck.json").write_text(
+            json.dumps(
+                {"entrypoint": f"{relative}:agent", "adapter": "openai_agents"}
+            ),
+            encoding="utf-8",
+        )
+        return root
+
+    nested_a = build(tmp_path / "one", "src/deep/agent.py")
+    nested_b = build(tmp_path / "elsewhere" / "two", "src/deep/agent.py")
+    shallow = build(tmp_path / "three", "agent.py")
+
+    assert (
+        inspect_target(nested_a)[2].value.spec_id
+        == inspect_target(nested_b)[2].value.spec_id
+    )
+    assert (
+        inspect_target(nested_a)[2].value.spec_id
+        != inspect_target(shallow)[2].value.spec_id
+    )

--- a/tests/agentcheck/test_target_loading.py
+++ b/tests/agentcheck/test_target_loading.py
@@ -12,7 +12,11 @@ import pytest
 
 from agentcheck.adapters import OpenAIAgentsAdapter
 from agentcheck.cli import main
-from agentcheck.config import apply_python_executable, load_config
+from agentcheck.config import (
+    apply_python_executable,
+    load_config,
+    portable_entrypoint,
+)
 from agentcheck.errors import ConfigurationError
 from agentcheck.initialize import write_initial_config
 from agentcheck.inspect import TargetLoadError, load_target
@@ -167,11 +171,27 @@ def test_module_level_agent_still_loads(tmp_path: Path) -> None:
 
 
 def test_account_agent_spec_id_remains_stable() -> None:
+    """In-process and worker inspection must agree on identity.
+
+    They agree only when both derive it the same way, so this also pins the
+    relationship between the two identity modes: supplying the portable
+    locator yields the pipeline's ``spec_id``, and omitting it reproduces
+    exactly the location-bound value the worker records as ``legacy_spec_id``.
+    """
+
     loaded, source = load_target(EXAMPLE)
-    expected = OpenAIAgentsAdapter().inspect(loaded, source=source)
     root, config = load_config(EXAMPLE)
+    portable = OpenAIAgentsAdapter().inspect(
+        loaded, source=source, identity_locator=portable_entrypoint(root, config.entrypoint)
+    )
+    location_bound = OpenAIAgentsAdapter().inspect(loaded, source=source)
+
     result = inspect_in_subprocess(root, config)
-    assert result.require_value().spec_id == expected.spec_id
+    worker_spec = result.require_value()
+
+    assert worker_spec.spec_id == portable.spec_id
+    assert worker_spec.legacy_spec_id == location_bound.spec_id
+    assert worker_spec.spec_id != worker_spec.legacy_spec_id
 
 
 def test_missing_dependency_fails_clearly_without_pip(

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -129,6 +129,9 @@ COMPATIBILITY_SUITE: dict[str, dict[str, object]] = {
             # interpreters, and this contract must hold on every version the
             # package claims to support.
             "tests/agentcheck/test_custom_agent_contract.py",
+            # Target identity is derived from a path resolved and relativized by
+            # the interpreter, so its normalization is a cross-version surface.
+            "tests/agentcheck/test_portable_identity.py",
         ),
         "symbols": ("main", "import"),
     },


### PR DESCRIPTION
## The bug

`spec_id` hashed the **absolute** entrypoint path, so the same unchanged agent
inspected as a *different target* in a different directory.

```
/home/waseem/proj/agent-under-test   agentspec-01e73067…
/opt/ci/ws/agent-under-test          agentspec-3918f52b…
/var/tmp/x1y2z3/agent-under-test     agentspec-fd6adcb2…
```

Three byte-identical copies, three identities — reproduced end to end through
the real pipeline before any fix. A suite or baseline produced on a developer
machine was refused in CI purely because the checkout lived somewhere else,
which defeats the point of a CI-oriented behavioral testing tool.

## The leak was narrow

Already portable: `config.entrypoint`, `SpecBinding.entrypoint`,
`SourceFileEntry.path`, `entrypoint_digest`, and the handoff graph (whose
locations are structural, not path-derived). Only the adapter fingerprint's
`source` key carried the checkout location.

## New identity model

Identity hashes the entrypoint **relative to the target root**, canonicalized
through the resolved path to POSIX form.

**Semantic** (moves identity): declared name · framework and verified version ·
model · instructions digest · every declared tool with its full input *and*
output schema and its `state_changing` / `destructive` / `replaceable` flags ·
handoff graph by structural position · the relative entrypoint.

**Location metadata** (excluded): absolute path, username, temp directory, OS
root, CI workspace root; how the same relative path was spelled (`./agent.py`,
`agent//agent.py`); the host path separator; whether the checkout was reached
through a symlink.

Evidence still records the real absolute location for diagnostics. Evidence
never influences identity.

## Legacy artifacts — bridged, never invented

An inspection also records `legacy_spec_id`: the identity the **same**
inspection would have produced under the old contract, reproduced from the same
bytes (a test pins it against the previously-committed literal). A frozen
suite, replay manifest or baseline carrying a legacy identity is accepted only
when this inspection *reproduces* that value — possible only at the original
path with an unchanged behavioral surface, which is exactly the evidence the
old contract required. Carried anywhere else it is refused.

The refusal states the migration path **conditionally**, because a relocated
legacy artifact and a real contract change are indistinguishable from the
recorded identity alone. Nothing is rewritten in place; nothing is migrated
silently.

`legacy_spec_id` is not a downgrade path. It is the *stricter* binding (it
pins the path too), so it can admit nothing the portable identity would not.
Tests prove a forged identity, a legacy identity belonging to a different agent
at this very path, and a forged `legacy_spec_id` planted in a stored
`agent-spec.json` are all refused.

## Source integrity is untouched

Replay still binds `entrypoint_digest` and the bounded file set, and still
refuses changed source **from the new location**. Frozen suites still verify
their own fingerprint, so a hand-edited `spec_id` invalidates the document.
Declared policy packs are still bound explicitly rather than folded into
`spec_id`. Portability widened *where* a trusted artifact may be used; it did
not widen *what counts as the same source*.

## Compatibility — measured, not assumed

Regenerating the bundled example at one fixed path across this change moves
exactly three values: `spec_id`, and the `suite_id` and `fingerprint` derived
from it.

```
FIELDS THAT DIFFER: ['fingerprint', 'spec_id', 'suite_id']
cases byte-identical : True
scenario fingerprints: 35/35 unchanged
```

All 35 scenario fingerprints are unchanged, so **baseline cases still align**
and only the top-level identity gate differs. `agentcheck.agent_spec.v1` gains
one optional field, `legacy_spec_id`; specs written before it still load. No
other serialized contract gains or loses a field, and no fingerprint algorithm
changes. The package version is untouched.

## Honesty boundary

`framework_version` remains an identity input by design — the adapter is pinned
to a verified minor version, and a different SDK version may legitimately
produce a different spec. Portability therefore means *same contract, same
pinned framework semantics, different filesystem root*. It does not mean
different framework versions are equivalent.

## Validation

- `python -m pytest tests -q -n 2` — 1262 passed
- ruff · mypy · workflow-safety · secret-scan — clean
- 35 new tests in `tests/agentcheck/test_portable_identity.py`, added to the
  cross-version compatibility manifest
- End-to-end: suite generated locally accepted from a CI checkout; baseline
  created locally gates a CI run; replay works across checkouts and still
  rejects changed source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
