### PR TITLE
Fault-test the destructive actions that take no arguments

### DIFF
--- a/agentcheck/generate/boundaries.py
+++ b/agentcheck/generate/boundaries.py
@@ -392,7 +392,21 @@ def _analyze(tool: ToolDefinition) -> _Analysis:
     if surface.truncated:
         reasons.append("the declared parameter list was truncated during extraction")
     if not surface.parameters:
-        return _Analysis((), (*reasons, "the declared schema exposes no parameters"))
+        # Nothing to probe at the schema boundary -- that much was always right.
+        # But "no invalid call can be constructed" is not "no valid call can be
+        # constructed": a schema declaring no parameters admits exactly one
+        # in-contract call, the empty one. Withholding it here also withheld the
+        # baseline the behavioural generators need, so a zero-argument
+        # destructive action such as `cancel_trip()` got no tool-failure, no
+        # degraded-evidence and no ambiguous-timeout case at all.
+        #
+        # Still validated rather than assumed. A schema that rejects `{}` -- it
+        # requires a property it never declared, say -- yields no baseline, and
+        # the generators skip it as before.
+        without_parameters = (*reasons, "the declared schema exposes no parameters")
+        if validator.is_valid({}):
+            return _Analysis((), without_parameters, baseline={})
+        return _Analysis((), without_parameters)
 
     baseline: dict[str, Any] = {}
     for parameter in surface.parameters:

--- a/tests/agentcheck/test_generate.py
+++ b/tests/agentcheck/test_generate.py
@@ -838,9 +838,16 @@ def test_zero_argument_function_tool_generates_an_empty_invocation() -> None:
     assert list(schema.get("required") or []) == []
 
     suite = build_frozen_suite(spec, AgentCheckConfig(), seed=SEED)
-    assert len(suite.cases) == 1
-    case = suite.cases[0]
-    assert case.lineage.origin is CaseOrigin.ZERO_INPUT_INVOCATION
+    # A zero-parameter schema is in-contract with the empty object, so the tool
+    # also earns an action-path case. The zero-input invocation is still its own
+    # case and is the one this test follows through the gateway.
+    zero_input = [
+        case
+        for case in suite.cases
+        if case.lineage.origin is CaseOrigin.ZERO_INPUT_INVOCATION
+    ]
+    assert len(zero_input) == 1
+    case = zero_input[0]
     assert case.lineage.tool_name == "ping"
     scenario = case.scenario
     assert scenario.scenario_id == "zero-input-ping"
@@ -848,11 +855,7 @@ def test_zero_argument_function_tool_generates_an_empty_invocation() -> None:
     assert scenario.required_tool_behavior[0].arguments_match == {}
     assert "source:zero_input_invocation" in scenario.dimension_tags
     assert lint_scenario(scenario, spec) == ()
-    assert suite.provenance.sources == (
-        "built_in",
-        "schema_boundary",
-        "zero_input_invocation",
-    )
+    assert "zero_input_invocation" in suite.provenance.sources
     assert suite.coverage.tools == ("ping",)
     assert suite.coverage.tools_without_boundary_cases == ()
 
