### PR TITLE
feat: separate the release version from generation semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,10 +58,23 @@ These are hashed or stored, so changing them re-identifies existing artifacts:
 - `Scenario.expected_fingerprint()` hashes the scenario document minus display
   identity.
 - `FrozenSuite.expected_fingerprint()` hashes the whole suite document, which
-  **includes `provenance.generator_version`** — that is `agentcheck.__version__`.
-  Bumping the package version therefore moves every suite fingerprint. It is a
-  compatibility event, not a routine bump.
-- Replay manifests, baselines, and review records embed the same version.
+  includes `provenance.generator_version`. That is
+  **`GENERATOR_COMPATIBILITY_VERSION`, not `agentcheck.__version__`** — the two
+  are deliberately different things and must not be conflated again.
+  - `agentcheck.__version__` is the distribution release. It appears in
+    `--version`, and in run, baseline, replay and review records as "which build
+    executed this". Releasing must not re-identify a suite that asserts exactly
+    the same thing, so it is not part of suite provenance.
+  - `GENERATOR_COMPATIBILITY_VERSION` (in `agentcheck/generate/suite.py`) is the
+    generation semantics. Raise it when a change *should* re-identify otherwise
+    equivalent suites: a new case family, a changed default budget, different
+    fixture wiring, altered lint or selection behaviour. Adding an unused field,
+    renaming the package, or cutting a release does not qualify.
+  - Raising it never invalidates an artifact already on disk: a stored suite
+    validates against the `generator_version` it recorded, not against today's.
+- Replay manifests, baselines, and review records embed `agentcheck.__version__`
+  as execution provenance. That is a record of the run, not of what a suite
+  asserts, and it is not suite identity.
 
 If a fingerprint changes and you did not intend a contract change, stop and find
 out why rather than re-freezing the expected values.

