### PR TITLE
ci: resolve the workflow into one status that always reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,3 +281,35 @@ jobs:
           "$RUNNER_TEMP/wheel-venv/bin/python" -c "import agentcheck; print(agentcheck.__version__)"
           "$RUNNER_TEMP/wheel-venv/bin/agentcheck" --help > /dev/null
           echo "wheel install smoke passed"
+
+  required:
+    # The single status branch protection should require. The matrix cannot play
+    # that role: it is skipped by design on documentation-only pull requests, and
+    # a skipped job never reports, so requiring it by name leaves those pull
+    # requests waiting forever for a status that will never arrive.
+    #
+    # always() is what makes this report at all when an upstream job is skipped.
+    # It deliberately does not mean "pass anyway": the script refuses a skipped
+    # matrix on a code change, refuses a failed or cancelled matrix in any scope,
+    # and treats an unreadable classification as a code change.
+    name: Required CI
+    needs: [scope, tests, checks]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve required job results
+        env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+          CHECKS_RESULT: ${{ needs.checks.result }}
+          EXPENSIVE: ${{ needs.scope.outputs.expensive }}
+        # Standard library only, so the gate does not depend on an install
+        # succeeding in order to report that something failed.
+        run: python3 scripts/check_required_ci.py

--- a/docs/ci-trust-model.md
+++ b/docs/ci-trust-model.md
@@ -51,6 +51,57 @@ No AgentCheck test requires a provider credential. Fork PRs must never receive
 repository secrets, write tokens, deployment environments, or PyPI publishing
 authority.
 
+## Required status checks
+
+Branch protection should require exactly one CI status: **`Required CI`**.
+
+It is a gate job that depends on `scope`, `tests` and `checks`, runs under
+`if: always()` so it reports even when the matrix is skipped, and resolves the
+workflow through `scripts/check_required_ci.py`. `always()` makes it report; it
+does not make it lenient. The script refuses a skipped matrix on a code change,
+refuses a failed or cancelled matrix in any scope, requires `scope` and `checks`
+to have succeeded, and treats an unreadable classification as a code change.
+
+Requiring the matrix jobs by name does not work, and the failure mode is quiet.
+`Tests (Python 3.10 | 3.11 | 3.12)` are skipped by design on documentation-only
+pull requests, and a skipped job never reports a status, so a required matrix
+name leaves those pull requests stuck at *"Waiting for status to be reported"*
+with nothing failing and nothing to fix.
+
+### Migrating the ruleset
+
+The `main integrity and CI` ruleset currently requires these six contexts:
+
+```
+Classify change scope
+Tests (Python 3.10)
+Tests (Python 3.11)
+Tests (Python 3.12)
+Quality, packaging, extras, and workflow trust
+dependency-review
+```
+
+After this change, **remove the three `Tests (Python …)` entries and add
+`Required CI`**, leaving:
+
+```
+Classify change scope
+Quality, packaging, extras, and workflow trust
+dependency-review
+Required CI
+```
+
+Nothing is weakened by the removal. `Required CI` fails whenever any of those
+three matrix jobs fails or is cancelled, and additionally fails if the matrix is
+skipped on a change that was not documentation-only — a case the per-name
+requirements could not express at all. Keeping `Classify change scope` and the
+quality job listed is redundant but harmless, since the gate already requires
+both; they are worth keeping so a deleted gate job cannot silently leave `main`
+with no required check.
+
+Do the ruleset edit only after this workflow is on `main`, so `Required CI` has
+reported at least once and is selectable in the ruleset UI.
+
 ## Release boundary
 
 `.github/workflows/release.yml` runs only for a published, non-prerelease GitHub

