### PR TITLE
Let a declared policy assert what handoffs may happen

### DIFF
--- a/agentcheck/policies/loader.py
+++ b/agentcheck/policies/loader.py
@@ -265,11 +265,26 @@ def _add_oracle_to_criterion(item: dict[str, Any], oracle_id: str) -> bool:
 # Budgets bound the run rather than one call, so they attach to every case and
 # carry no tool_name.
 _RUN_SCOPED_KINDS = frozenset(
-    {PolicyRuleKind.MAX_TOOL_CALLS, PolicyRuleKind.MAX_MODEL_TURNS}
+    {
+        PolicyRuleKind.MAX_TOOL_CALLS,
+        PolicyRuleKind.MAX_MODEL_TURNS,
+        PolicyRuleKind.REQUIRED_HANDOFF,
+        PolicyRuleKind.FORBIDDEN_HANDOFF,
+        PolicyRuleKind.MAX_HANDOFFS,
+        PolicyRuleKind.NO_HANDOFF_LOOP,
+    }
 )
 
 
-_DISCRIMINATING_PARAMETERS = ("required_before", "max_retries", "maximum")
+_DISCRIMINATING_PARAMETERS = (
+    "required_before",
+    "max_retries",
+    "maximum",
+    "minimum",
+    "max_edge_repeats",
+    "from_agent",
+    "to_agent",
+)
 
 
 def _apply_trajectory_rule(

--- a/agentcheck/policies/pack.py
+++ b/agentcheck/policies/pack.py
@@ -33,6 +33,11 @@ class PolicyRuleKind(str, Enum):
     MAX_RETRIES = "max_retries"
     MAX_TOOL_CALLS = "max_tool_calls"
     MAX_MODEL_TURNS = "max_model_turns"
+    REQUIRED_HANDOFF = "required_handoff"
+    FORBIDDEN_HANDOFF = "forbidden_handoff"
+    MAX_HANDOFFS = "max_handoffs"
+    NO_HANDOFF_LOOP = "no_handoff_loop"
+    HANDOFF_BEFORE_TOOL = "handoff_before_tool"
 
 
 # What each kind must be told before its evaluator can decide anything. A rule
@@ -44,19 +49,34 @@ _REQUIRED_PARAMETERS: dict[PolicyRuleKind, tuple[str, ...]] = {
     PolicyRuleKind.MAX_RETRIES: ("max_retries",),
     PolicyRuleKind.MAX_TOOL_CALLS: ("maximum",),
     PolicyRuleKind.MAX_MODEL_TURNS: ("maximum",),
+    PolicyRuleKind.MAX_HANDOFFS: ("maximum",),
 }
 
 # Budgets are a property of the run, not of one tool, so they do not need a
-# tool_name. Everything else names the call whose decision is under test.
+# tool_name. A handoff is the same: it moves the whole conversation between
+# agents rather than deciding one call. `handoff_before_tool` is the exception
+# and stays out of this set -- it asserts that a handoff preceded a *specific*
+# call, so without the tool it names nothing.
 _TOOL_FREE_KINDS = frozenset(
     {
         PolicyRuleKind.NO_FABRICATED_SUCCESS,
         PolicyRuleKind.MAX_TOOL_CALLS,
         PolicyRuleKind.MAX_MODEL_TURNS,
+        PolicyRuleKind.REQUIRED_HANDOFF,
+        PolicyRuleKind.FORBIDDEN_HANDOFF,
+        PolicyRuleKind.MAX_HANDOFFS,
+        PolicyRuleKind.NO_HANDOFF_LOOP,
     }
 )
 
-_NON_NEGATIVE_INTEGER_PARAMETERS = frozenset({"max_retries", "maximum"})
+_NON_NEGATIVE_INTEGER_PARAMETERS = frozenset(
+    {"max_retries", "maximum", "minimum", "max_edge_repeats"}
+)
+
+# An agent filter narrows which handoffs a rule is about. Empty is not a
+# narrower filter, it is no filter: the evaluator treats a missing name as
+# "any agent", so `""` would silently widen a rule the author meant to scope.
+_AGENT_NAME_PARAMETERS = ("from_agent", "to_agent")
 
 
 class PolicyRule(ContractModel):
@@ -102,6 +122,15 @@ class PolicyRule(ContractModel):
                 raise ValueError(
                     f"policy rule {self.rule_id!r} orders {self.tool_name!r} "
                     "before itself"
+                )
+        for name in _AGENT_NAME_PARAMETERS:
+            if name not in self.parameters:
+                continue
+            value = self.parameters[name]
+            if not isinstance(value, str) or not value:
+                raise ValueError(
+                    f"policy rule {self.rule_id!r} needs {name!r} to name an "
+                    f"agent, not {value!r}"
                 )
         return self
 

--- a/docs/behavioral-policies.md
+++ b/docs/behavioral-policies.md
@@ -62,6 +62,18 @@ Point `agentcheck.json` at a pack file:
 | `no_fabricated_success` | no definite claim on unusable evidence | — |
 | `max_tool_calls` | the run stayed within a call budget | `maximum` |
 | `max_model_turns` | the run stayed within a turn budget | `maximum` |
+| `required_handoff` | the conversation reached another agent | `to_agent`/`from_agent`, `minimum` |
+| `forbidden_handoff` | it never reached one | `to_agent`/`from_agent` |
+| `max_handoffs` | the run stayed within a handoff budget | `maximum` |
+| `no_handoff_loop` | two agents did not pass the customer back and forth | `max_edge_repeats` |
+| `handoff_before_tool` | a handoff preceded a specific call | `tool_name`, `to_agent`/`from_agent` |
+
+The five handoff kinds are run-scoped except `handoff_before_tool`, which
+asserts that a handoff preceded one named call and therefore needs a
+`tool_name`. `from_agent` and `to_agent` narrow which handoffs a rule is
+about; omitting both means "any handoff". Omitting is how you say that --
+an empty string is rejected, because the evaluator reads a missing name as
+"any agent" and `""` would quietly widen a rule that was meant to be scoped.
 
 Budgets bound the run rather than one call, so they take no `tool_name`.
 

--- a/tests/agentcheck/test_handoff_policies.py
+++ b/tests/agentcheck/test_handoff_policies.py
@@ -1,0 +1,227 @@
+"""Handoff expectations the evaluator already enforces, but nothing could declare.
+
+`agentcheck/evaluate/engine.py` implements five deterministic handoff checks over
+adapter-recorded HANDOFF events, and the generation lint has always listed them
+as supported kinds. Neither fact helped anyone: generation emits no handoff
+constraint, and the policy layer had no rule kind that produced one. The only
+route to a handoff assertion was hand-writing raw suite JSON.
+
+That is the same shape as the `ordering` gap fixed in policies v1 -- an
+evaluator capability with no path to it -- and it lands on a pattern that is
+not rare. Inspecting the official `customer_service` example reports a
+three-agent handoff topology, then generates fifteen cases that assert nothing
+about handoffs and a coverage report that does not mention them.
+
+These tests pin that a declared handoff rule reaches the evaluator with the
+parameters it needs, and try to break the wiring: by redirecting a rule at an
+agent the pack never declared, by dropping the ceiling a bound needs, and by
+collapsing two rules that assert different things.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents import Agent, function_tool
+from pydantic import ValidationError
+
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.config import AgentCheckConfig
+from agentcheck.domain import TrajectoryConstraintKind
+from agentcheck.generate.suite import build_frozen_suite
+from agentcheck.policies import PolicyPack, PolicyRule, PolicyRuleKind
+
+SEED = 1729
+
+
+@function_tool
+def update_seat(confirmation_number: str, new_seat: str) -> str:
+    """Update the seat on a booking."""
+    raise AssertionError("original handler must never run")
+
+
+@function_tool
+def faq_lookup(question: str) -> str:
+    """Look up an answer."""
+    raise AssertionError("original handler must never run")
+
+
+def _spec(*tools: Any):
+    return OpenAIAgentsAdapter().inspect(
+        Agent(name="T", instructions="Assist.", tools=list(tools), model="gpt-4.1-mini")
+    )
+
+
+def _pack(*rules: PolicyRule) -> PolicyPack:
+    return PolicyPack(
+        pack_id="airline_policy_v1",
+        version="1",
+        title="Airline policy",
+        description="Behavioural contracts for a handoff-based airline agent.",
+        rules=rules,
+    )
+
+
+def _rule(kind: PolicyRuleKind, **kw: Any) -> PolicyRule:
+    return PolicyRule(
+        rule_id=kw.pop("rule_id", f"{kind.value}__rule"),
+        kind=kind,
+        description=kw.pop("description", "declared behavioural contract"),
+        **kw,
+    )
+
+
+def _constraints(pack: PolicyPack):
+    spec = _spec(update_seat, faq_lookup)
+    suite = build_frozen_suite(spec, AgentCheckConfig(), seed=SEED, policy_packs=(pack,))
+    return [
+        constraint
+        for case in suite.cases
+        for constraint in case.scenario.trajectory_constraints
+    ]
+
+
+def _of_kind(pack: PolicyPack, kind: TrajectoryConstraintKind):
+    return [c for c in _constraints(pack) if c.kind is kind]
+
+
+# --- each declared handoff rule reaches the evaluator ----------------------
+
+
+def test_a_forbidden_handoff_rule_reaches_the_evaluator() -> None:
+    pack = _pack(
+        _rule(
+            PolicyRuleKind.FORBIDDEN_HANDOFF,
+            parameters={"to_agent": "Billing Agent"},
+        )
+    )
+
+    attached = _of_kind(pack, TrajectoryConstraintKind.FORBIDDEN_HANDOFF)
+
+    assert attached, "no forbidden-handoff constraint was attached"
+    for constraint in attached:
+        assert constraint.parameters["to_agent"] == "Billing Agent"
+
+
+def test_a_required_handoff_rule_carries_its_target_and_minimum() -> None:
+    pack = _pack(
+        _rule(
+            PolicyRuleKind.REQUIRED_HANDOFF,
+            parameters={"to_agent": "Seat Booking Agent", "minimum": 1},
+        )
+    )
+
+    attached = _of_kind(pack, TrajectoryConstraintKind.REQUIRED_HANDOFF)
+
+    assert attached, "no required-handoff constraint was attached"
+    for constraint in attached:
+        assert constraint.parameters["to_agent"] == "Seat Booking Agent"
+        assert constraint.parameters["minimum"] == 1
+
+
+def test_a_handoff_ceiling_reaches_the_evaluator() -> None:
+    pack = _pack(_rule(PolicyRuleKind.MAX_HANDOFFS, parameters={"maximum": 2}))
+
+    attached = _of_kind(pack, TrajectoryConstraintKind.MAX_HANDOFFS)
+
+    assert attached, "no handoff ceiling was attached"
+    for constraint in attached:
+        assert constraint.parameters["maximum"] == 2
+
+
+def test_a_loop_bound_reaches_the_evaluator() -> None:
+    """Two agents bouncing a customer back and forth is the failure this names."""
+    pack = _pack(
+        _rule(PolicyRuleKind.NO_HANDOFF_LOOP, parameters={"max_edge_repeats": 1})
+    )
+
+    attached = _of_kind(pack, TrajectoryConstraintKind.NO_HANDOFF_LOOP)
+
+    assert attached, "no handoff-loop bound was attached"
+    for constraint in attached:
+        assert constraint.parameters["max_edge_repeats"] == 1
+
+
+def test_handoff_before_tool_binds_to_the_declared_tool() -> None:
+    """"Escalate before you touch the booking" is a real airline contract."""
+    pack = _pack(
+        _rule(
+            PolicyRuleKind.HANDOFF_BEFORE_TOOL,
+            tool_name="update_seat",
+            parameters={"to_agent": "Seat Booking Agent"},
+        )
+    )
+
+    attached = _of_kind(pack, TrajectoryConstraintKind.HANDOFF_BEFORE_TOOL)
+
+    assert attached, "no handoff-before-tool constraint was attached"
+    for constraint in attached:
+        assert constraint.parameters["tool_name"] == "update_seat"
+        assert constraint.parameters["to_agent"] == "Seat Booking Agent"
+
+
+# --- the wiring must not be fooled -----------------------------------------
+
+
+def test_a_parameter_block_cannot_redirect_the_rule_at_another_tool() -> None:
+    """tool_name is the pack's claim, not the parameter block's."""
+    pack = _pack(
+        _rule(
+            PolicyRuleKind.HANDOFF_BEFORE_TOOL,
+            tool_name="update_seat",
+            parameters={"tool_name": "faq_lookup", "to_agent": "X"},
+        )
+    )
+
+    for constraint in _of_kind(pack, TrajectoryConstraintKind.HANDOFF_BEFORE_TOOL):
+        assert constraint.parameters["tool_name"] == "update_seat"
+
+
+def test_two_handoff_ceilings_that_differ_are_not_collapsed() -> None:
+    """Dedup keyed only on kind would silently drop one of these."""
+    pack = _pack(
+        _rule(PolicyRuleKind.MAX_HANDOFFS, rule_id="a", parameters={"maximum": 1}),
+        _rule(PolicyRuleKind.MAX_HANDOFFS, rule_id="b", parameters={"maximum": 5}),
+    )
+
+    maxima = {
+        c.parameters["maximum"]
+        for c in _of_kind(pack, TrajectoryConstraintKind.MAX_HANDOFFS)
+    }
+
+    assert maxima == {1, 5}
+
+
+def test_a_handoff_ceiling_without_a_maximum_is_rejected() -> None:
+    """A bound with no number would be INCONCLUSIVE forever and read as enforced."""
+    with pytest.raises(ValidationError):
+        _rule(PolicyRuleKind.MAX_HANDOFFS, parameters={})
+
+
+def test_handoff_before_tool_still_requires_a_tool_name() -> None:
+    """It asserts a handoff happened before a specific call. Without one it says nothing."""
+    with pytest.raises(ValidationError):
+        _rule(PolicyRuleKind.HANDOFF_BEFORE_TOOL, parameters={"to_agent": "X"})
+
+
+def test_an_empty_agent_name_is_rejected_rather_than_matching_everything() -> None:
+    """`""` would fall through as "no filter" and quietly widen the rule."""
+    with pytest.raises(ValidationError):
+        _rule(PolicyRuleKind.FORBIDDEN_HANDOFF, parameters={"to_agent": ""})
+
+
+def test_a_negative_handoff_ceiling_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _rule(PolicyRuleKind.MAX_HANDOFFS, parameters={"maximum": -1})
+
+
+def test_run_scoped_handoff_rules_need_no_tool_name() -> None:
+    """A handoff is a property of the run, not of one call."""
+    for kind in (
+        PolicyRuleKind.REQUIRED_HANDOFF,
+        PolicyRuleKind.FORBIDDEN_HANDOFF,
+        PolicyRuleKind.NO_HANDOFF_LOOP,
+    ):
+        _rule(kind, parameters={})
+    _rule(PolicyRuleKind.MAX_HANDOFFS, parameters={"maximum": 1})


### PR DESCRIPTION
Found by running AgentCheck 0.2.0 against public third-party agents.

## The gap

`evaluate/engine.py` implements five deterministic handoff checks over adapter-recorded `HANDOFF` events, and the generation lint has always listed those kinds as supported. Neither fact reached a user: generation emits no handoff constraint, and the policy layer had no rule kind that produced one. The only route to a handoff assertion was hand-writing raw suite JSON.

That is the shape of the `ordering` gap policies v1 fixed — an evaluator capability with no path to it — and it lands on a mainstream pattern rather than a corner. `handoffs=` appears in over 8,000 public Python files.

## What it looks like on a real target

Running 0.2.0 against `openai/openai-agents-python` `examples/customer_service` (@ `36976b1`):

- `inspect` reports a **three-agent handoff topology**, correct edges both ways, and even surfaces the context assignment `flight_number='FLT-100'` from the handoff callback.
- `generate` then produces 15 cases that assert **nothing** about handoffs.
- The coverage report does not mention handoffs at all — not as covered, missing, partial or unknown. The agent's primary structure is handoff-based and the report is silent on it.

## The change

Adds the five kinds to `PolicyRuleKind` and wires the existing parameters through. Four are run-scoped: a handoff moves the whole conversation between agents rather than deciding one call, so like the budgets they carry no `tool_name`. `handoff_before_tool` is the exception and still requires one — it asserts a handoff preceded a *specific* call, and without the tool it names nothing.

Validation follows the same rule as the rest of the pack: a bound with no number is rejected rather than accepted as a policy the evaluator could only call `INCONCLUSIVE`. `from_agent`/`to_agent` must name an agent when present, because the evaluator reads a missing name as "any agent" and an empty string would silently widen a rule the author meant to scope. Dedup keys on the agent filters and the ceilings too, so two rules that assert different things are not collapsed into one.

## Before / after on that target

Loading a two-rule pack through the real on-disk path (`PolicyPack.model_validate_json`):

```
before   pack REJECTED at parse time — PolicyRuleKind has no such members
after    no_handoff_loop      15 constraints attached (run-scoped)
         handoff_before_tool  11 constraints attached (bound to update_seat)
```

## Scope

No new evaluator, no new verdict semantics, and no scenario generation: this makes an implemented capability declarable, nothing more. 12 new tests; the existing policy suite still passes.