--- a/agentcheck/generate/__init__.py
+++ b/agentcheck/generate/__init__.py
@@ -42,6 +42,7 @@ from .selection import (
     select_units,
 )
 from .suite import (
+    GENERATOR_COMPATIBILITY_VERSION,
     DEFAULT_SUITE_FILENAME,
     FROZEN_SUITE_CONTRACT_VERSION,
     CaseLineage,
@@ -70,6 +71,7 @@ from .templates import (
 )
 
 __all__ = [
+    "GENERATOR_COMPATIBILITY_VERSION",
     "ACCOUNT_SUPPORT_SUITE",
     "ACCOUNT_TOOLS",
     "DEFAULT_MAX_MUTATIONS",

--- a/agentcheck/generate/suite.py
+++ b/agentcheck/generate/suite.py
@@ -24,7 +24,6 @@ from typing import Any, Literal, Mapping, Sequence
 
 from pydantic import Field, model_serializer, model_validator
 
-from agentcheck import __version__
 from agentcheck.artifacts import create_private_file, replace_private_file
 from agentcheck.config import AgentCheckConfig, contained_path
 from agentcheck.domain import (
@@ -78,6 +77,30 @@ FROZEN_SUITE_CONTRACT_VERSION: Literal["agentcheck.frozen_suite.v1"] = (
 )
 DEFAULT_SUITE_FILENAME = "agentcheck-suite.json"
 GENERATOR_NAME = "agentcheck.generate.suite"
+
+GENERATOR_COMPATIBILITY_VERSION = "1"
+"""Which generation *semantics* produced a suite, independent of the release.
+
+This is not the package version, and the difference matters. A frozen suite's
+fingerprint covers its provenance, so recording the release here made every
+suite re-identify whenever the distribution was published -- a 0.1.1 to 0.2.0
+bump moved every ``suite_id`` while the generated cases were byte-identical.
+Identity would have tracked "which wheel wrote this" rather than "what this
+asserts", and a routine release would have looked like a behavioural change.
+
+Bump this only when generation semantics change in a way that *should*
+re-identify otherwise-equivalent suites: a new case family, a changed default
+budget, different fixture wiring, altered lint or selection behaviour. Adding a
+field that no generated case populates does not qualify. Renaming the package
+does not qualify. Releasing does not qualify.
+
+Old values keep their meaning: a stored suite validates against the
+``generator_version`` it recorded, so raising this never invalidates an artifact
+that is already on disk -- it only marks suites generated from here on as coming
+from different semantics.
+"""
+
+
 
 MAX_UNSUPPORTED_FEATURES = 100
 _MAX_SUITE_BYTES = 8 * 1024 * 1024
@@ -738,7 +761,7 @@ def build_frozen_suite(
         seed=seed,
         provenance=GeneratorProvenance(
             generator=GENERATOR_NAME,
-            generator_version=__version__,
+            generator_version=GENERATOR_COMPATIBILITY_VERSION,
             sources=sources,
             policy_packs=tuple(pack.pack_id for pack in policy_packs),
         ),

--- a/tests/agentcheck/test_interactive_scenarios.py
+++ b/tests/agentcheck/test_interactive_scenarios.py
@@ -89,10 +89,15 @@ BUILT_IN_FINGERPRINTS_SEED_7 = {
 
 # A generated suite for a target with no confirmation-required tool declares no
 # follow-up anywhere, so its whole document stays byte-identical within the
-# current generator version. The package version is currently part of suite
-# provenance, so the intentional 0.1.1 release bump moved this pin.
+# current generation semantics.
+#
+# This pin used to move on every release, because provenance recorded the
+# package version: the 0.1.1 bump moved it once for no behavioural reason.
+# Provenance now records GENERATOR_COMPATIBILITY_VERSION instead, so from here
+# the only thing that may move this value is a deliberate change to how suites
+# are generated. If a release moves it again, that is the regression.
 NO_FOLLOWUP_SUITE_FINGERPRINT = (
-    "sha256:70c4e36947c5f188831517afbbdd7d567f06173730e4b46dd116ca4e87118819"
+    "sha256:b5285d2503fc63f5dc02a9f7bdd559fd465c02b7aaa2b53f88b3b9cf0fff4732"
 )
 # Likewise for a scenario embedded in a parent contract: a replay manifest over
 # the built-in suite, digested by the tree before ``followup_turns`` existed.

--- a/tests/agentcheck/test_version_decoupling.py
+++ b/tests/agentcheck/test_version_decoupling.py
@@ -1,0 +1,220 @@
+"""Releasing the package must not re-identify suites that assert the same thing.
+
+A frozen suite's fingerprint covers its provenance, and provenance recorded the
+package release. So publishing 0.1.1 -> 0.2.0 moved every ``suite_id`` while the
+generated cases stayed byte-identical: identity tracked which wheel wrote the
+document rather than what the document asserts, and a routine release was
+indistinguishable from a behavioural change.
+
+Generation semantics now carry their own version. These tests pin the boundary
+in both directions -- a release must not move identity, and a semantics bump
+must.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from agents import Agent, function_tool
+
+import agentcheck
+import agentcheck.generate.suite as suite_module
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.config import AgentCheckConfig
+from agentcheck.generate.suite import (
+    GENERATOR_COMPATIBILITY_VERSION,
+    build_frozen_suite,
+    encode_frozen_suite,
+    load_frozen_suite,
+)
+
+
+SEED = 1729
+
+
+@function_tool
+def delete_record(record_id: str, reason: str) -> str:
+    """Delete a record permanently. This removes it for good."""
+    raise AssertionError("original handler must never run")
+
+
+@function_tool
+def lookup_record(record_id: str) -> str:
+    """Look up a stored record."""
+    raise AssertionError("original handler must never run")
+
+
+def _spec(*tools: Any):
+    return OpenAIAgentsAdapter().inspect(
+        Agent(name="T", instructions="Assist.", tools=list(tools), model="gpt-4.1-mini")
+    )
+
+
+def _suite(spec: Any):
+    return build_frozen_suite(spec, AgentCheckConfig(), seed=SEED)
+
+
+@pytest.fixture
+def released(monkeypatch: pytest.MonkeyPatch):
+    """Simulate publishing a new package release and nothing else."""
+
+    def _release(version: str) -> None:
+        monkeypatch.setattr(agentcheck, "__version__", version, raising=False)
+        monkeypatch.setattr(suite_module, "__version__", version, raising=False)
+
+    return _release
+
+
+# --- a release must not move identity --------------------------------------
+
+
+def test_a_package_release_alone_does_not_move_suite_identity(released) -> None:
+    spec = _spec(delete_record, lookup_record)
+
+    before = _suite(spec)
+    released("9.9.9")
+    after = _suite(spec)
+
+    assert after.fingerprint == before.fingerprint
+    assert after.suite_id == before.suite_id
+
+
+def test_a_package_release_alone_does_not_move_scenario_fingerprints(released) -> None:
+    spec = _spec(delete_record, lookup_record)
+
+    before = [case.scenario.fingerprint for case in _suite(spec).cases]
+    released("9.9.9")
+    after = [case.scenario.fingerprint for case in _suite(spec).cases]
+
+    assert after == before
+
+
+def test_a_package_release_alone_does_not_move_the_spec_identity(released) -> None:
+    """The target did not change, so neither may the identity derived from it."""
+
+    before = _spec(delete_record).spec_id
+    released("9.9.9")
+    after = _spec(delete_record).spec_id
+
+    assert after == before
+
+
+def test_provenance_records_generation_semantics_not_the_release(released) -> None:
+    spec = _spec(delete_record)
+
+    released("9.9.9")
+    provenance = _suite(spec).provenance
+
+    assert provenance.generator_version == GENERATOR_COMPATIBILITY_VERSION
+    assert provenance.generator_version != agentcheck.__version__
+
+
+# --- a semantics bump must move exactly the intended boundary ---------------
+
+
+def test_a_generator_semantics_bump_moves_suite_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = _spec(delete_record, lookup_record)
+    before = _suite(spec)
+
+    monkeypatch.setattr(suite_module, "GENERATOR_COMPATIBILITY_VERSION", "2")
+    after = _suite(spec)
+
+    assert after.fingerprint != before.fingerprint
+    assert after.suite_id != before.suite_id
+    assert after.provenance.generator_version == "2"
+
+
+def test_a_generator_semantics_bump_does_not_reach_the_scenarios(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The boundary is suite identity. Individual cases are unchanged data."""
+
+    spec = _spec(delete_record, lookup_record)
+    before = [case.scenario.fingerprint for case in _suite(spec).cases]
+
+    monkeypatch.setattr(suite_module, "GENERATOR_COMPATIBILITY_VERSION", "2")
+    after = [case.scenario.fingerprint for case in _suite(spec).cases]
+
+    assert after == before
+
+
+# --- artifacts already on disk ---------------------------------------------
+
+
+def test_a_suite_frozen_by_an_older_release_still_loads(
+    tmp_path: Path, released
+) -> None:
+    """A stored suite validates against what it recorded, not against today."""
+
+    spec = _spec(delete_record)
+    legacy = json.loads(encode_frozen_suite(_suite(spec)))
+    # Exactly the shape releases used to write: the package version verbatim.
+    legacy["provenance"]["generator_version"] = "0.1.0"
+    legacy["fingerprint"] = ""
+    legacy["suite_id"] = ""
+    path = tmp_path / "legacy-suite.json"
+    path.write_text(json.dumps(legacy), encoding="utf-8")
+    rebuilt = load_frozen_suite(path)
+    stored = tmp_path / "stored.json"
+    stored.write_bytes(encode_frozen_suite(rebuilt))
+
+    released("9.9.9")
+    reloaded = load_frozen_suite(stored)
+
+    assert reloaded.provenance.generator_version == "0.1.0"
+    assert reloaded.fingerprint == rebuilt.fingerprint
+    assert len(reloaded.cases) == len(rebuilt.cases)
+
+
+def test_a_tampered_suite_is_still_rejected(tmp_path: Path) -> None:
+    """Decoupling identity must not soften integrity."""
+
+    spec = _spec(delete_record)
+    forged = json.loads(encode_frozen_suite(_suite(spec)))
+    # Keep the recorded fingerprint, change what it covers.
+    forged["provenance"]["generator_version"] = "not-what-was-hashed"
+    path = tmp_path / "forged.json"
+    path.write_text(json.dumps(forged), encoding="utf-8")
+
+    with pytest.raises(Exception) as caught:
+        load_frozen_suite(path)
+    assert "fingerprint" in str(caught.value).lower()
+
+
+def test_a_suite_round_trips_unchanged_across_a_release(
+    tmp_path: Path, released
+) -> None:
+    spec = _spec(delete_record, lookup_record)
+    path = tmp_path / "suite.json"
+    path.write_bytes(encode_frozen_suite(_suite(spec)))
+    before = load_frozen_suite(path)
+
+    released("9.9.9")
+    after = load_frozen_suite(path)
+
+    assert after.fingerprint == before.fingerprint
+    assert after.suite_id == before.suite_id
+
+
+# --- the release version is still reported where it belongs ----------------
+
+
+def test_the_cli_still_reports_the_package_release() -> None:
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "agentcheck", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert agentcheck.__version__ in (result.stdout + result.stderr)
+    assert GENERATOR_COMPATIBILITY_VERSION not in result.stdout.split()[-1:]


### PR DESCRIPTION
A frozen suite's fingerprint covers its provenance, and provenance recorded
`agentcheck.__version__`. Publishing therefore moved every `suite_id` while the
generated cases stayed byte-identical — identity tracked *which wheel wrote the
document* rather than *what the document asserts*.

The repository already carried the scar. A pinned fingerprint in the interactive
tests was annotated: *"the intentional 0.1.1 release bump moved this pin."*

## The split

| | Meaning | Where it appears |
|---|---|---|
| `agentcheck.__version__` | distribution release | `--version`; run / baseline / replay / review records ("which build ran this") |
| `GENERATOR_COMPATIBILITY_VERSION` | generation semantics | suite `provenance.generator_version` — drives suite identity |

Raise the compatibility version only when a change *should* re-identify otherwise
equivalent suites (new case family, changed default budget, different fixture
wiring, altered lint/selection). Releasing does not qualify.

## Nothing on disk moves

A stored suite validates against the `generator_version` **it recorded**, so old
artifacts keep loading and keep their identity. Only suites generated from here
carry the new value. Tamper rejection is unchanged.

Verified blast radius before/after: `spec_id`, scenario fingerprints — never
moved; suite fingerprint + `suite_id` — moved on a release, now don't.

## One-time cost

The pinned no-follow-up suite fingerprint moved once, updated here with its
rationale corrected. **From now on, a release that moves it is the regression** —
which is exactly what the new tests assert.

## Tests (10 new)

Both directions: a release must not move suite identity, scenario fingerprints or
spec identity; a semantics bump must move suite identity *without* reaching into
the scenarios. Plus: an older-release suite still loads, a tampered suite is
still rejected, round-trip across a release is stable, and `--version` still
reports the release.

Focused: 10 new + 212 in provenance-adjacent modules; ruff + mypy clean.