--- a/scripts/check_required_ci.py
+++ b/scripts/check_required_ci.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Resolve the whole CI workflow into one required status.
+
+Branch protection needs a check name that always reports. The expensive test
+matrix cannot be that name: it is skipped by design on documentation-only pull
+requests, and a skipped job never reports, so requiring it leaves those pull
+requests waiting for a status that will never arrive.
+
+This collapses the workflow into a single answer. The rule it applies is the one
+that is easy to get wrong by hand:
+
+* the classifier and the quality job must have *succeeded* in every scope --
+  neither is ever skipped, so anything else is a real problem;
+* the matrix must have succeeded when the change was classified expensive;
+* the matrix may be skipped only when the change was classified cheap;
+* a failed or cancelled matrix is never an acceptable skip, in either scope.
+
+Anything it cannot classify is treated as a code change, so a broken or missing
+classification demands the full suite rather than waving the change through.
+
+Reads ``needs.<job>.result`` values and the classifier output from the
+environment. Standard library only: this runs before any project install.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+SUCCESS = "success"
+SKIPPED = "skipped"
+
+# GitHub reports one of these for `needs.<job>.result`.
+KNOWN_RESULTS = frozenset({SUCCESS, SKIPPED, "failure", "cancelled"})
+
+
+def _decide(
+    scope: str, tests: str, checks: str, expensive: str
+) -> tuple[bool, list[str]]:
+    problems: list[str] = []
+
+    # Neither of these is conditional, so "not success" always means broken.
+    if scope != SUCCESS:
+        problems.append(
+            f"scope (change classification) reported {scope or 'nothing'!r}; "
+            "expected 'success'"
+        )
+    if checks != SUCCESS:
+        problems.append(
+            f"checks (quality, packaging, extras, workflow trust) reported "
+            f"{checks or 'nothing'!r}; expected 'success'"
+        )
+
+    # An unrecognised classification is a code change. Failing closed here is
+    # what stops a broken classifier from silently buying a free pass.
+    cheap = expensive == "false"
+    if expensive not in {"true", "false"}:
+        problems.append(
+            f"scope produced expensive={expensive or 'nothing'!r}, which is neither "
+            "'true' nor 'false'; treating this as a code change"
+        )
+
+    if tests == SUCCESS:
+        pass
+    elif tests == SKIPPED:
+        if not cheap:
+            problems.append(
+                "tests were skipped on a change that requires the full matrix; "
+                "a skipped suite never satisfies this gate outside a "
+                "documentation-only change"
+            )
+    elif tests in KNOWN_RESULTS:
+        # failure / cancelled -- never acceptable, including on a docs-only run
+        # where the matrix was not expected to contribute anything.
+        problems.append(
+            f"tests reported {tests!r}; a failed or cancelled matrix is never "
+            "treated as an acceptable skip"
+        )
+    else:
+        problems.append(f"tests reported the unrecognised result {tests or 'nothing'!r}")
+
+    return not problems, problems
+
+
+def main() -> int:
+    scope = os.environ.get("SCOPE_RESULT", "")
+    tests = os.environ.get("TESTS_RESULT", "")
+    checks = os.environ.get("CHECKS_RESULT", "")
+    expensive = os.environ.get("EXPENSIVE", "")
+
+    print(
+        "required CI inputs: "
+        f"scope={scope or '(unset)'} tests={tests or '(unset)'} "
+        f"checks={checks or '(unset)'} expensive={expensive or '(unset)'}"
+    )
+
+    ok, problems = _decide(scope, tests, checks, expensive)
+    if ok:
+        shape = "documentation-only" if expensive == "false" else "full"
+        print(f"PASS: every required job reported an acceptable result ({shape} scope)")
+        return 0
+
+    print("FAIL: required CI did not pass")
+    for problem in problems:
+        print(f"  - {problem}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agentcheck/test_required_ci_gate.py
+++ b/tests/agentcheck/test_required_ci_gate.py
@@ -1,0 +1,172 @@
+"""One required status check that tells the truth about the whole workflow.
+
+The expensive matrix is skipped for documentation-only pull requests, which is
+deliberate. Naming those matrix jobs as branch-protection requirements is what
+turned that optimisation into a deadlock: a skipped job never reports, so the
+pull request waits for a status that will never arrive.
+
+The fix is a single always-present gate. Its decision lives in
+``scripts/check_required_ci.py`` rather than inline in YAML, because "a skipped
+matrix is fine here but a failed one is not" is exactly the kind of rule that
+should be executable and tested rather than reviewed by eye.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+import yaml
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPOSITORY_ROOT / ".github" / "workflows"
+GATE = REPOSITORY_ROOT / "scripts" / "check_required_ci.py"
+GATE_JOB = "required"
+GATE_NAME = "Required CI"
+
+
+def _ci() -> dict[Any, Any]:
+    loaded = yaml.safe_load((WORKFLOWS / "ci.yml").read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _decide(
+    *, scope: str, tests: str, checks: str, expensive: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GATE)],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "SCOPE_RESULT": scope,
+            "TESTS_RESULT": tests,
+            "CHECKS_RESULT": checks,
+            "EXPENSIVE": expensive,
+        },
+    )
+
+
+# --- the deadlock this exists to prevent -----------------------------------
+
+
+def test_docs_only_run_passes_with_a_skipped_matrix() -> None:
+    """The whole point: skipped-because-docs must resolve, not hang."""
+
+    result = _decide(scope="success", tests="skipped", checks="success", expensive="false")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_code_change_passes_only_when_the_matrix_actually_ran() -> None:
+    result = _decide(scope="success", tests="success", checks="success", expensive="true")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_a_skipped_matrix_on_a_code_change_is_refused() -> None:
+    """Skipping the suite on a code change must never satisfy the gate."""
+
+    result = _decide(scope="success", tests="skipped", checks="success", expensive="true")
+
+    assert result.returncode == 1
+    assert "tests" in result.stdout.lower()
+
+
+# --- a failure is never an acceptable skip ---------------------------------
+
+
+@pytest.mark.parametrize("outcome", ["failure", "cancelled"])
+@pytest.mark.parametrize("expensive", ["true", "false"])
+def test_a_failed_or_cancelled_matrix_always_fails_the_gate(
+    outcome: str, expensive: str
+) -> None:
+    """Including on a docs-only run, where the matrix was not even expected."""
+
+    result = _decide(
+        scope="success", tests=outcome, checks="success", expensive=expensive
+    )
+
+    assert result.returncode == 1, result.stdout
+
+
+@pytest.mark.parametrize("outcome", ["failure", "cancelled", "skipped"])
+@pytest.mark.parametrize("expensive", ["true", "false"])
+def test_quality_checks_must_succeed_in_every_scope(
+    outcome: str, expensive: str
+) -> None:
+    """The quality job runs for docs-only changes too, so it may never be absent."""
+
+    result = _decide(
+        scope="success", tests="success", checks=outcome, expensive=expensive
+    )
+
+    assert result.returncode == 1, result.stdout
+    assert "checks" in result.stdout.lower()
+
+
+@pytest.mark.parametrize("outcome", ["failure", "cancelled", "skipped"])
+def test_a_broken_classifier_fails_the_gate(outcome: str) -> None:
+    result = _decide(
+        scope=outcome, tests="success", checks="success", expensive="true"
+    )
+
+    assert result.returncode == 1, result.stdout
+    assert "scope" in result.stdout.lower()
+
+
+def test_an_unreadable_scope_output_fails_closed() -> None:
+    """An unset or unexpected classification is treated as a code change."""
+
+    for expensive in ("", "maybe", "TRUE"):
+        result = _decide(
+            scope="success", tests="skipped", checks="success", expensive=expensive
+        )
+        assert result.returncode == 1, f"{expensive!r} should fail closed"
+
+
+# --- the workflow actually wires it up -------------------------------------
+
+
+def test_the_gate_job_is_always_present_and_depends_on_the_others() -> None:
+    jobs = _ci()["jobs"]
+    assert GATE_JOB in jobs, "ci.yml must define the required-status gate"
+    gate = jobs[GATE_JOB]
+
+    assert gate["name"] == GATE_NAME
+    # always() is what makes it report even when the matrix is skipped.
+    assert "always()" in str(gate["if"])
+    assert set(gate["needs"]) == {"scope", "tests", "checks"}
+    assert gate["runs-on"] == "ubuntu-latest"
+
+
+def test_the_gate_reads_every_job_result_it_claims_to_cover() -> None:
+    gate = _ci()["jobs"][GATE_JOB]
+    wired = "\n".join(str(step) for step in gate["steps"])
+
+    for expression in (
+        "needs.scope.result",
+        "needs.tests.result",
+        "needs.checks.result",
+        "needs.scope.outputs.expensive",
+    ):
+        assert expression in wired, f"gate ignores {expression}"
+    assert "check_required_ci.py" in wired
+
+
+def test_the_matrix_still_covers_every_supported_interpreter() -> None:
+    """The gate must not become an excuse to shrink real coverage."""
+
+    tests = _ci()["jobs"]["tests"]
+    matrix = str(tests["strategy"]["matrix"]["python-version"])
+
+    for version in ("3.10", "3.11", "3.12"):
+        assert version in matrix
+    assert tests["if"] == "needs.scope.outputs.expensive == 'true'"


### PR DESCRIPTION
Documentation-only pull requests skip the test matrix on purpose, and the
ruleset requires those matrix jobs **by name**. A skipped job never reports a
status, so the requirement can never be met — the PR sits at *"Waiting for status
to be reported"* with nothing failing and nothing to fix. The optimisation and
the protection were each reasonable; together they deadlocked. PR #33 is stuck
behind exactly this.

## The fix

A `Required CI` job depending on `scope`, `tests` and `checks`, under
`if: always()` so it reports even when the matrix is skipped.

**`always()` is what makes it report, not what makes it lenient.** The gate
refuses unless:

| Condition | Result |
|---|---|
| `scope` or `checks` not `success` | **FAIL** (neither is ever skipped) |
| matrix `success` | PASS |
| matrix `skipped`, docs-only | PASS |
| matrix `skipped`, code change | **FAIL** |
| matrix `failure` / `cancelled`, **either scope** | **FAIL** |
| classification neither `'true'` nor `'false'` | **FAIL** (treated as a code change) |

## Why the logic is a script, not inline YAML

"Skipped is fine here but not there, and failed is never fine" is the kind of
condition that should be executable and tested rather than reviewed by eye. It
lives in `scripts/check_required_ci.py` (standard library only, so the gate can
still report that something failed when an *install* is what failed), and
`tests/agentcheck/test_required_ci_gate.py` walks the truth table:

- docs-only with a skipped matrix → passes (the deadlock case)
- code change with a passing matrix → passes
- **skipped matrix on a code change → fails**
- **failed or cancelled matrix → fails in both scopes**
- skipped/failed/cancelled quality job → fails in both scopes
- broken classifier, and an unreadable `expensive` value → fail closed
- static assertions that the job is wired to all three results and that the
  matrix still covers 3.10 / 3.11 / 3.12

## Unchanged

Matrix coverage, the docs-only optimisation, hosted-runner-only policy,
`contents: read`, no secrets, no `pull_request_target`, SHA-pinned actions.
`scripts/check_workflow_safety.py` passes with 8 hosted jobs.

## Ruleset migration (documented, not performed)

`docs/ci-trust-model.md` records the exact edit. The `main integrity and CI`
ruleset currently requires six contexts; **remove the three `Tests (Python …)`
entries and add `Required CI`**:

```
Classify change scope
Quality, packaging, extras, and workflow trust
dependency-review
Required CI
```

This removes nothing — the gate fails whenever any matrix job fails or is
cancelled — and adds a case the per-name requirements could not express at all.

**I have not touched the ruleset.** It should be edited only after this is on
`main` and `Required CI` has reported once, so it is selectable in the UI.

## Validation

37 focused tests pass (20 new gate tests + 17 existing workflow-safety tests);
`check_workflow_safety.py`, `check_no_secrets.py`, ruff and mypy all clean. This
is a workflow change, so `scope` classifies it `expensive=true` and CI runs the
full 3.10/3.11/3.12 matrix — which is also the first real report of
`Required CI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
