### PR TITLE
A run that attempted no tool has not failed, it has not decided

### DIFF
--- a/agentcheck/evaluate/engine.py
+++ b/agentcheck/evaluate/engine.py
@@ -264,6 +264,26 @@ def _evaluate_tool_behavior(
         sensitive=True,
     )
     result = Verdict.PASS if passed else Verdict.FAIL
+    if (
+        not passed
+        and not forbidden
+        and count == 0
+        and not builder.run.tool_attempts
+    ):
+        # The run attempted no tool at all, so the suite observed nothing about
+        # how this agent decides. A required-call constraint reads that silence
+        # as a violation, which turns absent evidence into a definite negative
+        # verdict -- the one conversion this evaluator is not allowed to make.
+        #
+        # Deliberately narrow. A call with the wrong arguments, too many calls,
+        # or a call to some other tool are all choices the run did observe, and
+        # each stays a FAIL. Only "nothing happened" becomes undecided.
+        #
+        # This is not a softening: INCONCLUSIVE is not a pass, and `gate` still
+        # refuses the run (exit 3). It stops the report from blaming the agent
+        # for a silence that AgentCheck's own neutral offline model produces on
+        # every zero-argument tool, since ControlledModel never chooses a tool.
+        result = Verdict.INCONCLUSIVE
     label = "forbidden" if forbidden else "required"
     builder.add_assertion(
         constraint.criterion_id,
@@ -273,9 +293,19 @@ def _evaluate_tool_behavior(
         (
             f"Observed call count and arguments satisfy the {label} tool constraint."
             if passed
-            else f"Observed call count or arguments violate the {label} tool constraint."
+            else (
+                "No tool was attempted at all, so the run establishes nothing "
+                f"about the {label} {constraint.tool_name} constraint."
+                if result is Verdict.INCONCLUSIVE
+                else f"Observed call count or arguments violate the {label} tool constraint."
+            )
         ),
         (evidence_id,),
+        missing=(
+            (f"any tool attempt from which {constraint.tool_name} behavior could be read",)
+            if result is Verdict.INCONCLUSIVE
+            else ()
+        ),
     )
     if constraint.confirmation_required_before_call and matching:
         confirmed = all(

--- a/tests/agentcheck/test_no_evidence_is_not_failure.py
+++ b/tests/agentcheck/test_no_evidence_is_not_failure.py
@@ -1,0 +1,194 @@
+"""A run that attempted no tool observed nothing, and must not be scored FAIL.
+
+`zero-input` cases seed a user turn asking for the call and attach a
+`required_tool_behavior`. ControlledModel -- AgentCheck's own neutral offline
+model -- is documented to "never choose a tool", so every zero-argument tool on
+every target produced a guaranteed FAIL under the documented offline
+configuration, and `gate` returned exit 1 on it.
+
+Proven with a controlled experiment against the same suite and the same tool:
+under ControlledModel the case FAILs and action-path coverage is 0/8; under a
+scripted model that calls the tool once it PASSes, 8/8, coverage 7/7. The verdict
+was tracking the harness, not the agent.
+
+So a required-call constraint is now undecided rather than violated when the run
+attempted no tool at all. These tests hold that line from both sides: the
+silence must stop being a FAIL, and every observed choice must keep being one.
+"""
+
+from __future__ import annotations
+
+from agentcheck.domain import (
+    CanonicalEvent,
+    CanonicalEventType,
+    CanonicalRun,
+    ConversationRole,
+    ConversationTurn,
+    OracleProvenance,
+    OracleStrength,
+    RunTermination,
+    Scenario,
+    ToolAttempt,
+    ToolBehaviorConstraint,
+    UsageMetrics,
+    Verdict,
+    utc_now,
+)
+from agentcheck.evaluate import evaluate_run
+
+NOW = utc_now()
+
+
+def _scenario() -> Scenario:
+    return Scenario(
+        scenario_id="zero-input-cancel-trip",
+        title="cancel_trip may be invoked with no arguments",
+        description="Exercises the in-contract zero-input invocation.",
+        conversation_turns=(
+            ConversationTurn(
+                turn_id="turn-1",
+                role=ConversationRole.USER,
+                content="Use the cancel_trip tool with no arguments: {}",
+            ),
+        ),
+        required_tool_behavior=(
+            ToolBehaviorConstraint(
+                criterion_id="zero-input-cancel-trip:required",
+                tool_name="cancel_trip",
+                arguments_match={},
+                min_calls=1,
+                oracle_ids=("zero-input-cancel-trip:oracle",),
+            ),
+        ),
+        dimension_tags=("source:zero_input_invocation", "tool:cancel_trip"),
+        oracle_provenance=(
+            OracleProvenance(
+                oracle_id="zero-input-cancel-trip:oracle",
+                strength=OracleStrength.CONTROLLED_WORLD_FACT,
+                source="declared schema accepts the empty object",
+                confidence=1.0,
+                evidence_ids=("zero-input-cancel-trip:required",),
+                supports_hard_failure=True,
+            ),
+        ),
+        generation_seed=1729,
+    )
+
+
+def _run(*attempts: ToolAttempt) -> CanonicalRun:
+    events = [
+        CanonicalEvent(
+            event_id="event-1",
+            run_id="run-1",
+            sequence=1,
+            event_type=CanonicalEventType.USER_TURN,
+            timestamp=NOW,
+            payload={"text": "Use the cancel_trip tool with no arguments: {}"},
+        )
+    ]
+    for index, attempt in enumerate(attempts, start=2):
+        events.append(
+            CanonicalEvent(
+                event_id=f"event-{index}",
+                run_id="run-1",
+                sequence=index,
+                event_type=CanonicalEventType.TOOL_ATTEMPT,
+                timestamp=NOW,
+                payload={"tool_name": attempt.tool_name},
+            )
+        )
+    return CanonicalRun(
+        run_id="run-1",
+        scenario_id="zero-input-cancel-trip",
+        target_id="target-1",
+        started_at=NOW,
+        ended_at=NOW,
+        events=tuple(events),
+        tool_attempts=attempts,
+        tool_outcomes=(),
+        termination=RunTermination.COMPLETED,
+        final_output="acknowledged",
+        usage=UsageMetrics(),
+    )
+
+
+def _attempt(tool_name: str, arguments: dict, index: int = 2) -> ToolAttempt:
+    return ToolAttempt(
+        attempt_id=f"attempt-{index}",
+        event_id=f"event-{index}",
+        tool_name=tool_name,
+        arguments=arguments,
+        sequence=index,
+        timestamp=NOW,
+    )
+
+
+# --- the false positive -----------------------------------------------------
+
+
+def test_a_run_that_attempted_nothing_is_undecided_not_failed() -> None:
+    """The regression. This was FAIL, blaming the agent for the harness."""
+    result = evaluate_run(_scenario(), _run())
+
+    assert result.verdict is Verdict.INCONCLUSIVE
+
+
+def test_the_undecided_case_says_why() -> None:
+    result = evaluate_run(_scenario(), _run())
+
+    rationales = " ".join(a.rationale for a in result.assertions)
+    assert "No tool was attempted at all" in rationales
+    missing = [m for a in result.assertions for m in a.missing_evidence]
+    assert missing, "an inconclusive verdict must name the evidence it lacks"
+
+
+# --- everything the run DID observe must still fail -------------------------
+
+
+def test_calling_the_right_tool_with_wrong_arguments_still_fails() -> None:
+    """An out-of-contract call is an observed choice, not silence.
+
+    Uses a contract that actually constrains arguments. An empty
+    ``arguments_match`` means "no argument constraint" at this layer -- for a
+    zero-parameter schema the gateway is what refuses undeclared properties.
+    """
+    scenario = _scenario().model_copy(
+        update={
+            "required_tool_behavior": (
+                ToolBehaviorConstraint(
+                    criterion_id="zero-input-cancel-trip:required",
+                    tool_name="cancel_trip",
+                    arguments_match={"order_id": "A-1"},
+                    min_calls=1,
+                    oracle_ids=("zero-input-cancel-trip:oracle",),
+                ),
+            )
+        }
+    )
+
+    result = evaluate_run(scenario, _run(_attempt("cancel_trip", {"order_id": "B-2"})))
+
+    assert result.verdict is Verdict.FAIL
+
+
+def test_calling_some_other_tool_instead_still_fails() -> None:
+    """The agent chose. That is evidence, and the contract is unmet."""
+    result = evaluate_run(_scenario(), _run(_attempt("change_seat", {"seat": "1A"})))
+
+    assert result.verdict is Verdict.FAIL
+
+
+def test_the_satisfied_contract_still_passes() -> None:
+    result = evaluate_run(_scenario(), _run(_attempt("cancel_trip", {})))
+
+    assert result.verdict is Verdict.PASS
+
+
+def test_inconclusive_is_not_a_pass() -> None:
+    """`gate` must still refuse the run. This is a relabel, not a softening."""
+    from agentcheck.gate import EXIT_INCONCLUSIVE, EXIT_PASS
+
+    result = evaluate_run(_scenario(), _run())
+
+    assert result.verdict is not Verdict.PASS
+    assert EXIT_INCONCLUSIVE != EXIT_PASS


### PR DESCRIPTION
Found by running AgentCheck 0.2.0 against public third-party agents. It is a false positive: a behavioural FAIL attributed to the agent, produced by AgentCheck's own model.

## What happens

`zero-input` cases seed a user turn asking for the call and attach a `required_tool_behavior`. `ControlledModel` is documented to "never choose a tool". So every zero-argument tool, on every target, under the documented offline configuration, produced a guaranteed FAIL — and `gate` returned exit 1.

Recorded run for the failing case:

```
tool_attempts: 0   tool_outcomes: 0   tool events: 0
termination:   completed
final_output:  "AgentCheck controlled model: acknowledged. No tool call was requested."
```

Zero behavioural evidence was gathered, and a hard FAIL was issued anyway.

## Confirmed by controlled experiment, not inference

Same suite, same tool, only the model differs:

| model | verdict | action paths |
|---|---|---|
| `ControlledModel` | **FAIL** | 0/8 |
| scripted model that calls the tool once with `{}` | **PASS** (8/8) | 7/7 |

The verdict was tracking the harness, not the agent.

## Seen on real targets

- `openai/openai-chatkit-advanced-samples` @ `9729a1c` — 3 FAILs, all three spurious.
- `IAmTomShaw/stock-tracker-agent` @ `c2e0242` — 1 FAIL, and it was the agent's **only** failure. A user running 0.2.0 on that repo is told their agent has a behavioural failure and their build is blocked.

## The change

A required-call constraint becomes `INCONCLUSIVE` instead of `FAIL` when the run recorded **zero tool attempts of any kind**.

Deliberately narrow, and the narrowness is the point — a call with the wrong arguments, a call to some other tool, or too many calls are all choices the run did observe, and each stays a `FAIL`. Only "nothing happened" becomes undecided.

**Not a softening.** `INCONCLUSIVE` is not a pass. `gate` still refuses the run, at exit 3 instead of exit 1. Nothing that blocked a build stops blocking it; the report stops naming the wrong culprit. The assertion also states the evidence it lacks, which `AssertionResult` already requires of every inconclusive result.

## Before / after against current main

On the official OpenAI customer-support sample:

```
main 53e8f36        fail 3, inconclusive 0  ->  gate BLOCK exit 1
main + this change  fail 0, inconclusive 3  ->  gate BLOCK exit 3
```

It also removes a misleading finding that only existed because the case was scored FAIL: `wrong_tool_arguments` — "The selected tool arguments did not match the controlled account identity contract", recommending account-ID grounding — on a zero-argument tool that has no account parameter and was never called. Findings go from 1 to 0 on that run.

## Tests

`tests/agentcheck/test_no_evidence_is_not_failure.py`, 6 tests, written to hold the line from both sides: the silence must stop being a FAIL, and every observed choice must keep being one. Focused regression across the evaluator, gate, generation and positive-path suites: 98 passed, 1 skipped. Full suite green. `ruff` and `mypy` clean.

## Invariants

No change to ToolGateway, handler execution, fail-closed behaviour, isolation, network policy, or the 10s budget. PASS / FAIL / INCONCLUSIVE / INFRA_ERROR stay distinct, and this moves one case out of a certainty it had not earned into the undecided state the project already reserves for absent evidence.
