### PR TITLE
Give PydanticAI tools the risk markers the other adapter assigns

### DIFF
--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -53,7 +53,7 @@ from agentcheck.domain.run import (
     UsageMetrics,
 )
 from agentcheck.domain.scenario import ConversationRole, ConversationTurn
-from agentcheck.inspect.capabilities import extract_capabilities
+from agentcheck.inspect.capabilities import classify_tool, extract_capabilities
 
 from .base import (
     portable_identity,
@@ -240,13 +240,26 @@ def _tool_definition(name: str, tool: Any) -> ToolDefinition:
     tool_def = getattr(tool, "tool_def", None)
     schema = getattr(tool_def, "parameters_json_schema", None)
     description = getattr(tool_def, "description", None)
+    resolved = description if isinstance(description, str) and description else None
+    # The same shared classifier the OpenAI Agents adapter uses. These two flags
+    # were hardcoded False here, and everything downstream reads them: fault
+    # generation skips a tool that is not state-changing, and the
+    # ambiguous-timeout case is destructive-only. A PydanticAI target therefore
+    # received no fault family for any tool, while `inspect` printed a summary
+    # of zero state-changing actions directly above a capability listing that
+    # described the same tool as state-changing -- capability extraction
+    # classifies independently, so only the adapter disagreed.
+    #
+    # Still inferred, still not authoritative, and reported as such. This buys
+    # parity with the other adapter, not a stronger claim than it makes.
+    _, state_changing, destructive = classify_tool(name, resolved)
     return ToolDefinition(
         name=name,
-        description=description if isinstance(description, str) and description else None,
+        description=resolved,
         input_schema=dict(schema) if isinstance(schema, Mapping) else {},
         output_schema=None,
-        state_changing=False,
-        destructive=False,
+        state_changing=state_changing,
+        destructive=destructive,
         replaceable=True,
     )
 

--- a/tests/agentcheck/test_pydantic_ai_risk_parity.py
+++ b/tests/agentcheck/test_pydantic_ai_risk_parity.py
@@ -1,0 +1,157 @@
+"""PydanticAI tools must carry the risk markers the other adapter carries.
+
+`classify_tool` says why it exists: "a tool definition must carry its risk
+markers before a capability can be built from it". The OpenAI Agents adapter
+calls it. The PydanticAI adapter hardcoded `state_changing=False,
+destructive=False` and never did.
+
+Everything downstream reads those two flags. Fault generation skips a tool that
+is not state-changing, and the ambiguous-timeout case is destructive-only, so a
+PydanticAI target received no tool-failure, no degraded-evidence and no
+duplicate-side-effect case for any tool at all -- the whole systematic fault
+capability was inert for one of the two supported frameworks.
+
+It was visible in `inspect` as a contradiction: the summary counted zero
+state-changing actions while the capability listing under it described the same
+tool as state-changing and destructive, because capability extraction classifies
+independently of the adapter.
+
+These tests hold the two adapters to the same answer for the same tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.models.test import TestModel
+
+from agentcheck.adapters import OpenAIAgentsAdapter, PydanticAIAdapter
+from agentcheck.config import AgentCheckConfig
+from agentcheck.generate.boundaries import build_outcome_variant_cases
+from agentcheck.generate.suite import build_frozen_suite
+
+SEED = 1729
+
+
+def _pydantic_spec() -> Any:
+    agent = PydanticAgent(TestModel(), system_prompt="You help customers manage orders.")
+
+    @agent.tool_plain
+    def cancel_subscription(customer_id: str) -> str:
+        """Cancel the customer subscription."""
+        raise AssertionError("original handler must never run")
+
+    @agent.tool_plain
+    def update_record(record_id: str) -> str:
+        """Update a record."""
+        raise AssertionError("original handler must never run")
+
+    @agent.tool_plain
+    def lookup_order(order_id: str) -> str:
+        """Look up an order."""
+        raise AssertionError("original handler must never run")
+
+    return PydanticAIAdapter().inspect(agent)
+
+
+def _openai_spec() -> Any:
+    from agents import Agent, function_tool
+
+    @function_tool
+    def cancel_subscription(customer_id: str) -> str:
+        """Cancel the customer subscription."""
+        raise AssertionError("original handler must never run")
+
+    @function_tool
+    def update_record(record_id: str) -> str:
+        """Update a record."""
+        raise AssertionError("original handler must never run")
+
+    @function_tool
+    def lookup_order(order_id: str) -> str:
+        """Look up an order."""
+        raise AssertionError("original handler must never run")
+
+    return OpenAIAgentsAdapter().inspect(
+        Agent(
+            name="T",
+            instructions="You help customers manage orders.",
+            tools=[cancel_subscription, update_record, lookup_order],
+            model="gpt-4.1-mini",
+        )
+    )
+
+
+def _markers(spec: Any) -> dict[str, tuple[bool, bool]]:
+    return {
+        item.value.name: (item.value.state_changing, item.value.destructive)
+        for item in spec.tools.items
+    }
+
+
+# --- the defect -------------------------------------------------------------
+
+
+def test_a_pydantic_tool_carries_risk_markers_at_all() -> None:
+    """The regression. Every marker was hardcoded False."""
+    markers = _markers(_pydantic_spec())
+
+    assert markers["cancel_subscription"] == (True, True), (
+        "a cancellation was not marked state-changing and destructive"
+    )
+    assert markers["update_record"] == (True, False)
+
+
+def test_both_adapters_classify_the_same_tool_the_same_way() -> None:
+    """Same name, same description, same declared schema -- same answer.
+
+    Asserted as parity rather than against fixed expectations, so this test
+    keeps holding if the shared classifier's judgement changes.
+    """
+    assert _markers(_pydantic_spec()) == _markers(_openai_spec())
+
+
+def test_a_pydantic_target_now_gets_its_fault_family() -> None:
+    """Nothing downstream fires while the flags are False."""
+    scenarios = build_outcome_variant_cases(_pydantic_spec(), seed=SEED)
+    titles = " ".join(s.title for s in scenarios)
+
+    assert scenarios, "no fault scenario was generated for any PydanticAI tool"
+    assert "cancel_subscription" in titles
+    # Destructive-only: the duplicate-side-effect question this tool most needs.
+    assert any("times out" in s.title for s in scenarios)
+
+
+def test_the_inspect_summary_agrees_with_its_own_capability_listing() -> None:
+    """The contradiction users actually saw: 0 state-changing, next to a
+    capability described as state-changing."""
+    spec = _pydantic_spec()
+
+    counted = sum(1 for item in spec.tools.items if item.value.state_changing)
+    from agentcheck.inspect.capabilities import extract_capabilities
+
+    definitions = [item.value for item in spec.tools.items]
+    extracted = extract_capabilities(definitions)
+    described = sum(1 for cap in extracted if cap.capability.state_changing)
+
+    assert counted == described
+
+
+# --- the fix must not over-reach -------------------------------------------
+
+
+def test_a_lookup_is_still_not_state_changing() -> None:
+    """Parity means the same classifier, not a blanket "everything is risky"."""
+    markers = _markers(_pydantic_spec())
+
+    assert markers["lookup_order"] == (False, False)
+
+
+def test_a_pydantic_suite_still_builds_and_stays_deterministic() -> None:
+    spec = _pydantic_spec()
+    first = build_frozen_suite(spec, AgentCheckConfig(), seed=SEED)
+    second = build_frozen_suite(spec, AgentCheckConfig(), seed=SEED)
+
+    assert first.fingerprint == second.fingerprint
+    assert len(first.cases) > 0


### PR DESCRIPTION
Found by running AgentCheck 0.2.0 against public third-party agents.

## What was wrong

`classify_tool` states its own contract: *"a tool definition must carry its risk markers before a capability can be built from it."* The OpenAI Agents adapter calls it. This one did not:

```python
# agentcheck/adapters/pydantic_ai.py, _tool_definition
state_changing=False,   # hardcoded
destructive=False,      # hardcoded
```

Everything downstream reads those two flags. Fault generation skips a tool that is not state-changing, and the ambiguous-timeout case is destructive-only. So a PydanticAI target received **no tool-failure, no degraded-evidence and no duplicate-side-effect case for any tool at all** — the systematic fault testing that is the headline of 0.2.0 was inert for one of the two supported frameworks, and silently so: the suite generated, ran, and passed.

## How it showed up

As a contradiction inside a single `inspect` report:

```
Detected:
- 0 state-changing actions
- 0 destructive actions
...
Capabilities (action kind and risk are inferred, not authoritative):
- cancel_subscription: modify, state-changing, destructive (confidence 0.70)
```

Capability extraction classifies independently of the adapter, so only the adapter disagreed.

## The change

Call the same shared classifier the other adapter uses. This buys **parity, not a stronger claim** — the classification is the same lexical inference, still reported as inferred and not authoritative, and a lookup is still not state-changing.

## Before / after

Measured on a PydanticAI target written against the pinned framework version:

```
before   13 cases,  0 fault cases
after    18 cases,  5 fault cases
```

The `inspect` summary now also agrees with its own capability listing.

## Tests

`tests/agentcheck/test_pydantic_ai_risk_parity.py`, 6 tests. They assert **parity between the two adapters for the same tool** rather than fixed expectations, so they keep holding if the shared classifier's judgement changes. One test pins the contradiction directly: the summary count must equal the capability-listing count. The 46 existing PydanticAI adapter and example tests still pass.

## Note on scope

This does not make risk classification good — a separate campaign finding is that the classifier is vocabulary-limited and misses `bash`, `write`, `execute_python`, and description-declared mutations. That is a limitation to address with a developer-declared risk channel, not by widening inference. This PR only stops one supported adapter from discarding the classification the other one keeps.
