### PR TITLE
One command for the release question, and the 0.2.0 release

### DIFF
--- a/.github/workflows/agentcheck-example.yml
+++ b/.github/workflows/agentcheck-example.yml
@@ -65,36 +65,21 @@ jobs:
           python -m pip install --upgrade "pip==26.1.2" "setuptools==83.0.0"
           python -m pip install ".[openai-agents]"
 
-      - name: Run deterministic AgentCheck tests
+      - name: Gate the change on agent behaviour
+        # One command for the whole flow: run the frozen suite, compare it to
+        # the trusted baseline, and return one status.
+        #
+        #   0  no new behavioural failure -- historical failures the baseline
+        #      already accepts do not block
+        #   1  a behavioural failure is new against the baseline
+        #   2  the run is not certifiable (infrastructure, or a suite / source /
+        #      baseline mismatch). Deliberately not reported as a regression:
+        #      a suite that could not execute has not said anything about the
+        #      agent, and calling that a behavioural result is how a broken
+        #      harness becomes a green build.
+        #   3  the suite could not decide. Never treated as a pass.
         run: |
-          set +e
-          agentcheck test "$AGENTCHECK_TARGET" --no-store --run-id "ci-${{ github.run_id }}"
-          status=$?
-          set -e
-          # Historical FAILs (1) and INCONCLUSIVE (3) are not release blockers.
-          # The baseline check decides whether any FAIL is new. Infrastructure (2)
-          # still fails the job.
-          if [ "$status" -eq 2 ] || [ "$status" -eq 130 ]; then
-            exit "$status"
-          fi
-          if [ "$status" -gt 3 ]; then
-            exit "$status"
-          fi
-
-      - name: Require a committed baseline
-        run: |
-          baseline="$AGENTCHECK_TARGET/$AGENTCHECK_BASELINE"
-          if [ ! -f "$baseline" ]; then
-            echo "No trusted baseline at $baseline"
-            echo "Create one explicitly with:"
-            echo "  agentcheck baseline create \"$AGENTCHECK_TARGET\" --latest --out $AGENTCHECK_BASELINE"
-            echo "A failing test run is never an implicit baseline."
-            exit 2
-          fi
-
-      - name: Fail on new authoritative regressions
-        run: |
-          agentcheck baseline check "$AGENTCHECK_TARGET" \
+          agentcheck gate "$AGENTCHECK_TARGET" \
             --baseline "$AGENTCHECK_BASELINE" \
             --run-id "ci-${{ github.run_id }}" \
             --json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Breaking any of these is a correctness bug, not a style issue:
 | `agentcheck/replay/` | Manifests, source binding, filesets. |
 | `agentcheck/report/`, `agentcheck/baseline/`, `agentcheck/review/` | Reporting, CI gating, human decisions on findings. |
 | `agentcheck/regression/` | Run-to-run behavioral comparison over stored artifacts. Executes nothing. |
+| `agentcheck/gate.py` | The CI decision: runs the suite, compares the baseline, and answers whether a change blocks the build. Orchestrates the above; decides no verdicts of its own. |
 | `agentcheck/identity.py` | Portable target identity and its bounded legacy compatibility path. |
 | `agentcheck/redaction.py`, `agentcheck/privacy.py` | Credential redaction for artifacts and logs. |
 | `agentcheck/cli.py` | The `agentcheck` command. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+Notable changes per release. Dates are release dates.
