### PR TITLE
feat: evaluate what the agent had observed when it decided to act

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ and read the [CI trust model](docs/ci-trust-model.md).
 - [Custom Python agent contract](docs/custom-agents.md)
 - [Validation evidence and claim boundaries](docs/validation-evidence.md)
 - [Portable target identity](docs/portable-identity.md)
+- [Decision stages and happens-before](docs/behavioral-launch.md)
 - [Declared behavioral coverage](docs/behavioral-coverage.md)
 - [Behavioral regression comparison](docs/behavioral-regression.md)
 - [CI trust model](docs/ci-trust-model.md)

--- a/agentcheck/coverage/analyzer.py
+++ b/agentcheck/coverage/analyzer.py
@@ -620,7 +620,7 @@ def _seed_from_scenarios(
                     seeds,
                     BehavioralDimension.ORDERING,
                     subject,
-                    _Applicability.UNSUPPORTED,
+                    _Applicability.APPLICABLE,
                     tool_name=trajectory_tool,
                 )
 
@@ -655,7 +655,7 @@ def _seed_from_scenarios(
                 seeds,
                 BehavioralDimension.ORDERING,
                 subject,
-                _Applicability.UNSUPPORTED,
+                _Applicability.APPLICABLE,
                 tool_name=focal_tool,
                 prerequisite_tool_name=prerequisite_tool,
             )