@@ -925,8 +928,15 @@ agent = Agent(
     assert "Frozen suite written." in output
     assert not (target / "HANDLER_RAN").exists()
     suite = load_frozen_suite(target / DEFAULT_SUITE_FILENAME)
-    assert len(suite.cases) == 1
-    case = suite.cases[0]
-    assert case.lineage.origin is CaseOrigin.ZERO_INPUT_INVOCATION
+    zero_input = [
+        case
+        for case in suite.cases
+        if case.lineage.origin is CaseOrigin.ZERO_INPUT_INVOCATION
+    ]
+    assert len(zero_input) == 1
+    case = zero_input[0]
     assert case.scenario.tool_fixtures[0].arguments_match == {}
     assert case.scenario.required_tool_behavior[0].arguments_match == {}
+    # The tripwire above still holds: no case, action path included, ran the
+    # original handler.
+    assert not (target / "HANDLER_RAN").exists()

--- a/tests/agentcheck/test_positive_path_cases.py
+++ b/tests/agentcheck/test_positive_path_cases.py
@@ -129,15 +129,38 @@ def test_one_case_per_tool_with_a_constructible_baseline() -> None:
 
 
 def test_tools_without_a_constructible_baseline_are_omitted() -> None:
-    """Fail conservatively: no invented semantics for an unreadable contract."""
+    """Fail conservatively: no invented semantics for an unreadable contract.
+
+    The example used to be a zero-parameter tool, on the reasoning that "exposes
+    no parameters" meant "no baseline exists". Those are different claims: a
+    schema declaring no parameters has a perfectly constructible baseline, the
+    empty object. A required parameter whose type cannot be resolved is the
+    genuinely unconstructible case, and it is the one this guarantee is for.
+    """
 
     @function_tool
-    def opaque() -> str:
-        """Takes nothing."""
+    def opaque(payload: Any) -> str:
+        """Takes a payload whose declared type cannot be resolved."""
         raise AssertionError("original handler must never run")
 
-    # A zero-parameter tool exposes no parameters, so no baseline exists.
     assert _positive(_spec(opaque)) == ()
+
+
+def test_a_zero_parameter_tool_has_a_constructible_baseline() -> None:
+    """The empty object is in-contract, so the action path is reachable."""
+
+    @function_tool
+    def cancel_trip() -> str:
+        """Cancel the traveller's upcoming trip."""
+        raise AssertionError("original handler must never run")
+
+    cases = _positive(_spec(cancel_trip))
+
+    assert len(cases) == 1
+    # Calling stays optional -- declining is not a defect -- so the contract is
+    # an allowed call, bound to the empty object rather than invented arguments.
+    allowed = cases[0].allowed_tool_behavior
+    assert [(b.tool_name, b.arguments_match) for b in allowed] == [("cancel_trip", {})]
 
 
 def test_generation_is_deterministic() -> None:

--- a/tests/agentcheck/test_zero_argument_actions.py
+++ b/tests/agentcheck/test_zero_argument_actions.py
@@ -1,0 +1,188 @@
+"""A destructive action that takes no arguments must still be fault-tested.
+
+Schema-boundary generation asks "what invalid call can be constructed", and for
+a tool that declares no parameters the honest answer is "none". That answer was
+being reused as "no valid argument object exists either", so the whole
+behavioural fault family was skipped: the loop that builds tool-failure,
+degraded-evidence and ambiguous-timeout cases bails on a missing baseline.
+
+The result was that `cancel_trip()` -- destructive, zero-argument, found in the
+official OpenAI customer-support sample -- produced exactly one scenario, and
+that scenario carried no fixtures, no trajectory constraints and no output
+criteria. It could not fail. `delete_account(account_id)`, identical in every
+way that matters except for taking an argument, produced ten.
+
+An empty object is a valid in-contract argument set for a schema that declares
+no parameters. These tests pin that, and try to break the fix in the directions
+that would make it unsafe: by inventing arguments, by escaping the bound, by
+letting an unvalidated schema through, or by disturbing parameterised tools.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents import Agent, function_tool
+
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.generate.boundaries import (
+    MAX_FAULT_VARIANT_SCENARIOS,
+    build_outcome_variant_cases,
+    derive_boundaries,
+)
+
+SEED = 1729
+
+
+@function_tool
+def cancel_trip() -> str:
+    """Cancel the traveller's upcoming trip and note the refund."""
+    raise AssertionError("original handler must never run")
+
+
+@function_tool
+def delete_account(account_id: str) -> str:
+    """Permanently delete the named account."""
+    raise AssertionError("original handler must never run")
+
+
+@function_tool
+def list_trips() -> str:
+    """List the traveller's trips."""
+    raise AssertionError("original handler must never run")
+
+
+def _spec(*tools: Any):
+    return OpenAIAgentsAdapter().inspect(
+        Agent(name="T", instructions="Assist.", tools=list(tools), model="gpt-4.1-mini")
+    )
+
+
+def _suffixes(scenarios: tuple[Any, ...], tool: str) -> set[str]:
+    prefix = f"action-{tool.replace('_', '-')}-"
+    return {
+        s.scenario_id[len(prefix) :]
+        for s in scenarios
+        if s.scenario_id.startswith(prefix)
+    }
+
+
+# --- the defect itself ------------------------------------------------------
+
+
+def test_a_zero_argument_destructive_tool_gets_its_fault_family() -> None:
+    """The regression. Before the fix this set was empty."""
+    scenarios = build_outcome_variant_cases(_spec(cancel_trip), seed=SEED)
+    suffixes = _suffixes(scenarios, "cancel_trip")
+
+    assert "tool-failure" in suffixes
+    for degraded in (
+        "empty-response",
+        "malformed-response",
+        "partial-response",
+        "stale-response",
+    ):
+        assert degraded in suffixes, f"{degraded} missing for a zero-argument tool"
+
+
+def test_a_zero_argument_destructive_tool_keeps_its_ambiguous_timeout() -> None:
+    """The duplicate-side-effect question is the whole point of a `cancel_trip()`."""
+    scenarios = build_outcome_variant_cases(_spec(cancel_trip), seed=SEED)
+
+    assert "ambiguous-outcome" in _suffixes(scenarios, "cancel_trip")
+
+
+def test_taking_an_argument_is_not_what_earns_fault_coverage() -> None:
+    """Two destructive tools that differ only in arity must be treated alike."""
+    scenarios = build_outcome_variant_cases(_spec(cancel_trip, delete_account), seed=SEED)
+
+    assert _suffixes(scenarios, "cancel_trip") == _suffixes(scenarios, "delete_account")
+
+
+# --- the fix must not invent anything ---------------------------------------
+
+
+def test_the_generated_call_carries_no_invented_arguments() -> None:
+    """A zero-parameter schema admits exactly one in-contract call: the empty one.
+
+    Supplying anything else would be an out-of-contract call dressed as a
+    positive path, and the gateway is required to fail closed on those.
+    """
+    scenarios = build_outcome_variant_cases(_spec(cancel_trip), seed=SEED)
+
+    seen_a_call = False
+    for scenario in scenarios:
+        for behavior in (
+            *scenario.required_tool_behavior,
+            *scenario.allowed_tool_behavior,
+        ):
+            if behavior.tool_name != "cancel_trip":
+                continue
+            seen_a_call = True
+            assert behavior.arguments_match in (None, {}), (
+                f"{scenario.scenario_id} invented arguments for a zero-parameter "
+                f"schema: {behavior.arguments_match!r}"
+            )
+
+    for scenario in scenarios:
+        for fixture in scenario.tool_fixtures:
+            if fixture.tool_name != "cancel_trip":
+                continue
+            seen_a_call = True
+            assert fixture.arguments_match in (None, {}), (
+                f"{scenario.scenario_id} bound a fixture to invented arguments: "
+                f"{fixture.arguments_match!r}"
+            )
+
+    assert seen_a_call, "no call contract was asserted at all; the test proved nothing"
+
+
+def test_a_read_only_zero_argument_tool_still_gets_no_fault_family() -> None:
+    """Arity was never the gate -- declared risk is. Retrying a lookup is ordinary."""
+    scenarios = build_outcome_variant_cases(_spec(list_trips), seed=SEED)
+
+    assert _suffixes(scenarios, "list_trips") == set()
+
+
+def test_no_schema_boundary_is_invented_for_a_zero_parameter_tool() -> None:
+    """There is genuinely nothing to probe at the boundary. That part was right."""
+    assert derive_boundaries(_spec(cancel_trip).tools.items[0].value) == ()
+
+
+# --- the fix must not disturb what already worked ---------------------------
+
+
+def test_a_parameterised_tool_is_unchanged_by_the_fix() -> None:
+    alone = _suffixes(build_outcome_variant_cases(_spec(delete_account), seed=SEED), "delete_account")
+    together = _suffixes(
+        build_outcome_variant_cases(_spec(cancel_trip, delete_account), seed=SEED),
+        "delete_account",
+    )
+
+    assert alone == together
+
+
+def test_generation_stays_deterministic() -> None:
+    spec = _spec(cancel_trip, delete_account)
+    first = build_outcome_variant_cases(spec, seed=SEED)
+    second = build_outcome_variant_cases(spec, seed=SEED)
+
+    assert [s.scenario_id for s in first] == [s.scenario_id for s in second]
+    assert [s.fingerprint for s in first] == [s.fingerprint for s in second]
+
+
+def test_generation_stays_bounded_when_every_tool_is_zero_argument() -> None:
+    """Zero-argument tools must not be a way around the spec-wide cap."""
+
+    def _make(index: int) -> Any:
+        async def _fn() -> str:
+            raise AssertionError("original handler must never run")
+
+        _fn.__name__ = f"cancel_thing_{index}"
+        _fn.__doc__ = f"Permanently delete thing {index}."
+        return function_tool(_fn)
+
+    spec = _spec(*[_make(i) for i in range(40)])
+    scenarios = build_outcome_variant_cases(spec, seed=SEED)
+
+    assert len(scenarios) <= MAX_FAULT_VARIANT_SCENARIOS


### PR DESCRIPTION
Found by running AgentCheck 0.2.0 against the official OpenAI customer-support sample (`openai/openai-chatkit-advanced-samples` @ `9729a1c`) as part of a real-world validation campaign.

## The defect

`cancel_trip()` in that sample is destructive by AgentCheck's own classification. It produced **one** scenario — "cancel_trip may be invoked with no arguments" — carrying no fixtures, no trajectory constraints and no output criteria. It could not fail.

A structurally identical tool that happens to take an argument produced ten:

```
delete_account(account_id) -> 10 scenarios   (incl. all 5 fault variants + ambiguous timeout)
cancel_trip()              ->  1 scenario    (no oracles at all)
```

Arity, not declared risk, was deciding which irreversible actions got fault coverage.

## Root cause

`_analyze` in `generate/boundaries.py` asks what *invalid* call can be constructed. For a schema declaring no parameters the honest answer is "none", and it returned early — without a baseline. But every behavioural generator gates on that same baseline:

```python
analysis = _analyze(definition)
if analysis.baseline is None:
    continue
```

So "no invalid call can be constructed" was silently reused as "no valid call can be constructed either". A schema that declares no parameters admits exactly one in-contract call: the empty one.

## The fix

Offer `{}` as the baseline for a zero-parameter schema — validated, not assumed. A schema that rejects `{}` still yields no baseline and is skipped exactly as before.

Scope held deliberately tight:

- **Schema-boundary output is unchanged.** There is genuinely nothing to probe; a test pins that no boundary is invented.
- **Nothing is conjured.** Fixtures and call contracts bind to `{}`; a test asserts no argument is invented for a zero-parameter schema.
- **Arity was never the gate and still isn't.** A read-only zero-argument lookup gets no fault family, because retrying a lookup is ordinary behaviour.

## Before / after on the real target

| | before | after |
|---|---|---|
| suite total | 30 cases | 44 cases |
| `cancel_trip` (destructive) | 1 vacuous | 8, incl. ambiguous timeout |
| `add_checked_bag` (state-changing) | 1 vacuous | 7 |
| `change_seat` (parameterised) | 11 | 11 — unchanged |

`add_checked_bag` correctly gets no ambiguous-timeout case: it is state-changing but not destructive.

## Tests

`tests/agentcheck/test_zero_argument_actions.py`, 9 tests. 4 fail on current main, all 9 pass with the fix. They are written to break the fix rather than confirm it: by inventing arguments, by escaping the spec-wide bound, by letting an unvalidated schema through, and by disturbing parameterised tools.

## Invariants

Verified end-to-end on a target whose handlers raise `AssertionError` if reached: 18/18 scenarios executed, **0 infra errors**, no handler ran. No change to ToolGateway, fail-closed behaviour, isolation, network policy, verdict semantics, or the 10s budget.

`GENERATOR_COMPATIBILITY_VERSION` does not move. Specs with no zero-argument tools generate byte-identical suites, so suites that are otherwise equivalent keep their identity; affected specs change fingerprint because their content genuinely changed.