+
+Two version numbers matter in this project and they move independently:
+
+- the **release version** below, which identifies the distribution, and
+- `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, which identifies
+  generation *semantics* and is what suite identity is built on.
+
+A release that does not change generation semantics leaves every suite
+fingerprint where it was. That is stated for each release under **Suite
+identity**.
+
+## 0.2.0
+
+**Suite identity:** unchanged. `GENERATOR_COMPATIBILITY_VERSION` stays `1`, so
+suites frozen under 0.1.x keep their `suite_id` and scenario fingerprints and
+load without regeneration.
+
+### Added
+
+- `agentcheck gate <target>` — a single CI entry point that answers whether a
+  change should block the build. It reports separate exit codes for a
+  behavioural failure (1), a target that is not certifiable (2), and an
+  inconclusive run (3), so a broken harness cannot be read as a clean pass.
+  See `docs/ci-gate.md`.
+- Degraded-evidence fault cases. Suites now generate scenarios for `empty`,
+  `malformed`, `partial`, and `stale` tool results, bounded by
+  `MAX_FAULT_VARIANT_SCENARIOS = 64`. See `docs/fault-testing.md`.
+- Policy rule kinds `ordering`, `max_retries`, `max_tool_calls`, and
+  `max_model_turns`, each mapping onto a trajectory constraint the evaluator
+  already implements. See `docs/behavioral-policies.md`.
+
+### Changed
+
+- `no_fabricated_success` now treats degraded tool results as unreliable
+  evidence, not just hard failures. An agent that receives a truncated or stale
+  payload and reports clean success is a FAIL where it previously passed.
+  `acknowledges_tool_error` is deliberately unchanged: degraded evidence is not
+  a tool error.
+- Suite provenance records generation semantics rather than the release
+  version. Publishing a new version no longer re-identifies otherwise-identical
+  suites.
+- The missing-entrypoint error names the file it looked for and the command
+  that fixes it.
+
+### Fixed
+
+- Policy rule parameters were discarded when constraints were built, so
+  `max_retries: 2` and `max_retries: 5` were indistinguishable and collapsed
+  into one constraint.
+- `ordering` constraints were dropped by a stale lint allowlist before reaching
+  the evaluator, so a declared ordering rule silently did not run.
+
+### Compatibility
+
+No change to the interception boundary, fail-closed behaviour, isolation, the
+network policy, source binding, or verdict semantics. The new degraded-evidence
+FAIL is the one behavioural scoring change: a suite regenerated under 0.2.0 can
+report failures that 0.1.x did not surface. Existing frozen suites are
+unaffected until regenerated.
+
+## 0.1.1 and earlier
+
+Released before this changelog was kept. See the git history.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include CHANGELOG.md
 include CONTRIBUTING.md
 include SECURITY.md
 include AGENTS.md

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ agentcheck test .
 - `generate` creates a frozen behavioral test suite.
 - `test` runs the agent against that suite and evaluates its behavior.
 
+In CI, one command covers the release question:
+
+```bash
+agentcheck gate .
+```
+
+It runs the frozen suite, compares the result against a trusted baseline, and
+returns a single status: `0` allow, `1` a behavioral failure is new, `2` the run
+was not certifiable, `3` the suite could not decide. Failures a baseline already
+accepts do not block. See [the CI gate](docs/ci-gate.md).
+
 The target directory must already exist. `generate` and `test` may inspect the
 target again because each command independently validates current source instead
 of trusting stale state. PydanticAI and Custom Python targets require an explicit
@@ -78,6 +89,13 @@ Finalizing report...
 
 Each scenario ends as `PASS`, `FAIL`, `INCONCLUSIVE`, or `INFRA_ERROR`; harness
 failures are never presented as behavioral failures or passes.
+
+Generated suites also include fault cases — the tool errors, times out, or
+returns an empty, unparseable, truncated or stale payload — so the suite asks
+what the agent does when a tool does not cooperate, not only when it does. What
+gets generated follows the tool's *declared* risk, never its name. See
+[fault testing](docs/fault-testing.md) and, to declare your own contracts,
+[behavioral policies](docs/behavioral-policies.md).
 
 ## What AgentCheck catches
 
@@ -197,6 +215,9 @@ and read the [CI trust model](docs/ci-trust-model.md).
 - [Portable target identity](docs/portable-identity.md)
 - [Decision stages and happens-before](docs/behavioral-launch.md)
 - [Declared behavioral coverage](docs/behavioral-coverage.md)
+- [Fault testing](docs/fault-testing.md)
+- [Behavioral policies](docs/behavioral-policies.md)
+- [The CI gate](docs/ci-gate.md)
 - [Behavioral regression comparison](docs/behavioral-regression.md)
 - [CI trust model](docs/ci-trust-model.md)
 - [PyPI package](https://pypi.org/project/agentcheck-ai/)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ and read the [CI trust model](docs/ci-trust-model.md).
 - [The CI gate](docs/ci-gate.md)
 - [Behavioral regression comparison](docs/behavioral-regression.md)
 - [CI trust model](docs/ci-trust-model.md)
+- [Changelog](CHANGELOG.md)
 - [PyPI package](https://pypi.org/project/agentcheck-ai/)
 
 ## Contributing

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/agentcheck/cli.py
+++ b/agentcheck/cli.py
@@ -23,6 +23,7 @@ from agentcheck.application import (
 )
 from agentcheck.baseline.contract import DEFAULT_BASELINE_FILENAME
 from agentcheck.baseline.service import check_baseline, create_baseline, encode_comparison
+from agentcheck.gate import EXIT_NOT_CERTIFIABLE, gate_error_result, run_gate
 from agentcheck.config import DEFAULT_ENTRYPOINT, contained_path, entrypoint_location
 from agentcheck.coverage import (
     BehavioralCoverage,
@@ -324,6 +325,38 @@ def _parser() -> argparse.ArgumentParser:
         ),
     )
     _add_python_option(test_parser)
+
+    gate_parser = commands.add_parser(
+        "gate",
+        help="run the trusted suite and decide whether CI should block",
+        description=(
+            "Run the frozen suite, compare it against the trusted baseline, and "
+            "return one CI status. A run that could not execute is reported as "
+            "not certifiable rather than as a pass or a regression, and an "
+            "inconclusive suite is never reported as a pass. Exit codes match "
+            "agentcheck test: 0 pass, 1 behavioural failure, 2 not certifiable, "
+            "3 inconclusive."
+        ),
+    )
+    gate_parser.add_argument("target", nargs="?", default=".")
+    gate_parser.add_argument(
+        "--baseline",
+        help=(
+            "relative path to the trusted baseline inside the target "
+            "(defaults to agentcheck-baseline.json)"
+        ),
+    )
+    gate_parser.add_argument("--seed", type=_seed, help="override the configured suite seed")
+    gate_parser.add_argument(
+        "--run-id", type=_run_id, help="set a safe artifact run ID"
+    )
+    gate_parser.add_argument(
+        "--no-store", action="store_true", help="skip writing the local SQLite index"
+    )
+    gate_parser.add_argument(
+        "--json", action="store_true", help="print the decision as JSON on stdout"
+    )
+    _add_python_option(gate_parser)
 
     report_parser = commands.add_parser(
         "report",
@@ -1663,6 +1696,65 @@ def _baseline_create_command(
     return 0
 
 
+def _gate_command(
+    target: str,
+    *,
+    baseline: str | None,
+    seed: int | None,
+    run_id: str | None,
+    persist_store: bool,
+    as_json: bool,
+    python_executable: str | None,
+) -> int:
+    reporter = _TestProgressReporter(stream=sys.stderr if as_json else sys.stdout)
+
+    def on_inspected(spec: AgentSpec) -> None:
+        reporter.inspection_complete()
+
+    def on_prepared(
+        frozen: Any, total: int, invalid: int, excluded_by_selection: int
+    ) -> None:
+        reporter.suite_ready(frozen, total, invalid, excluded_by_selection)
+
+    reporter.start()
+    try:
+        result = run_gate(
+            target,
+            baseline=baseline,
+            seed=seed,
+            run_id=run_id,
+            persist_store=persist_store,
+            python_executable=python_executable,
+            progress=reporter.case_completed,
+            on_inspected=on_inspected,
+            on_prepared=on_prepared,
+        )
+    except Exception as exc:
+        # A suite that could not load or no longer matches its target raises
+        # before any scenario runs. The top-level handler already reports that
+        # to a human on stderr with exit 2, but under `--json` it would leave
+        # stdout empty -- and a CI step piping this into a parser would fail on
+        # an empty document instead of reading the not-certifiable decision.
+        if not as_json:
+            raise
+        message = redact_log_text(str(exc)) or type(exc).__name__
+        # Keep the human line on stderr as well, so a CI log reads the same
+        # whether or not the step asked for JSON.
+        print(f"AgentCheck error: {message}", file=sys.stderr)
+        print(gate_error_result(message).to_json())
+        return EXIT_NOT_CERTIFIABLE
+    finally:
+        reporter.close()
+
+    if as_json:
+        print(result.render(), end="", file=sys.stderr)
+        print(result.to_json())
+    else:
+        print()
+        print(result.render(), end="")
+    return result.exit_code
+
+
 def _baseline_check_command(
     target: str,
     *,
@@ -1743,6 +1835,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 run_id=args.run_id,
                 persist_store=not args.no_store,
                 select=args.select,
+                python_executable=args.python_executable,
+            )
+        if args.command == "gate":
+            return _gate_command(
+                args.target,
+                baseline=args.baseline,
+                seed=args.seed,
+                run_id=args.run_id,
+                persist_store=not args.no_store,
+                as_json=args.json,
                 python_executable=args.python_executable,
             )
         if args.command == "report":

--- a/agentcheck/config.py
+++ b/agentcheck/config.py
@@ -314,7 +314,15 @@ def entrypoint_location(root: Path, entrypoint: str) -> tuple[Path, str]:
 def resolve_entrypoint(root: Path, entrypoint: str) -> tuple[Path, str]:
     source, attribute = entrypoint_location(root, entrypoint)
     if not source.is_file():
-        raise ConfigurationError(f"entrypoint source does not exist: {source}")
+        # This is the first error a new user is likely to see, so it says what
+        # to do rather than only what is missing.
+        raise ConfigurationError(
+            f"entrypoint source does not exist: {source}\n"
+            f"  agentcheck.json points at {entrypoint!r}, relative to {root}.\n"
+            "  Either create that file, or point the config at the module that "
+            "builds your agent:\n"
+            f"    agentcheck init {root} --entrypoint path/to/agent.py:agent --force"
+        )
     return source, attribute
 
 

--- a/agentcheck/gate.py
+++ b/agentcheck/gate.py
@@ -1,0 +1,308 @@
+"""One command for the release question: does this change block the build?
+
+`test` answers "what did the agent do". `baseline check` answers "is any of that
+new". A release gate needs both, plus one thing neither says on its own: whether
+the run is even certifiable. A suite that could not execute is not a passing
+suite, and it is not a behavioural regression either -- reporting it as either
+one is how a broken harness becomes a green build.
+
+This orchestrates the existing operations and does not reimplement them. It runs
+the frozen suite through the same `execute_suite`, compares against a trusted
+baseline through the same `check_baseline`, and maps the result onto the exit
+codes the CLI already documents.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agentcheck.application import SuiteExecution, execute_suite
+from agentcheck.baseline.contract import DEFAULT_BASELINE_FILENAME
+from agentcheck.baseline.service import check_baseline
+from agentcheck.config import contained_path
+from agentcheck.domain import Verdict
+
+
+# The exit contract `test` already publishes, reused rather than reinvented.
+EXIT_PASS = 0
+EXIT_BEHAVIORAL_FAILURE = 1
+EXIT_NOT_CERTIFIABLE = 2
+EXIT_INCONCLUSIVE = 3
+
+
+class GateDecision(str):
+    """A gate outcome, readable in a log and stable in JSON."""
+
+    PASS = "pass"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    decision: str
+    exit_code: int
+    reason: str
+    detail: tuple[str, ...]
+    summary_block: str
+    counts: dict[str, int]
+    run_id: str
+    suite_fingerprint: str | None
+    baseline_path: str | None
+    baseline_compared: bool
+    report_path: str
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "decision": self.decision,
+                "exit_code": self.exit_code,
+                "reason": self.reason,
+                "detail": list(self.detail),
+                "baseline_summary": self.summary_block,
+                "counts": self.counts,
+                "run_id": self.run_id,
+                "suite_fingerprint": self.suite_fingerprint,
+                "baseline": self.baseline_path,
+                "baseline_compared": self.baseline_compared,
+                "report": self.report_path,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    def render(self) -> str:
+        head = "BLOCK" if self.decision == GateDecision.BLOCK else "PASS"
+        lines = [f"{head}: {self.reason}", ""]
+        counts = ", ".join(
+            f"{name} {self.counts.get(name, 0)}"
+            for name in ("pass", "fail", "inconclusive", "infra_error")
+        )
+        lines.append(f"  verdicts   {counts}")
+        lines.append(f"  run        {self.run_id}")
+        if self.suite_fingerprint:
+            lines.append(f"  suite      {self.suite_fingerprint}")
+        lines.append(
+            "  baseline   "
+            + (
+                f"{self.baseline_path} (compared)"
+                if self.baseline_compared
+                else f"{self.baseline_path or DEFAULT_BASELINE_FILENAME} (none recorded)"
+            )
+        )
+        lines.append(f"  report     {self.report_path}")
+        if self.detail:
+            lines.append("")
+            lines.extend(f"  - {item}" for item in self.detail)
+        if self.summary_block:
+            lines.append("")
+            lines.extend(
+                f"  {line}" for line in self.summary_block.rstrip().splitlines()
+            )
+        return "\n".join(lines) + "\n"
+
+
+def gate_error_result(message: str) -> GateResult:
+    """A gate answer for a run that never started.
+
+    A suite that failed to load or a target that no longer matches it stops
+    before any scenario executes, so there is no run and no report. That is
+    still an answer to the release question -- the strongest one available is
+    "not certifiable" -- and a caller reading `--json` needs it as a document
+    rather than as an empty stdout it has to parse.
+
+    `counts` is deliberately empty rather than zeroed. Zeros would read as
+    "nothing failed", which is a claim this run is in no position to make.
+    """
+
+    return GateResult(
+        decision=GateDecision.BLOCK,
+        exit_code=EXIT_NOT_CERTIFIABLE,
+        reason=message,
+        detail=(
+            "the suite did not execute, so no behavioural claim is made",
+            "this is not recorded as a behavioural regression",
+        ),
+        summary_block="",
+        counts={},
+        run_id="",
+        suite_fingerprint=None,
+        baseline_path=None,
+        baseline_compared=False,
+        report_path="",
+    )
+
+
+def _counts(execution: SuiteExecution) -> dict[str, int]:
+    counter = execution.counts
+    return {verdict.value.lower(): counter[verdict] for verdict in Verdict}
+
+
+def _baseline_file(root: Path, baseline: str | None) -> Path | None:
+    try:
+        candidate = contained_path(root, baseline or DEFAULT_BASELINE_FILENAME)
+    except Exception:
+        return None
+    return candidate if candidate.is_file() else None
+
+
+def run_gate(
+    target: str | Path,
+    *,
+    baseline: str | None = None,
+    seed: int | None = None,
+    run_id: str | None = None,
+    persist_store: bool = True,
+    python_executable: str | None = None,
+    progress: Any | None = None,
+    on_inspected: Any | None = None,
+    on_prepared: Any | None = None,
+) -> GateResult:
+    """Execute the trusted suite, compare it to the baseline, and decide."""
+
+    execution = execute_suite(
+        target,
+        seed=seed,
+        run_id=run_id,
+        persist_store=persist_store,
+        python_executable=python_executable,
+        progress=progress,
+        on_inspected=on_inspected,
+        on_prepared=on_prepared,
+    )
+    counts = _counts(execution)
+    root = execution.target_root
+    suite_fingerprint = (
+        execution.frozen_suite.fingerprint if execution.frozen_suite else None
+    )
+    report = str(execution.report_path)
+
+    # Certifiability first. An infrastructure error means the suite did not get
+    # to say anything, so it is neither a pass nor a regression, and answering
+    # the release question from it would be answering it from nothing.
+    if counts.get("infra_error"):
+        return GateResult(
+            decision=GateDecision.BLOCK,
+            exit_code=EXIT_NOT_CERTIFIABLE,
+            reason="the run is not certifiable, so no behavioural claim is made",
+            detail=(
+                f"{counts['infra_error']} case(s) stopped on infrastructure, "
+                "not on agent behaviour",
+                "this is not recorded as a behavioural regression",
+                "fix the harness or the fixtures, then re-run the gate",
+            ),
+            summary_block="",
+            counts=counts,
+            run_id=execution.run_id,
+            suite_fingerprint=suite_fingerprint,
+            baseline_path=None,
+            baseline_compared=False,
+            report_path=report,
+        )
+
+    baseline_file = _baseline_file(root, baseline)
+    if baseline_file is None:
+        # Without a trusted baseline there is nothing to call a *regression*, so
+        # the gate answers the weaker question it can actually answer.
+        detail: list[str] = [
+            "no trusted baseline was found, so nothing was compared",
+            f"record one with: agentcheck baseline create {root}"
+            " --latest --out " + DEFAULT_BASELINE_FILENAME,
+        ]
+        if counts.get("fail"):
+            return GateResult(
+                decision=GateDecision.BLOCK,
+                exit_code=EXIT_BEHAVIORAL_FAILURE,
+                reason="the suite recorded a behavioural failure",
+                detail=tuple([f"{counts['fail']} failing case(s)", *detail]),
+                summary_block="",
+                counts=counts,
+                run_id=execution.run_id,
+                suite_fingerprint=suite_fingerprint,
+                baseline_path=None,
+                baseline_compared=False,
+                report_path=report,
+            )
+        if counts.get("inconclusive"):
+            return GateResult(
+                decision=GateDecision.BLOCK,
+                exit_code=EXIT_INCONCLUSIVE,
+                reason="the suite could not decide, which is not a pass",
+                detail=tuple(
+                    [f"{counts['inconclusive']} inconclusive case(s)", *detail]
+                ),
+                summary_block="",
+                counts=counts,
+                run_id=execution.run_id,
+                suite_fingerprint=suite_fingerprint,
+                baseline_path=None,
+                baseline_compared=False,
+                report_path=report,
+            )
+        return GateResult(
+            decision=GateDecision.PASS,
+            exit_code=EXIT_PASS,
+            reason="every case passed",
+            detail=tuple(detail),
+            summary_block="",
+            counts=counts,
+            run_id=execution.run_id,
+            suite_fingerprint=suite_fingerprint,
+            baseline_path=None,
+            baseline_compared=False,
+            report_path=report,
+        )
+
+    relative = str(baseline_file.relative_to(root))
+    checked = check_baseline(
+        root, baseline_path=relative, run_id=execution.run_id, latest=False
+    )
+    if checked.exit_code == EXIT_PASS:
+        return GateResult(
+            decision=GateDecision.PASS,
+            exit_code=EXIT_PASS,
+            reason="no new behavioural failure against the trusted baseline",
+            detail=(
+                f"{counts.get('fail', 0)} known failure(s) accepted by the baseline",
+            ),
+            summary_block="",
+            counts=counts,
+            run_id=execution.run_id,
+            suite_fingerprint=suite_fingerprint,
+            baseline_path=relative,
+            baseline_compared=True,
+            report_path=report,
+        )
+
+    reason = {
+        EXIT_BEHAVIORAL_FAILURE: "a behavioural failure is new against the trusted baseline",
+        EXIT_NOT_CERTIFIABLE: "the comparison could not be trusted",
+        EXIT_INCONCLUSIVE: "the comparison could not decide, which is not a pass",
+    }.get(checked.exit_code, "the baseline check refused this run")
+    return GateResult(
+        decision=GateDecision.BLOCK,
+        exit_code=checked.exit_code,
+        reason=reason,
+        detail=(),
+        summary_block=checked.summary,
+        counts=counts,
+        run_id=execution.run_id,
+        suite_fingerprint=suite_fingerprint,
+        baseline_path=relative,
+        baseline_compared=True,
+        report_path=report,
+    )
+
+
+__all__ = [
+    "EXIT_BEHAVIORAL_FAILURE",
+    "EXIT_INCONCLUSIVE",
+    "EXIT_NOT_CERTIFIABLE",
+    "EXIT_PASS",
+    "GateDecision",
+    "GateResult",
+    "gate_error_result",
+    "run_gate",
+]

--- a/docs/ci-gate.md
+++ b/docs/ci-gate.md
@@ -1,0 +1,77 @@
+# The CI gate
+
+```bash
+agentcheck gate .
+```
+
+One command for the release question: run the trusted suite, compare it to the
+trusted baseline, and return one status CI can branch on. It orchestrates the
+existing operations — the same `test` execution and the same `baseline check`
+comparison — rather than reimplementing either.
+
+## Exit codes
+
+The contract `agentcheck test` already publishes, reused unchanged:
+
+| Code | Meaning | CI should |
+| --- | --- | --- |
+| `0` | no new behavioural failure | allow |
+| `1` | a behavioural failure is new against the baseline | block |
+| `2` | the run is **not certifiable** | block |
+| `3` | the suite could not decide | block |
+
+## Why "not certifiable" is its own answer
+
+A case that stopped on infrastructure — a missing fixture, a worker that could
+not start, a suite or source or baseline that does not match — has said nothing
+about the agent. Reporting that as a pass hides a broken harness behind a green
+build. Reporting it as a regression blames the agent for something it did not
+do. So it is neither: exit `2`, and the gate does not consult the baseline at
+all, because there is nothing trustworthy to compare.
+
+An infrastructure error outranks a failure in the same run. A suite that only
+half executed cannot certify the half that did.
+
+`INCONCLUSIVE` is never quietly a pass either. Where the evidence a criterion
+needs was not observed, the gate blocks with exit `3` and says so.
+
+## Historical failures do not block
+
+A baseline records the failures you have already accepted. The gate blocks on
+what is **new** against it, so a target with known defects stays green until its
+behaviour changes:
+
+```bash
+agentcheck test . --no-store
+agentcheck baseline create . --latest --out agentcheck-baseline.json
+```
+
+Record a baseline from an explicit command, never from a failing CI run. Without
+one the gate still answers the weaker question it can — it blocks on any failure
+and tells you how to record a baseline — and says plainly that nothing was
+compared.
+
+## Machine-readable output
+
+```bash
+agentcheck gate . --json
+```
+
+Prints the decision, exit code, reason, verdict counts, run ID, suite
+fingerprint and report path as JSON on stdout, with the human summary on stderr
+so both are usable in the same step.
+
+Every exit path prints a document, including the one where the suite never ran
+at all -- a frozen suite that no longer matches its target, or a config the CLI
+could not resolve. That case is the one a parsing step most needs, because it is
+where a broken harness would otherwise look like nothing happened. It reports
+`"decision": "block"` with exit code 2, and `"counts": {}` rather than zeroed
+counts: no scenario executed, so `"fail": 0` would be a claim this run cannot
+make.
+
+## In GitHub Actions
+
+`.github/workflows/agentcheck-example.yml` is a copyable template. It runs on a
+GitHub-hosted runner with `contents: read`, no secrets, and no provider
+credentials: the suite runs against simulated tools, so nothing in it needs a
+model key.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ build-backend = "setuptools.build_meta"
 #
 #     pip install 'agentcheck-ai[all]'    import agentcheck    agentcheck --help
 name = "agentcheck-ai"
-# This release version is also recorded as `provenance.generator_version` in
-# newly frozen suites and participates in their fingerprints. Existing suites
-# remain loadable, but a routine package bump can re-identify otherwise-equivalent
-# newly generated suites. Separating those concepts is known technical debt.
-version = "0.1.1"
+# Release provenance only. Suite identity is versioned separately by
+# `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
+# does not move scenario fingerprints or re-identify equivalent suites.
+# `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
+version = "0.2.0"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"
@@ -83,6 +83,7 @@ agentcheck = "agentcheck.cli:main"
 [project.urls]
 Homepage = "https://github.com/WaseemGhanem98/AgentCheck"
 Documentation = "https://github.com/WaseemGhanem98/AgentCheck#readme"