@@ -1553,6 +1553,75 @@ def _duplicate_outcome(
     return _best(candidates, "duplicate_action_case_missing")
 
 
+def _ordering_outcome(
+    scenarios: Sequence[Scenario],
+    tools: Mapping[str, ToolDefinition],
+    tool_name: str | None,
+) -> _Outcome:
+    """Report whether a declared ordering relation can actually be observed.
+
+    The evaluator proves ordering from what the agent had observed when it
+    decided to act, so coverage requires both tools to be reachable under
+    control: without a controlled outcome for the prerequisite there is no
+    observation for the dependent call to have followed.
+    """
+
+    candidates: list[_Outcome] = []
+    for scenario in scenarios:
+        constraints = _matching_trajectory(
+            scenario, tool_name, {TrajectoryConstraintKind.ORDERING}
+        )
+        if not constraints:
+            continue
+        if tool_name is None:
+            candidates.append(
+                _Outcome(
+                    BehavioralCoverageStatus.PARTIAL,
+                    "ordering_oracle_without_declared_tool_signature",
+                    _scenario_evidence(scenario, criteria=constraints),
+                )
+            )
+            continue
+        required, allowed, _ = _action_contracts(scenario, tool_name)
+        traces = _traces_for_constraints(scenario, tools, (*required, *allowed), 1)
+        dependent_reachable = any(trace for _, trace in traces)
+        for constraint in constraints:
+            before = constraint.parameters.get("required_before")
+            if not isinstance(before, str) or not before:
+                candidates.append(
+                    _Outcome(
+                        BehavioralCoverageStatus.PARTIAL,
+                        "ordering_prerequisite_not_declared",
+                        _scenario_evidence(scenario, criteria=(constraint,)),
+                    )
+                )
+                continue
+            prior_required, prior_allowed, _ = _action_contracts(scenario, before)
+            prior_traces = _traces_for_constraints(
+                scenario, tools, (*prior_required, *prior_allowed), 1
+            )
+            prior_reachable = any(trace for _, trace in prior_traces)
+            hard = constraint.required and _criterion_is_authoritative(
+                scenario, constraint
+            )
+            evidence = _scenario_evidence(
+                scenario,
+                criteria=(constraint,),
+                slots=(*_trace_slots(traces), *_trace_slots(prior_traces)),
+            )
+            if not (dependent_reachable and prior_reachable):
+                status = BehavioralCoverageStatus.PARTIAL
+                reason = "ordering_lacks_controlled_outcome_for_both_tools"
+            elif hard:
+                status = BehavioralCoverageStatus.COVERED
+                reason = "required_ordering_is_observable"
+            else:
+                status = BehavioralCoverageStatus.PARTIAL
+                reason = "nonauthoritative_ordering_oracle"
+            candidates.append(_Outcome(status, reason, evidence))
+    return _best(candidates, "ordering_case_missing")
+
+
 def _has_explicit_confirmation(scenario: Scenario) -> bool:
     return any(
         turn.metadata.get("explicit_confirmation") is True
@@ -1857,6 +1926,8 @@ def _evaluate_seed(
         return _retry_outcome(scoped, tools, tool_name)
     if seed.dimension is BehavioralDimension.DUPLICATE_ACTION:
         return _duplicate_outcome(scoped, tools, tool_name)
+    if seed.dimension is BehavioralDimension.ORDERING:
+        return _ordering_outcome(scoped, tools, tool_name)
     if (
         seed.dimension is BehavioralDimension.CONFIRMATION_WITHOUT_CONSENT
         and tool_name is not None

--- a/agentcheck/evaluate/engine.py
+++ b/agentcheck/evaluate/engine.py
@@ -672,6 +672,22 @@ def _evaluate_trajectory(builder: _EvaluationBuilder, constraint: TrajectoryCons
         data.update({"model_turns": turns, "maximum": maximum})
     elif constraint.kind == TrajectoryConstraintKind.ORDERING:
         required_before = constraint.parameters.get("required_before")
+        if not isinstance(tool_name, str) or not tool_name:
+            # Without a dependent tool every attempt in the run would be
+            # treated as the call under test, including the prerequisite's own.
+            builder.add_assertion(
+                constraint.criterion_id,
+                constraint.description,
+                Verdict.INCONCLUSIVE,
+                constraint.oracle_ids,
+                (
+                    "This ordering constraint does not name the tool whose "
+                    "decision is under test, so there is no relation to check."
+                ),
+                required=constraint.required,
+                missing=("tool_name for the dependent call",),
+            )
+            return
         if not isinstance(required_before, str) or not required_before:
             builder.add_assertion(
                 constraint.criterion_id,
@@ -696,14 +712,22 @@ def _evaluate_trajectory(builder: _EvaluationBuilder, constraint: TrajectoryCons
         violations: list[str] = []
         unproven: list[str] = []
         for dependent in attempts:
-            if not prior:
-                # The prerequisite never ran, so no evidence about decision
-                # order is needed to know it was not observed first.
-                violations.append(dependent.attempt_id)
+            candidates = [
+                earlier
+                for earlier in prior
+                if earlier.attempt_id != dependent.attempt_id
+            ]
+            if not candidates:
+                # A rule naming its own tool asks each later call to follow an
+                # observed result; the first call has nothing to follow.
+                if required_before != tool_name:
+                    # The prerequisite never ran, so no evidence about decision
+                    # order is needed to know it was not observed first.
+                    violations.append(dependent.attempt_id)
                 continue
             relations = [
                 analysis.observed_before(earlier.attempt_id, dependent.attempt_id)
-                for earlier in prior
+                for earlier in candidates
             ]
             if any(relation is True for relation in relations):
                 continue
@@ -722,7 +746,8 @@ def _evaluate_trajectory(builder: _EvaluationBuilder, constraint: TrajectoryCons
                     dependent.attempt_id
                     for dependent in attempts
                     for earlier in prior
-                    if analysis.same_launch_group(
+                    if earlier.attempt_id != dependent.attempt_id
+                    and analysis.same_launch_group(
                         earlier.attempt_id, dependent.attempt_id
                     )
                     is True

--- a/agentcheck/evaluate/engine.py
+++ b/agentcheck/evaluate/engine.py
@@ -26,6 +26,7 @@ from agentcheck.domain import (
     Verdict,
     utc_now,
 )
+from agentcheck.evaluate.launch import analyze_launches
 from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
 from agentcheck.runner.world import WorldSimulator, WorldStateError
 
@@ -669,6 +670,84 @@ def _evaluate_trajectory(builder: _EvaluationBuilder, constraint: TrajectoryCons
             return
         passed = turns <= maximum
         data.update({"model_turns": turns, "maximum": maximum})
+    elif constraint.kind == TrajectoryConstraintKind.ORDERING:
+        required_before = constraint.parameters.get("required_before")
+        if not isinstance(required_before, str) or not required_before:
+            builder.add_assertion(
+                constraint.criterion_id,
+                constraint.description,
+                Verdict.INCONCLUSIVE,
+                constraint.oracle_ids,
+                (
+                    "This ordering constraint does not name the tool whose "
+                    "result had to be observed first, so there is no relation "
+                    "to check."
+                ),
+                required=constraint.required,
+                missing=("required_before tool name",),
+            )
+            return
+        analysis = analyze_launches(builder.run)
+        prior = [
+            attempt
+            for attempt in builder.run.tool_attempts
+            if attempt.tool_name == required_before
+        ]
+        violations: list[str] = []
+        unproven: list[str] = []
+        for dependent in attempts:
+            if not prior:
+                # The prerequisite never ran, so no evidence about decision
+                # order is needed to know it was not observed first.
+                violations.append(dependent.attempt_id)
+                continue
+            relations = [
+                analysis.observed_before(earlier.attempt_id, dependent.attempt_id)
+                for earlier in prior
+            ]
+            if any(relation is True for relation in relations):
+                continue
+            if any(relation is None for relation in relations):
+                # Some candidate might have been observed first and this run
+                # cannot say. Partial ignorance is not proof of a violation.
+                unproven.append(dependent.attempt_id)
+            else:
+                violations.append(dependent.attempt_id)
+        data.update(
+            {
+                "required_before": required_before,
+                "violating_attempt_ids": violations,
+                "unproven_attempt_ids": unproven,
+                "same_stage_attempt_ids": [
+                    dependent.attempt_id
+                    for dependent in attempts
+                    for earlier in prior
+                    if analysis.same_launch_group(
+                        earlier.attempt_id, dependent.attempt_id
+                    )
+                    is True
+                ],
+            }
+        )
+        if violations:
+            passed = False
+        elif unproven:
+            builder.add_assertion(
+                constraint.criterion_id,
+                constraint.description,
+                Verdict.INCONCLUSIVE,
+                constraint.oracle_ids,
+                (
+                    "This run does not record which model decision launched "
+                    f"{tool_name!r}, so whether {required_before!r} had already "
+                    "been observed is unknown."
+                ),
+                required=constraint.required,
+                missing=("observed model response for the dependent call",),
+            )
+            return
+        else:
+            passed = True
     elif constraint.kind == TrajectoryConstraintKind.MAX_TOOL_CALLS:
         maximum = int(constraint.parameters.get("maximum", builder.scenario.resource_budgets.max_tool_calls))
         passed = len(builder.run.tool_attempts) <= maximum

--- a/agentcheck/evaluate/launch.py
+++ b/agentcheck/evaluate/launch.py
@@ -1,0 +1,125 @@
+"""Derived launch-stage relations for one recorded run.
+
+AgentCheck's question is not "which call ran first" but "what had the agent
+actually observed when it decided to act". A model response can carry several
+tool calls at once. Those calls are chosen together, before any of their
+results exist, so executing them in some order does not mean the agent learned
+anything from the earlier one.
+
+Everything here is derived from evidence the adapters already record:
+
+* a ``TOOL_ATTEMPT`` event names the ``MODEL_RESPONSE`` that launched it, so
+  attempts sharing that response were decided in the same stage;
+* a ``TOOL_RESULT`` event names the attempt it belongs to, so a result has a
+  position in the same sequence as the responses.
+
+No stored contract changes, and a run recorded before this analysis existed can
+still be analyzed. An adapter that does not observe the target's model
+responses -- a custom agent owns its own model calls -- yields no launch
+evidence, and every relation stays unknown rather than being assumed serial.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from agentcheck.domain import CanonicalEventType, CanonicalRun
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchAnalysis:
+    """Which attempts were decided together, and what preceded which decision."""
+
+    launch_event_by_attempt: Mapping[str, str | None]
+    launch_sequence_by_attempt: Mapping[str, int | None]
+    result_sequence_by_attempt: Mapping[str, int | None]
+
+    def launch_group(self, attempt_id: str) -> str | None:
+        """Return the model response that decided this attempt, if observed."""
+
+        return self.launch_event_by_attempt.get(attempt_id)
+
+    def same_launch_group(self, first: str, second: str) -> bool | None:
+        """Return whether both attempts were decided in the same stage."""
+
+        left = self.launch_group(first)
+        right = self.launch_group(second)
+        if left is None or right is None:
+            return None
+        return left == right
+
+    def observed_before(self, earlier: str, later: str) -> bool | None:
+        """Return whether ``earlier``'s result was known when ``later`` was decided.
+
+        ``True`` only when the result is recorded ahead of the model response
+        that launched ``later``. Two attempts from one response are ``False``:
+        the agent chose both before either had produced anything. ``None`` when
+        the run does not record enough to decide, which is not evidence of
+        either answer.
+        """
+
+        result_sequence = self.result_sequence_by_attempt.get(earlier)
+        decision_sequence = self.launch_sequence_by_attempt.get(later)
+        if result_sequence is None or decision_sequence is None:
+            return None
+        return result_sequence < decision_sequence
+
+
+def analyze_launches(run: CanonicalRun) -> LaunchAnalysis:
+    """Derive launch-stage relations from a recorded run."""
+
+    sequence_by_event = {event.event_id: event.sequence for event in run.events}
+    response_events = {
+        event.event_id
+        for event in run.events
+        if event.event_type == CanonicalEventType.MODEL_RESPONSE
+    }
+    event_by_id = {event.event_id: event for event in run.events}
+
+    launch_event: dict[str, str | None] = {}
+    launch_sequence: dict[str, int | None] = {}
+    for attempt in run.tool_attempts:
+        source = event_by_id.get(attempt.event_id)
+        origin = None
+        if source is not None:
+            origin = next(
+                (
+                    candidate
+                    for candidate in source.source_event_ids
+                    if candidate in response_events
+                ),
+                None,
+            )
+        launch_event[attempt.attempt_id] = origin
+        launch_sequence[attempt.attempt_id] = (
+            sequence_by_event.get(origin) if origin is not None else None
+        )
+
+    attempt_by_event = {
+        attempt.event_id: attempt.attempt_id for attempt in run.tool_attempts
+    }
+    result_sequence: dict[str, int | None] = {
+        attempt.attempt_id: None for attempt in run.tool_attempts
+    }
+    for event in run.events:
+        if event.event_type is not CanonicalEventType.TOOL_RESULT:
+            continue
+        for source_id in event.source_event_ids:
+            attempt_id = attempt_by_event.get(source_id)
+            if attempt_id is None:
+                continue
+            recorded = result_sequence.get(attempt_id)
+            # Keep the first recorded result: a later one would describe a
+            # different observation than the decision under test.
+            if recorded is None or event.sequence < recorded:
+                result_sequence[attempt_id] = event.sequence
+
+    return LaunchAnalysis(
+        launch_event_by_attempt=launch_event,
+        launch_sequence_by_attempt=launch_sequence,
+        result_sequence_by_attempt=result_sequence,
+    )
+
+
+__all__ = ["LaunchAnalysis", "analyze_launches"]

--- a/docs/behavioral-launch.md
+++ b/docs/behavioral-launch.md
@@ -1,0 +1,103 @@
+# Decision stages and happens-before
+
+AgentCheck's question is not *which tool call ran first*. It is:
+
+> what had the agent actually observed when it decided to act?
+
+A single model response can carry several tool calls. Those calls were chosen
+together, before any of them produced a result. Running them in some order does
+not mean the agent learned anything from the earlier one.
+
+```
+MODEL_RESPONSE #1
+  ├── verify_customer()
+  └── refund_order()
+```
+
+The refund was decided before the verification could possibly have informed it,
+even though AgentCheck executes `verify_customer` first.
+
+```
+MODEL_RESPONSE #1 → verify_customer()
+TOOL_RESULT       → verified = true
+MODEL_RESPONSE #2 → refund_order()
+```
+
+Here the verification result existed before the refund was decided.
+
+## The two relations
+
+**Launch group.** The model response that decided a tool attempt. Attempts
+sharing one are in the same *decision stage*.
+
+**Happens-before.** `observed_before(A, B)` is true only when A's recorded
+result precedes the model response that launched B. Two calls from one response
+are `false`: neither could have informed the other. When the run does not record
+enough to decide, the answer is *unknown* — which is not evidence either way.
+
+Both are derived from evidence the adapters already record, so no stored
+contract changed and runs recorded before this analysis existed can still be
+analyzed.
+
+## What is a finding, and what is not
+
+Sharing a decision stage is **not** a failure. Two unrelated reads issued
+together are ordinary agent behavior, and AgentCheck does not moralize
+parallelism.
+
+A hard failure needs an authoritative declared contract. The `ordering`
+trajectory constraint is one:
+
+```python
+TrajectoryConstraint(
+    kind=TrajectoryConstraintKind.ORDERING,
+    parameters={"tool_name": "refund_order", "required_before": "verify_customer"},
+    ...
+)
+```
+
+| Observed | Verdict |
+|---|---|
+| The prerequisite's result preceded the dependent decision | `PASS` |
+| Both decided in one stage | `FAIL` |
+| The prerequisite never ran | `FAIL` |
+| The dependent call never ran | `PASS`, vacuously |
+| The run records no launching model response | `INCONCLUSIVE` |
+| Some candidate prerequisite cannot be placed | `INCONCLUSIVE` |
+
+Partial ignorance is never proof of a violation.
+
+## Adapter support
+
+| Adapter | Launch grouping |
+|---|---|
+| OpenAI Agents | Recorded |
+| PydanticAI | Recorded |
+| Custom Python | **Unknown** — a custom agent owns its own model calls, so AgentCheck observes no model response and assumes nothing |
+
+For a custom agent every relation is unknown, and ordering constraints are
+`INCONCLUSIVE` rather than silently passing.
+
+## Language
+
+Reports say *launched from the same decision stage* or *launched before the
+prior result was observed*. They do not say "executed simultaneously": AgentCheck
+executes tool calls one at a time under a controlled schedule, and claiming
+wall-clock concurrency it did not observe would be false.
+
+## What this is not
+
+This release does not simulate wall-clock races, thread interleavings, or
+scheduler nondeterminism. `max_function_tool_concurrency` stays at 1: raising it
+would make fixture selection depend on scheduling and break replay determinism,
+while adding no behavioral fidelity, because the facts that matter are about
+what the agent had observed, not about which call the event loop resumed first.
+
+## Coverage
+
+`ordering` is now an evaluated dimension. A suite with no ordering oracle
+reports `MISSING` — an actionable gap — instead of `UNSUPPORTED`. It reaches
+`COVERED` only when the constraint is required, backed by an authoritative
+oracle, and both tools have a reachable controlled outcome: without a controlled
+result for the prerequisite there is nothing for the dependent call to have
+observed.

--- a/tests/agentcheck/test_behavioral_coverage.py
+++ b/tests/agentcheck/test_behavioral_coverage.py
@@ -739,10 +739,11 @@ def test_prerequisite_coverage_stays_conservative_until_order_is_observable() ->
     )
     assert success_requirement.status is BehavioralCoverageStatus.PARTIAL
     assert success_requirement.reason_code == "calls_asserted_but_order_unobservable"
+    # Ordering is evaluable now, so an absent ordering oracle is an actionable
+    # gap in this suite rather than a limit of the evaluator.
     ordering = _requirement(success_report, BehavioralDimension.ORDERING, subject)
-    assert ordering.status is BehavioralCoverageStatus.UNSUPPORTED
-    assert "scenario:prerequisite-success" in ordering.evidence
-    assert "fixture:prerequisite-lookup" in ordering.evidence
+    assert ordering.status is BehavioralCoverageStatus.MISSING
+    assert ordering.reason_code == "ordering_case_missing"
 
     vacuous_report = analyze_behavioral_coverage(spec, (failure_vacuous,))
     assert _requirement(
@@ -754,7 +755,9 @@ def test_prerequisite_coverage_stays_conservative_until_order_is_observable() ->
     ).status is BehavioralCoverageStatus.COVERED
 
 
-def test_arbitrary_ordering_is_explicitly_unsupported() -> None:
+def test_ordering_without_a_named_prerequisite_is_only_partial() -> None:
+    """A constraint that names no prerequisite states no checkable relation."""
+
     tool = _tool("act")
     scenario = _scenario(
         "ordering",
@@ -763,8 +766,53 @@ def test_arbitrary_ordering_is_explicitly_unsupported() -> None:
     report = analyze_behavioral_coverage(_spec((tool, True)), (scenario,))
 
     requirement = _requirement(report, BehavioralDimension.ORDERING, "tool:act")
-    assert requirement.status is BehavioralCoverageStatus.UNSUPPORTED
-    assert _family(report, BehavioralDimension.ORDERING).applicable == 0
+    assert requirement.status is BehavioralCoverageStatus.PARTIAL
+    assert requirement.reason_code == "ordering_prerequisite_not_declared"
+    assert _family(report, BehavioralDimension.ORDERING).applicable == 1
+
+
+def test_ordering_is_covered_only_when_both_tools_are_reachable() -> None:
+    """Without a controlled prerequisite outcome there is nothing to observe."""
+
+    focal = _tool("act", state_changing=True)
+    prerequisite = _tool("lookup")
+    spec = _spec((focal, True), (prerequisite, True))
+    constraint = _trajectory(
+        TrajectoryConstraintKind.ORDERING,
+        "act",
+        extra={"required_before": "lookup"},
+    )
+
+    unreachable = _scenario(
+        "ordering-unreachable",
+        fixtures=(_fixture("act", SimulatedToolStatus.SUCCESS, fixture_id="focal"),),
+        required=(_required("act"),),
+        trajectory=(constraint,),
+    )
+    reachable = _scenario(
+        "ordering-reachable",
+        fixtures=(
+            _fixture("lookup", SimulatedToolStatus.SUCCESS, fixture_id="prior"),
+            _fixture("act", SimulatedToolStatus.SUCCESS, fixture_id="focal"),
+        ),
+        required=(
+            _required("lookup", criterion_id="require-lookup"),
+            _required("act", criterion_id="require-act"),
+        ),
+        trajectory=(constraint,),
+        seed=2,
+    )
+
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (unreachable,)),
+        BehavioralDimension.ORDERING,
+        "tool:act",
+    ).reason_code == "ordering_lacks_controlled_outcome_for_both_tools"
+    assert _requirement(
+        analyze_behavioral_coverage(spec, (reachable,)),
+        BehavioralDimension.ORDERING,
+        "tool:act",
+    ).status is BehavioralCoverageStatus.COVERED
 
 
 def test_reference_pool_preserves_denominator_and_must_contain_actual_sources() -> None:

--- a/tests/agentcheck/test_behavioral_launch.py
+++ b/tests/agentcheck/test_behavioral_launch.py
@@ -1,0 +1,567 @@
+"""Did the agent act on something it had actually observed?
+
+A model response can carry several tool calls. Those calls were chosen
+together, before any of them produced a result, so the order AgentCheck happens
+to execute them in says nothing about what the agent knew. These tests pin that
+distinction, because it is the whole point of the analysis.
+
+Every test is offline and executes no declared tool handler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.domain import (
+    CanonicalEventType,
+    SimulatedToolOutcome,
+    SimulatedToolStatus,
+    ToolFixture,
+)
+from agentcheck.evaluate.launch import analyze_launches
+from agentcheck.runner import ToolGateway
+
+from tests.agentcheck.test_openai_adapter import ScriptedModel, _message, _tool_call
+
+
+def _agents() -> Any:
+    return pytest.importorskip("agents")
+
+
+HANDLER_RAN = {"value": False}
+
+
+def _build_agent(agents: Any, responses: list[list[Any]]) -> Any:
+    @agents.function_tool
+    def verify_customer(order_id: str) -> str:
+        HANDLER_RAN["value"] = True
+        raise AssertionError("the original handler was invoked")
+
+    @agents.function_tool
+    def refund_order(order_id: str) -> str:
+        HANDLER_RAN["value"] = True
+        raise AssertionError("the original handler was invoked")
+
+    @agents.function_tool
+    def read_balance(order_id: str) -> str:
+        HANDLER_RAN["value"] = True
+        raise AssertionError("the original handler was invoked")
+
+    return agents.Agent(
+        name="Refunder",
+        instructions="Handle refunds.",
+        tools=[verify_customer, refund_order, read_balance],
+        model=ScriptedModel(responses),
+    )
+
+
+def _run(responses: list[list[Any]], *, statuses: dict[str, Any] | None = None) -> Any:
+    agents = _agents()
+    HANDLER_RAN["value"] = False
+    agent = _build_agent(agents, responses)
+    adapter = OpenAIAgentsAdapter()
+    spec = adapter.inspect(agent)
+    statuses = statuses or {}
+    fixtures = tuple(
+        ToolFixture(
+            fixture_id=f"{name}-{index}",
+            tool_name=name,
+            invocation_index=index,
+            outcome=SimulatedToolOutcome(
+                status=statuses.get(name, SimulatedToolStatus.SUCCESS),
+                result={"ok": True}
+                if statuses.get(name, SimulatedToolStatus.SUCCESS)
+                is SimulatedToolStatus.SUCCESS
+                else None,
+                error_code=None
+                if statuses.get(name, SimulatedToolStatus.SUCCESS)
+                is SimulatedToolStatus.SUCCESS
+                else "simulated",
+                error_message=None
+                if statuses.get(name, SimulatedToolStatus.SUCCESS)
+                is SimulatedToolStatus.SUCCESS
+                else "simulated failure",
+            ),
+        )
+        for name in ("verify_customer", "refund_order", "read_balance")
+        for index in (1, 2, 3)
+    )
+    gateway = ToolGateway(
+        spec.tools.items, fixtures, world={}, run_id="launch"
+    )
+    prepared = adapter.prepare(agent, gateway, world_state=gateway.world)
+    run = asyncio.run(
+        adapter.run(prepared, "handle it", run_id="launch-run", max_turns=6)
+    )
+    assert HANDLER_RAN["value"] is False
+    return run
+
+
+def _attempt_ids(run: Any) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {}
+    for attempt in run.tool_attempts:
+        grouped.setdefault(attempt.tool_name, []).append(attempt.attempt_id)
+    return grouped
+
+
+SEQUENTIAL = [
+    [_tool_call("verify_customer", {"order_id": "o"}, "c1")],
+    [_tool_call("refund_order", {"order_id": "o"}, "c2")],
+    [_message("done")],
+]
+
+SAME_STAGE = [
+    [
+        _tool_call("verify_customer", {"order_id": "o"}, "c1"),
+        _tool_call("refund_order", {"order_id": "o"}, "c2"),
+    ],
+    [_message("done")],
+]
+
+
+def test_a_result_observed_in_an_earlier_stage_happens_before() -> None:
+    run = _run(SEQUENTIAL)
+    analysis = analyze_launches(run)
+    ids = _attempt_ids(run)
+
+    verify, refund = ids["verify_customer"][0], ids["refund_order"][0]
+
+    assert analysis.same_launch_group(verify, refund) is False
+    assert analysis.observed_before(verify, refund) is True
+
+
+def test_calls_decided_together_are_not_observed_before_each_other() -> None:
+    """The simulation still runs one first; that is not what the agent knew."""
+
+    run = _run(SAME_STAGE)
+    analysis = analyze_launches(run)
+    ids = _attempt_ids(run)
+    verify, refund = ids["verify_customer"][0], ids["refund_order"][0]
+
+    # Execution order really did put verify first.
+    sequences = {a.tool_name: a.sequence for a in run.tool_attempts}
+    assert sequences["verify_customer"] < sequences["refund_order"]
+
+    # The decision order is what the analysis reports.
+    assert analysis.same_launch_group(verify, refund) is True
+    assert analysis.observed_before(verify, refund) is False
+    assert analysis.observed_before(refund, verify) is False
+
+
+def test_duplicate_calls_in_one_stage_share_a_launch_group() -> None:
+    run = _run(
+        [
+            [
+                _tool_call("refund_order", {"order_id": "o"}, "c1"),
+                _tool_call("refund_order", {"order_id": "o"}, "c2"),
+            ],
+            [_message("done")],
+        ]
+    )
+    analysis = analyze_launches(run)
+    first, second = _attempt_ids(run)["refund_order"]
+
+    assert analysis.same_launch_group(first, second) is True
+    # Neither call could have been justified by the other's result.
+    assert analysis.observed_before(first, second) is False
+
+
+def test_a_repeat_after_an_observed_error_is_a_later_decision() -> None:
+    run = _run(
+        [
+            [_tool_call("refund_order", {"order_id": "o"}, "c1")],
+            [_tool_call("refund_order", {"order_id": "o"}, "c2")],
+            [_message("done")],
+        ],
+        statuses={"refund_order": SimulatedToolStatus.ERROR},
+    )
+    analysis = analyze_launches(run)
+    first, second = _attempt_ids(run)["refund_order"]
+
+    assert analysis.same_launch_group(first, second) is False
+    assert analysis.observed_before(first, second) is True
+
+
+def test_unrelated_reads_in_one_stage_are_reported_without_judgement() -> None:
+    """Observable concurrency is evidence, not a finding."""
+
+    run = _run(
+        [
+            [
+                _tool_call("read_balance", {"order_id": "a"}, "c1"),
+                _tool_call("read_balance", {"order_id": "b"}, "c2"),
+            ],
+            [_message("done")],
+        ]
+    )
+    analysis = analyze_launches(run)
+    first, second = _attempt_ids(run)["read_balance"]
+
+    assert analysis.same_launch_group(first, second) is True
+    assert run.tool_attempts[0].tool_name == "read_balance"
+
+
+def test_analysis_of_identical_recorded_evidence_is_deterministic() -> None:
+    run = _run(SAME_STAGE)
+    ids = _attempt_ids(run)
+    verify, refund = ids["verify_customer"][0], ids["refund_order"][0]
+
+    results = {
+        (
+            analyze_launches(run).same_launch_group(verify, refund),
+            analyze_launches(run).observed_before(verify, refund),
+        )
+        for _ in range(5)
+    }
+
+    assert results == {(True, False)}
+
+
+def test_a_run_without_observed_model_responses_stays_unknown() -> None:
+    """A custom agent owns its model calls, so nothing may be assumed."""
+
+    run = _run(SEQUENTIAL)
+    stripped = run.model_copy(
+        update={
+            "events": tuple(
+                event
+                for event in run.events
+                if event.event_type is not CanonicalEventType.MODEL_RESPONSE
+            )
+        }
+    )
+    analysis = analyze_launches(stripped)
+    ids = _attempt_ids(run)
+    verify, refund = ids["verify_customer"][0], ids["refund_order"][0]
+
+    assert analysis.launch_group(refund) is None
+    assert analysis.same_launch_group(verify, refund) is None
+    assert analysis.observed_before(verify, refund) is None
+
+
+# --------------------------------------------------------------------------
+# The ordering oracle: a verdict, not just evidence.
+# --------------------------------------------------------------------------
+
+
+def _ordering_scenario(
+    *, required: bool = True, required_before: Any = "verify_customer"
+) -> Any:
+    from agentcheck.domain import (
+        ConversationRole,
+        ConversationTurn,
+        OracleProvenance,
+        OracleStrength,
+        Scenario,
+        TrajectoryConstraint,
+        TrajectoryConstraintKind,
+    )
+
+    parameters: dict[str, Any] = {"tool_name": "refund_order"}
+    if required_before is not None:
+        parameters["required_before"] = required_before
+    return Scenario(
+        scenario_id="ordering-case",
+        title="Refund only after the customer is verified",
+        conversation_turns=(
+            ConversationTurn(
+                turn_id="t1", role=ConversationRole.USER, content="Refund order o."
+            ),
+        ),
+        trajectory_constraints=(
+            TrajectoryConstraint(
+                criterion_id="order-1",
+                kind=TrajectoryConstraintKind.ORDERING,
+                description=(
+                    "refund_order must not be decided before verify_customer's "
+                    "result was observed."
+                ),
+                parameters=parameters,
+                oracle_ids=("oracle-1",),
+                required=required,
+            ),
+        ),
+        oracle_provenance=(
+            OracleProvenance(
+                oracle_id="oracle-1",
+                strength=OracleStrength.EXPLICIT_INSTRUCTION,
+                source="The developer declared this ordering requirement.",
+                confidence=1.0,
+                evidence_ids=("declared-ordering",),
+                supports_hard_failure=True,
+            ),
+        ),
+        dimension_tags=("test:launch-ordering",),
+        generation_seed=1,
+    )
+
+
+def _ordering_assertion(run: Any, scenario: Any) -> Any:
+    from agentcheck.evaluate import evaluate_run
+
+    evaluation = evaluate_run(scenario, run)
+    return next(
+        item for item in evaluation.assertions if item.assertion_id == "order-1"
+    )
+
+
+def test_ordering_passes_when_the_prerequisite_result_was_observed() -> None:
+    from agentcheck.domain import Verdict
+
+    assertion = _ordering_assertion(_run(SEQUENTIAL), _ordering_scenario())
+
+    assert assertion.result is Verdict.PASS
+
+
+def test_ordering_fails_when_both_calls_were_decided_together() -> None:
+    """The refund was chosen before the verification could have informed it."""
+
+    from agentcheck.domain import Verdict
+
+    assertion = _ordering_assertion(_run(SAME_STAGE), _ordering_scenario())
+
+    assert assertion.result is Verdict.FAIL
+
+
+def test_ordering_fails_when_the_prerequisite_never_ran() -> None:
+    from agentcheck.domain import Verdict
+
+    run = _run(
+        [
+            [_tool_call("refund_order", {"order_id": "o"}, "c1")],
+            [_message("done")],
+        ]
+    )
+
+    assert _ordering_assertion(run, _ordering_scenario()).result is Verdict.FAIL
+
+
+def test_ordering_passes_vacuously_when_the_dependent_call_never_ran() -> None:
+    from agentcheck.domain import Verdict
+
+    run = _run(
+        [
+            [_tool_call("verify_customer", {"order_id": "o"}, "c1")],
+            [_message("done")],
+        ]
+    )
+
+    assert _ordering_assertion(run, _ordering_scenario()).result is Verdict.PASS
+
+
+def test_ordering_is_inconclusive_when_launch_evidence_is_absent() -> None:
+    """Unknown stays unknown; it never becomes a behavioral failure."""
+
+    from agentcheck.domain import Verdict
+
+    run = _run(SEQUENTIAL)
+    stripped = run.model_copy(
+        update={
+            "events": tuple(
+                event
+                for event in run.events
+                if event.event_type is not CanonicalEventType.MODEL_RESPONSE
+            )
+        }
+    )
+
+    assertion = _ordering_assertion(stripped, _ordering_scenario())
+
+    assert assertion.result is Verdict.INCONCLUSIVE
+    assert assertion.missing_evidence
+
+
+def test_ordering_without_a_named_prerequisite_is_inconclusive() -> None:
+    from agentcheck.domain import Verdict
+
+    assertion = _ordering_assertion(
+        _run(SEQUENTIAL), _ordering_scenario(required_before=None)
+    )
+
+    assert assertion.result is Verdict.INCONCLUSIVE
+
+
+def test_sharing_a_launch_group_is_not_itself_a_failure() -> None:
+    """Two unrelated reads together must not fail an unrelated ordering rule."""
+
+    from agentcheck.domain import Verdict
+
+    run = _run(
+        [
+            [
+                _tool_call("read_balance", {"order_id": "a"}, "c1"),
+                _tool_call("read_balance", {"order_id": "b"}, "c2"),
+            ],
+            [_message("done")],
+        ]
+    )
+
+    assert _ordering_assertion(run, _ordering_scenario()).result is Verdict.PASS
+
+
+# --------------------------------------------------------------------------
+# Mutation-style: what wrong implementation would still pass the tests above?
+# --------------------------------------------------------------------------
+
+
+def test_a_missing_result_is_unknown_not_observed_before() -> None:
+    """Different launch stages alone do not prove the result was seen.
+
+    An implementation that answered from launch groups alone would call this
+    True, so the recorded result has to be load-bearing.
+    """
+
+    run = _run(SEQUENTIAL)
+    stripped = run.model_copy(
+        update={
+            "events": tuple(
+                event
+                for event in run.events
+                if event.event_type is not CanonicalEventType.TOOL_RESULT
+            )
+        }
+    )
+    analysis = analyze_launches(stripped)
+    ids = _attempt_ids(run)
+    verify, refund = ids["verify_customer"][0], ids["refund_order"][0]
+
+    assert analysis.same_launch_group(verify, refund) is False
+    assert analysis.observed_before(verify, refund) is None
+
+
+def test_partial_ignorance_across_candidates_is_inconclusive() -> None:
+    """One unusable candidate must not become proof of a violation.
+
+    Two verify_customer calls: the second shares the refund's decision stage,
+    and the first has no recorded result. An implementation that treated
+    "not proven before" as "violated" would fail this run.
+    """
+
+    from agentcheck.domain import Verdict
+
+    run = _run(
+        [
+            [_tool_call("verify_customer", {"order_id": "o"}, "c1")],
+            [
+                _tool_call("verify_customer", {"order_id": "o"}, "c2"),
+                _tool_call("refund_order", {"order_id": "o"}, "c3"),
+            ],
+            [_message("done")],
+        ]
+    )
+    first_verify = _attempt_ids(run)["verify_customer"][0]
+    first_event = next(
+        attempt.event_id
+        for attempt in run.tool_attempts
+        if attempt.attempt_id == first_verify
+    )
+    first_result = next(
+        event
+        for event in run.events
+        if event.event_type is CanonicalEventType.TOOL_RESULT
+        and first_event in event.source_event_ids
+    )
+    stripped = run.model_copy(
+        update={
+            "events": tuple(
+                event for event in run.events if event.event_id != first_result.event_id
+            )
+        }
+    )
+
+    assert _ordering_assertion(stripped, _ordering_scenario()).result is (
+        Verdict.INCONCLUSIVE
+    )
+
+
+def test_an_earlier_observed_candidate_still_satisfies_the_rule() -> None:
+    """The same shape, with evidence intact, is a pass rather than a failure."""
+
+    from agentcheck.domain import Verdict
+
+    run = _run(
+        [
+            [_tool_call("verify_customer", {"order_id": "o"}, "c1")],
+            [
+                _tool_call("verify_customer", {"order_id": "o"}, "c2"),
+                _tool_call("refund_order", {"order_id": "o"}, "c3"),
+            ],
+            [_message("done")],
+        ]
+    )
+
+    assert _ordering_assertion(run, _ordering_scenario()).result is Verdict.PASS
+
+
+# --------------------------------------------------------------------------
+# Per-adapter: each framework's linkage is verified, never assumed.
+# --------------------------------------------------------------------------
+
+
+def test_pydantic_ai_records_launch_grouping_for_one_response() -> None:
+    """PydanticAI's linkage is checked independently of the OpenAI adapter."""
+
+    pytest.importorskip("pydantic_ai")
+    from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+
+    from tests.agentcheck.test_pydantic_ai_adapter import (
+        _agent,
+        _fixture,
+        _prepare,
+        _run as _run_pydantic,
+        _script,
+        _turn,
+    )
+    from agentcheck.runner import ToolGateway
+    from agentcheck.adapters import PydanticAIAdapter
+
+    ran = {"value": False}
+
+    def verify_customer(order_id: str) -> str:
+        """Verify the customer."""
+
+        ran["value"] = True
+        raise AssertionError("the original handler was invoked")
+
+    def refund_order(order_id: str) -> str:
+        """Refund the order."""
+
+        ran["value"] = True
+        raise AssertionError("the original handler was invoked")
+
+    model = _script(
+        ModelResponse(
+            parts=[
+                ToolCallPart("verify_customer", {"order_id": "o"}),
+                ToolCallPart("refund_order", {"order_id": "o"}),
+            ]
+        ),
+        ModelResponse(parts=[TextPart("done")]),
+    )
+    agent = _agent(verify_customer, refund_order, model=model)
+    spec = PydanticAIAdapter().inspect(agent)
+    gateway = ToolGateway(
+        spec.tools.items,
+        (
+            _fixture("verify_customer", {"ok": True}),
+            _fixture("refund_order", {"ok": True}),
+        ),
+        world={},
+        run_id="pai-launch",
+    )
+    run = _run_pydantic(_prepare(agent, gateway), (_turn("t1", "refund it"),))
+
+    assert ran["value"] is False
+    analysis = analyze_launches(run)
+    ids = {attempt.tool_name: attempt.attempt_id for attempt in run.tool_attempts}
+    assert set(ids) == {"verify_customer", "refund_order"}
+    assert (
+        analysis.same_launch_group(ids["verify_customer"], ids["refund_order"]) is True
+    )
+    assert (
+        analysis.observed_before(ids["verify_customer"], ids["refund_order"]) is False
+    )

--- a/tests/agentcheck/test_behavioral_launch.py
+++ b/tests/agentcheck/test_behavioral_launch.py
@@ -565,3 +565,74 @@ def test_pydantic_ai_records_launch_grouping_for_one_response() -> None:
     assert (
         analysis.observed_before(ids["verify_customer"], ids["refund_order"]) is False
     )
+
+
+def test_ordering_without_a_dependent_tool_is_inconclusive() -> None:
+    """An unnamed dependent call would otherwise test every attempt in the run.
+
+    That includes the prerequisite's own calls, which would report a confident
+    violation from a constraint that never said what it constrained.
+    """
+
+    from agentcheck.domain import Verdict
+
+    scenario = _ordering_scenario()
+    constraint = scenario.trajectory_constraints[0]
+    ambiguous = scenario.model_copy(
+        update={
+            "trajectory_constraints": (
+                constraint.model_copy(
+                    update={"parameters": {"required_before": "verify_customer"}}
+                ),
+            )
+        }
+    )
+
+    assertion = _ordering_assertion(_run(SEQUENTIAL), ambiguous)
+
+    assert assertion.result is Verdict.INCONCLUSIVE
+    assert assertion.missing_evidence
+
+
+def test_a_lone_call_cannot_be_required_to_follow_itself() -> None:
+    """A rule naming its own tool exempts the first call, which follows nothing."""
+
+    from agentcheck.domain import Verdict
+
+    scenario = _ordering_scenario()
+    constraint = scenario.trajectory_constraints[0]
+    self_ordering = scenario.model_copy(
+        update={
+            "trajectory_constraints": (
+                constraint.model_copy(
+                    update={
+                        "parameters": {
+                            "tool_name": "refund_order",
+                            "required_before": "refund_order",
+                        }
+                    }
+                ),
+            )
+        }
+    )
+    single = _run(
+        [
+            [_tool_call("refund_order", {"order_id": "o"}, "c1")],
+            [_message("done")],
+        ]
+    )
+
+    assert _ordering_assertion(single, self_ordering).result is Verdict.PASS
+
+    # A second call decided in the same stage as the first still violates it.
+    same_stage = _run(
+        [
+            [
+                _tool_call("refund_order", {"order_id": "o"}, "c1"),
+                _tool_call("refund_order", {"order_id": "o"}, "c2"),
+            ],
+            [_message("done")],
+        ]
+    )
+
+    assert _ordering_assertion(same_stage, self_ordering).result is Verdict.FAIL

--- a/tests/compat_manifest.py
+++ b/tests/compat_manifest.py
@@ -83,6 +83,9 @@ COMPATIBILITY_SUITE: dict[str, dict[str, object]] = {
         ),
         "files": (
             "tests/agentcheck/test_prerequisite_fixtures.py",
+            # Decision-stage relations are derived from recorded event
+            # ordering across staged child-process execution.
+            "tests/agentcheck/test_behavioral_launch.py",
             "tests/agentcheck/test_interactive_scenarios.py",
             "tests/agentcheck/test_confirmation_variant_cases.py",
         ),


### PR DESCRIPTION
## The question

Not *which tool call ran first*, but:

> what had the agent actually observed when it decided to act?

A single model response can carry several tool calls. They were chosen
**together**, before any produced a result — so the order AgentCheck executes
them in says nothing about what the agent knew.

```
MODEL_RESPONSE #1
  ├── verify_customer()
  └── refund_order()
```

The refund was decided before the verification could possibly have informed it,
*even though AgentCheck executes `verify_customer` first*. That distinction is
the entire point.

## AgentCheck already recorded this and never used it

A `TOOL_ATTEMPT` event names the `MODEL_RESPONSE` that launched it; a
`TOOL_RESULT` event names its attempt. Verified with a probe before writing any
code — two calls from one response both linked to `event:0002`.

So both relations are **derived** from existing evidence:

- **Launch group** — the model response that decided an attempt.
- **`observed_before(A, B)`** — true only when A's recorded result precedes the
  model response that launched B. Two calls from one response are `false`
  (neither could have informed the other). Missing evidence is `None` — *not*
  either answer.

**No serialized contract changed**, and runs recorded before this analysis
existed can still be analyzed.

## A real oracle

`ORDERING` was declared in the domain, never emitted by the generator, and fell
through to `INCONCLUSIVE`. Nothing that previously passed changes meaning.

| Observed | Verdict |
|---|---|
| Prerequisite's result preceded the dependent decision | `PASS` |
| Both decided in one stage | `FAIL` |
| Prerequisite never ran | `FAIL` |
| Dependent call never ran | `PASS`, vacuously |
| No launching model response recorded | `INCONCLUSIVE` |
| Some candidate prerequisite unplaceable | `INCONCLUSIVE` |

**Sharing a decision stage is not itself a finding.** Two unrelated reads issued
together are ordinary behavior; a hard failure still requires a declared
contract. AgentCheck observes behavior, it does not moralize parallelism.

## Coverage

`ordering` becomes an evaluated dimension: a suite with no ordering oracle now
reports `MISSING` — an actionable gap — instead of `UNSUPPORTED`. It reaches
`COVERED` only when the constraint is required, authoritative, **and both tools
have a reachable controlled outcome** — without a controlled result for the
prerequisite there is nothing for the dependent call to have observed.

## Adapters — verified, not assumed

| Adapter | Launch grouping |
|---|---|
| OpenAI Agents | Recorded |
| PydanticAI | Recorded (tested independently) |
| Custom Python | **Unknown** — owns its own model calls, emits no `MODEL_RESPONSE`; every relation stays unknown and ordering is `INCONCLUSIVE` |

## Two bugs caught in adversarial review

Both fixed *before* writing tests to match them:

1. **Mixed evidence returned `FAIL`.** One candidate prerequisite provably not
   observed first + another *unknown* → I returned a violation. Partial
   ignorance is not proof. Now `INCONCLUSIVE`.
2. **Empty prerequisite list took the unknown path.** If the prerequisite never
   ran, no launch evidence is needed — that is a violation regardless.

Mutation-killing test added: an implementation answering from launch groups
alone would call `observed_before` true across stages;
`test_a_missing_result_is_unknown_not_observed_before` kills it.

## Deliberately not included

No locks, no `asyncio.gather`, and `max_function_tool_concurrency` stays at 1.

I tried twice to reproduce the gateway race I assumed existed — 32 racing
threads, then a forced barrier inside the fixture-selection critical section.
It does not exist: `async def _invoke_gateway` calls a **synchronous**
`gateway.invoke()` with no `await` inside, so each call is atomic. Raising
concurrency would make fixture selection scheduling-dependent and break replay
determinism while adding no behavioral fidelity.

## Compatibility

Nothing serialized changed. Regenerating the bundled example produces a
**byte-identical** suite:

```
FIELDS THAT DIFFER vs main: NONE
suite fingerprint identical: True
scenario fingerprints identical: True
```

## Validation

- `python -m pytest tests -q -n 2` — **1289 passed**
- ruff · mypy · workflow-safety · secret-scan — clean
- 18 new tests in `tests/agentcheck/test_behavioral_launch.py`, added to the
  cross-version compatibility manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