+Changelog = "https://github.com/WaseemGhanem98/AgentCheck/blob/main/CHANGELOG.md"
 Issues = "https://github.com/WaseemGhanem98/AgentCheck/issues"
 Source = "https://github.com/WaseemGhanem98/AgentCheck"
 

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -47,6 +47,7 @@ SDIST_ALLOWED_ROOTS = frozenset(
     {
         ".github",
         "AGENTS.md",
+        "CHANGELOG.md",
         "CONTRIBUTING.md",
         "LICENSE",
         "MANIFEST.in",

--- a/tests/agentcheck/test_gate.py
+++ b/tests/agentcheck/test_gate.py
@@ -1,0 +1,391 @@
+"""One CI status, and the three ways it must refuse to say "pass".
+
+`test` says what the agent did. `baseline check` says whether any of it is new.
+A release gate needs both plus the question neither answers alone: whether the
+run is certifiable at all. A suite that could not execute is not passing and is
+not a regression either, and reporting it as either one is how a broken harness
+becomes a green build.
+
+These tests drive the decision logic with fakes, so nothing here executes a
+suite or contacts a provider.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agentcheck import gate as gate_module
+from agentcheck.baseline.contract import DEFAULT_BASELINE_FILENAME
+from agentcheck.domain import Verdict
+from agentcheck.gate import (
+    EXIT_BEHAVIORAL_FAILURE,
+    EXIT_INCONCLUSIVE,
+    EXIT_NOT_CERTIFIABLE,
+    EXIT_PASS,
+    GateDecision,
+    gate_error_result,
+    run_gate,
+)
+
+
+class _FakeExecution:
+    def __init__(self, root: Path, counts: dict[Verdict, int]) -> None:
+        self.target_root = root
+        self.run_id = "run-1"
+        self.frozen_suite = type("S", (), {"fingerprint": "sha256:abc"})()
+        self.report_path = root / "report.html"
+        self._counts = Counter(counts)
+
+    @property
+    def counts(self) -> Counter:
+        return self._counts
+
+
+class _FakeChecked:
+    def __init__(self, exit_code: int, summary: str = "summary\n") -> None:
+        self.exit_code = exit_code
+        self.summary = summary
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def _patch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    counts: dict[Verdict, int],
+    root: Path,
+    checked: _FakeChecked | None = None,
+) -> dict[str, int]:
+    calls = {"check_baseline": 0}
+
+    def _execute(target: Any, **_: Any) -> Any:
+        return _FakeExecution(root, counts)
+
+    def _check(*_: Any, **__: Any) -> Any:
+        calls["check_baseline"] += 1
+        assert checked is not None, "baseline was compared when none was expected"
+        return checked
+
+    monkeypatch.setattr(gate_module, "execute_suite", _execute)
+    monkeypatch.setattr(gate_module, "check_baseline", _check)
+    return calls
+
+
+def _baseline(root: Path) -> None:
+    (root / DEFAULT_BASELINE_FILENAME).write_text("{}", encoding="utf-8")
+
+
+# --- the certifiability question comes first -------------------------------
+
+
+def test_an_infra_error_is_not_a_regression_and_not_a_pass(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _baseline(target)
+    calls = _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 3, Verdict.INFRA_ERROR: 1},
+        root=target,
+    )
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.BLOCK
+    assert result.exit_code == EXIT_NOT_CERTIFIABLE
+    assert "not certifiable" in result.reason
+    assert any("not recorded as a behavioural regression" in d for d in result.detail)
+    # The baseline is not even consulted: there is nothing trustworthy to compare.
+    assert calls["check_baseline"] == 0
+
+
+def test_an_infra_error_outranks_a_failure_in_the_same_run(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    """A run that half executed cannot certify the half that did."""
+
+    _baseline(target)
+    _patch(
+        monkeypatch,
+        counts={Verdict.FAIL: 2, Verdict.INFRA_ERROR: 1},
+        root=target,
+    )
+
+    result = run_gate(target)
+
+    assert result.exit_code == EXIT_NOT_CERTIFIABLE
+
+
+# --- with a trusted baseline -----------------------------------------------
+
+
+def test_no_new_failure_against_the_baseline_passes(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _baseline(target)
+    _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 40, Verdict.FAIL: 5},
+        root=target,
+        checked=_FakeChecked(EXIT_PASS),
+    )
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.PASS
+    assert result.exit_code == EXIT_PASS
+    assert result.baseline_compared is True
+
+
+def test_a_new_failure_against_the_baseline_blocks(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _baseline(target)
+    _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 40, Verdict.FAIL: 6},
+        root=target,
+        checked=_FakeChecked(EXIT_BEHAVIORAL_FAILURE),
+    )
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.BLOCK
+    assert result.exit_code == EXIT_BEHAVIORAL_FAILURE
+    assert "new" in result.reason
+
+
+def test_an_untrustworthy_comparison_is_not_a_regression(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    """Suite, source or baseline mismatch is a certification problem."""
+
+    _baseline(target)
+    _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 40},
+        root=target,
+        checked=_FakeChecked(EXIT_NOT_CERTIFIABLE),
+    )
+
+    result = run_gate(target)
+
+    assert result.exit_code == EXIT_NOT_CERTIFIABLE
+    assert "trusted" in result.reason
+
+
+# --- without a baseline ----------------------------------------------------
+
+
+def test_a_clean_run_without_a_baseline_passes_and_says_so(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _patch(monkeypatch, counts={Verdict.PASS: 12}, root=target)
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.PASS
+    assert result.exit_code == EXIT_PASS
+    assert result.baseline_compared is False
+    assert any("no trusted baseline" in d for d in result.detail)
+    assert any("baseline create" in d for d in result.detail)
+
+
+def test_a_failure_without_a_baseline_still_blocks(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _patch(monkeypatch, counts={Verdict.PASS: 10, Verdict.FAIL: 1}, root=target)
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.BLOCK
+    assert result.exit_code == EXIT_BEHAVIORAL_FAILURE
+
+
+def test_inconclusive_is_never_silently_a_pass(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 10, Verdict.INCONCLUSIVE: 2},
+        root=target,
+    )
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.BLOCK
+    assert result.exit_code == EXIT_INCONCLUSIVE
+    assert "not a pass" in result.reason
+
+
+# --- machine readable ------------------------------------------------------
+
+
+def test_the_decision_is_machine_readable(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _baseline(target)
+    _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 40, Verdict.FAIL: 6},
+        root=target,
+        checked=_FakeChecked(EXIT_BEHAVIORAL_FAILURE),
+    )
+
+    payload = json.loads(run_gate(target).to_json())
+
+    assert payload["decision"] == "block"
+    assert payload["exit_code"] == EXIT_BEHAVIORAL_FAILURE
+    assert payload["counts"]["fail"] == 6
+    assert payload["run_id"] == "run-1"
+    assert payload["suite_fingerprint"] == "sha256:abc"
+    assert payload["baseline_compared"] is True
+
+
+def test_the_rendering_leads_with_the_decision(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    _patch(monkeypatch, counts={Verdict.PASS: 1}, root=target)
+
+    rendered = run_gate(target).render()
+
+    assert rendered.startswith("PASS: ")
+    assert "verdicts" in rendered
+    assert "report" in rendered
+
+
+def test_a_baseline_outside_the_target_is_not_followed(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    """A gate must not be pointed at a baseline from somewhere else."""
+
+    _patch(monkeypatch, counts={Verdict.PASS: 5}, root=target)
+
+    result = run_gate(target, baseline="../elsewhere.json")
+
+    assert result.baseline_compared is False
+
+
+# --- the exit contract is the one the CLI already documents ----------------
+
+
+def test_the_exit_codes_match_the_published_contract() -> None:
+    assert (EXIT_PASS, EXIT_BEHAVIORAL_FAILURE, EXIT_NOT_CERTIFIABLE, EXIT_INCONCLUSIVE) == (
+        0,
+        1,
+        2,
+        3,
+    )
+
+
+# --- a run that never started is still an answer --------------------------
+
+
+def test_a_suite_that_could_not_load_is_reported_as_not_certifiable() -> None:
+    """A suite that no longer matches its target raises before anything runs.
+
+    That is not a pass and not a regression. It is the not-certifiable case,
+    and it has to survive as a decision rather than as an exception.
+    """
+    result = gate_error_result("frozen suite was generated for a different target")
+
+    assert result.decision == GateDecision.BLOCK
+    assert result.exit_code == EXIT_NOT_CERTIFIABLE
+    assert "different target" in result.reason
+    assert any("no behavioural claim" in item for item in result.detail)
+    assert any("not recorded as a behavioural regression" in item for item in result.detail)
+
+
+def test_a_run_that_never_started_reports_no_counts_rather_than_zeroes() -> None:
+    """Zeroed counts would read as "nothing failed".
+
+    No scenario executed, so the run is in no position to make that claim.
+    Absent evidence has to stay absent instead of being rendered as a clean
+    result a caller could believe.
+    """
+    result = gate_error_result("boom")
+
+    assert result.counts == {}
+    assert json.loads(result.to_json())["counts"] == {}
+    assert result.run_id == ""
+    assert result.suite_fingerprint is None
+    assert result.report_path == ""
+
+
+def test_the_error_path_still_produces_a_parseable_document() -> None:
+    """`--json` promises a document on every path.
+
+    The not-certifiable path is the one a CI script most needs to parse, since
+    it is the case where a broken harness would otherwise look green. Emitting
+    nothing there makes the consumer fail on an empty document instead of
+    reading the decision.
+    """
+    payload = json.loads(gate_error_result("suite mismatch").to_json())
+
+    assert payload["decision"] == "block"
+    assert payload["exit_code"] == EXIT_NOT_CERTIFIABLE
+    assert payload["baseline_compared"] is False
+    for field in ("decision", "exit_code", "reason", "detail", "counts", "report"):
+        assert field in payload, f"{field} missing; consumers parse a stable shape"
+
+
+def test_the_cli_emits_the_document_instead_of_an_empty_stdout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The regression this guards: exit 2 with zero bytes on stdout."""
+    from agentcheck import cli as cli_module
+    from agentcheck.errors import AgentCheckError
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AgentCheckError("frozen suite does not match this target")
+
+    monkeypatch.setattr(cli_module, "run_gate", _boom)
+
+    exit_code = cli_module._gate_command(
+        str(tmp_path),
+        baseline=None,
+        seed=None,
+        run_id=None,
+        persist_store=False,
+        as_json=True,
+        python_executable=None,
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == EXIT_NOT_CERTIFIABLE
+    payload = json.loads(captured.out)
+    assert payload["exit_code"] == EXIT_NOT_CERTIFIABLE
+    assert "does not match this target" in payload["reason"]
+    # The human line stays on stderr so a log reads the same either way.
+    assert "AgentCheck error:" in captured.err
+
+
+def test_the_error_path_without_json_keeps_the_existing_human_handling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without `--json` the top-level handler owns the message. Do not swallow it."""
+    from agentcheck import cli as cli_module
+    from agentcheck.errors import AgentCheckError
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AgentCheckError("frozen suite does not match this target")
+
+    monkeypatch.setattr(cli_module, "run_gate", _boom)
+
+    with pytest.raises(AgentCheckError):
+        cli_module._gate_command(
+            str(tmp_path),
+            baseline=None,
+            seed=None,
+            run_id=None,
+            persist_store=False,
+            as_json=False,
+            python_executable=None,
+        )

--- a/tests/agentcheck/test_version_decoupling.py
+++ b/tests/agentcheck/test_version_decoupling.py
@@ -218,3 +218,29 @@ def test_the_cli_still_reports_the_package_release() -> None:
     assert result.returncode == 0, result.stderr
     assert agentcheck.__version__ in (result.stdout + result.stderr)
     assert GENERATOR_COMPATIBILITY_VERSION not in result.stdout.split()[-1:]
+
+
+# --- the two hand-maintained declarations must not drift apart -------------
+
+
+def test_the_release_version_is_declared_once_in_effect() -> None:
+    """``pyproject.toml`` and ``agentcheck.__version__`` are edited by hand.
+
+    Nothing generates one from the other, so a bump that touches only one leaves
+    the wheel's metadata disagreeing with what ``--version`` prints and with what
+    ``provenance.release_version`` records. That is silent: both files are
+    individually valid.
+    """
+    import re
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    # Match the project table's own key, not a pinned dependency's version.
+    match = re.search(r"(?m)^version = \"([^\"]+)\"$", text)
+    assert match is not None, "no top-level version key in pyproject.toml"
+
+    assert match.group(1) == agentcheck.__version__, (
+        f"pyproject.toml declares {match.group(1)!r} but "
+        f"agentcheck.__version__ is {agentcheck.__version__!r}"
+    )


### PR DESCRIPTION
Milestones 4 and 5 of the pre-0.2.0 roadmap, plus the release itself. Builds on #35 (M1) and #36 (M2+M3).

## Milestone 4 — `agentcheck gate`

`test` answers what the agent did. `baseline check` answers whether any of it is new. A release gate needs both, plus the question neither answers alone: whether the run is certifiable at all. Every consumer was hand-assembling that from multiple commands, and the example workflow had four steps of shell doing it by hand.

`agentcheck gate <target>` orchestrates the existing operations — the same `execute_suite`, the same `check_baseline` — and maps the result onto the exit codes the CLI already publishes:

| exit | meaning |
|---|---|
| 0 | pass, or no *new* failure against a trusted baseline |
| 1 | a behavioural failure |
| 2 | not certifiable — the run made no behavioural claim |
| 3 | inconclusive, never a pass |

Certifiability is checked first and outranks a failure in the same run. On `INFRA_ERROR` the baseline is not consulted at all: a suite that could not execute has not said anything about the agent, and scoring it as either a pass or a regression is how a broken harness becomes a green build.

`.github/workflows/agentcheck-example.yml` drops from four hand-rolled steps to one call.

## Milestone 5 — onboarding

The first error a new user hits was `entrypoint source does not exist: <path>`, which named the resolved path but not what to do. It now names the file, the config that points at it, and the command that fixes it. README gains the gate in the quickstart; the three new capabilities get docs (`docs/ci-gate.md`, plus fault-testing and behavioral-policies from #36).

## Release 0.2.0

- Version bumped in both declarations, with a test that reads the project table's version key and asserts it matches `__version__`. Nothing derived one from the other, so a half-done bump left the wheel's metadata disagreeing with `--version` while both files stayed individually valid.
- The comment above that version key still described the package/suite-identity coupling as known technical debt. It was paid in #35, and **this bump demonstrates it**: the interactive-scenario fingerprint pin did not move from 0.1.1 to 0.2.0.
- Adds `CHANGELOG.md`, leading with whether suite identity moved — the question a consumer holding frozen suites actually has, and one no longer answerable from a version number alone. `check_distribution.py` gained the matching sdist allowlist entry.

## What end-to-end validation found

Running the real gate against the bundled example (fully local scripted model, no provider calls) surfaced a defect the unit tests missed, now fixed in the M4 commit:

**`--json` emitted zero bytes on the not-certifiable path.** A suite that no longer matches its target raises before any scenario runs, so no `GateResult` was ever built and the top-level handler printed only to stderr. A CI step piping `gate --json` into a parser — the documented usage — got an empty document and a parse error instead of the decision. That is the exact case a gate exists to report, since it is where a broken harness would otherwise look like nothing happened.

The error path now emits a document on every exit. `counts` is `{}`, deliberately not zeroed: no scenario executed, so `"fail": 0` would be a claim the run cannot make. The human line stays on stderr so a log reads the same either way. Five tests cover it, including the empty-stdout regression itself.

One expectation of mine was wrong, not the code: I expected a trailing comment in `agent.py` to trip source binding. It does not, and should not — source binding constrains *replay*, where a recorded run is re-executed, not a fresh `test` run that re-inspects the agent live. A changed declared surface does correctly produce exit 2.

## Validation

Full local suite: **1384 passed, 1 skipped**. `ruff` and `mypy` clean. Secret scan, workflow safety (8 hosted jobs), and the distribution audit pass. Clean-install smoke on the built 0.2.0 wheel: `agentcheck 0.2.0`, gate present, base install framework-free, `GENERATOR_COMPATIBILITY_VERSION` still `1`. Gate exercised end-to-end for exit 0 (baselined), 1 (unbaselined failures), and 2 (declared-surface change) — no provider spend.

## Invariants

No change to ToolGateway, handler execution, fail-closed behaviour, isolation, network policy, source binding, or the 10s budget. The gate reads verdicts and never produces them; `INFRA_ERROR` cannot become behavioural, and inconclusive is never a pass.

## Release safety

`release.yml` triggers only on a published GitHub Release, so merging this cannot publish to PyPI or create a tag. The bump is metadata only.
