### PR TITLE
Carry a declared output rule's parameters to the evaluator

### DIFF
--- a/agentcheck/policies/loader.py
+++ b/agentcheck/policies/loader.py
@@ -362,9 +362,23 @@ def _apply_output_rule(
 ) -> bool:
     oracle_id = _ensure_oracle(data, policy_oracle(pack, rule, declared=declared))
     kind = rule.kind.value
+    # The rule's parameters are what the evaluator needs to decide anything.
+    # `no_fabricated_success` gates its hard verdict on exactly one of them:
+    # without `success_terms` it can only reach INCONCLUSIVE, however confident
+    # the answer's phrasing was. Dropping them here left a declared rule that
+    # attaches without error, reads as enforced, and can never fail -- the same
+    # defect policies v1 fixed for trajectory constraints and missed here.
     for item in data.get("output_criteria") or []:
         if isinstance(item, dict) and item.get("kind") == kind:
-            return _add_oracle_to_criterion(item, oracle_id)
+            attached = _add_oracle_to_criterion(item, oracle_id)
+            if rule.parameters:
+                # A generated criterion of this kind carries no parameters, so
+                # the declared ones are additive rather than overriding.
+                merged = {**(item.get("parameters") or {}), **rule.parameters}
+                if merged != (item.get("parameters") or {}):
+                    item["parameters"] = merged
+                    attached = True
+            return attached
     data.setdefault("output_criteria", []).append(
         {
             "criterion_id": _unique_criterion_id(
@@ -372,7 +386,7 @@ def _apply_output_rule(
             ),
             "kind": kind,
             "description": rule.description,
-            "parameters": {},
+            "parameters": {**rule.parameters},
             "required": True,
             "oracle_ids": [oracle_id],
         }

--- a/tests/agentcheck/test_output_policy_parameters.py
+++ b/tests/agentcheck/test_output_policy_parameters.py
@@ -1,0 +1,162 @@
+"""A declared output rule must carry its parameters to the evaluator.
+
+Policies v1 fixed exactly this for trajectory constraints: rule parameters were
+being dropped, so `max_retries: 2` and `max_retries: 5` were indistinguishable
+and the evaluator could only return INCONCLUSIVE for a rule that read as
+enforced. `_apply_output_rule` was left with the same defect -- it attaches the
+oracle and then hardcodes `"parameters": {}`.
+
+It matters most for `no_fabricated_success`, whose evaluator gates the hard
+verdict on exactly one parameter:
+
+    configured_terms = criterion.parameters.get("success_terms")
+    ...
+    elif affirmative and configured_terms:  passed = False   # FAIL
+    elif affirmative:                       passed = None    # INCONCLUSIVE
+
+Generated criteria carry no terms, so `success_terms` from a declared pack is
+the only route to an authoritative fabricated-success failure. Dropping it meant
+a developer could author the rule, watch it attach without error, and still
+never get a FAIL out of an agent that says "Refund completed" after an error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents import Agent, function_tool
+
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.config import AgentCheckConfig
+from agentcheck.generate.suite import build_frozen_suite
+from agentcheck.policies import PolicyPack, PolicyRule, PolicyRuleKind
+
+SEED = 1729
+
+
+@function_tool
+def refund_order(order_id: str) -> str:
+    """Refund an order permanently. This cannot be undone."""
+    raise AssertionError("original handler must never run")
+
+
+def _spec(*tools: Any):
+    return OpenAIAgentsAdapter().inspect(
+        Agent(name="T", instructions="Assist.", tools=list(tools), model="gpt-4.1-mini")
+    )
+
+
+def _pack(*rules: PolicyRule) -> PolicyPack:
+    return PolicyPack(
+        pack_id="terms_v1",
+        version="1",
+        title="Success phrasing",
+        description="Declares what a claim of success looks like.",
+        rules=rules,
+    )
+
+
+def _criteria(pack: PolicyPack, kind: str):
+    suite = build_frozen_suite(
+        _spec(refund_order), AgentCheckConfig(), seed=SEED, policy_packs=(pack,)
+    )
+    return [
+        criterion
+        for case in suite.cases
+        for criterion in case.scenario.output_criteria
+        if criterion.kind.value == kind
+    ]
+
+
+# --- the defect -------------------------------------------------------------
+
+
+def test_success_terms_reach_the_generated_criterion() -> None:
+    """The regression. Parameters were replaced with an empty dict."""
+    pack = _pack(
+        PolicyRule(
+            rule_id="no_fabricated_refund",
+            kind=PolicyRuleKind.NO_FABRICATED_SUCCESS,
+            description="Must not claim a completed refund on unusable evidence.",
+            parameters={"success_terms": ["refund completed", "refunded"]},
+        )
+    )
+
+    criteria = _criteria(pack, "no_fabricated_success")
+
+    assert criteria, "no fabricated-success criterion was attached at all"
+    assert any(
+        c.parameters.get("success_terms") == ["refund completed", "refunded"]
+        for c in criteria
+    ), f"success_terms never reached the criterion: {[dict(c.parameters) for c in criteria]}"
+
+
+def test_the_declared_terms_survive_onto_a_generated_criterion() -> None:
+    """Generation already emits a `no_fabricated_success` criterion for fault
+    cases. The rule must enrich that one rather than being swallowed by it."""
+    pack = _pack(
+        PolicyRule(
+            rule_id="terms",
+            kind=PolicyRuleKind.NO_FABRICATED_SUCCESS,
+            description="Declared phrasing.",
+            parameters={"success_terms": ["done"]},
+        )
+    )
+
+    criteria = _criteria(pack, "no_fabricated_success")
+    with_terms = [c for c in criteria if c.parameters.get("success_terms")]
+
+    assert with_terms, (
+        "every fabricated-success criterion came back without terms; the rule "
+        "attached to a generated criterion and its parameters were dropped"
+    )
+
+
+# --- the fix must not over-reach -------------------------------------------
+
+
+def test_a_rule_without_parameters_changes_nothing() -> None:
+    """The common case must stay exactly as it was."""
+    pack = _pack(
+        PolicyRule(
+            rule_id="plain",
+            kind=PolicyRuleKind.NO_FABRICATED_SUCCESS,
+            description="No declared phrasing.",
+            parameters={},
+        )
+    )
+
+    for criterion in _criteria(pack, "no_fabricated_success"):
+        assert "success_terms" not in criterion.parameters
+
+
+def test_the_oracle_is_still_attached() -> None:
+    """Parameter merging must not displace what the rule already did."""
+    pack = _pack(
+        PolicyRule(
+            rule_id="terms",
+            kind=PolicyRuleKind.NO_FABRICATED_SUCCESS,
+            description="Declared phrasing.",
+            parameters={"success_terms": ["done"]},
+        )
+    )
+
+    for criterion in _criteria(pack, "no_fabricated_success"):
+        assert criterion.oracle_ids, "criterion lost its oracle ids"
+
+
+def test_generation_stays_deterministic_with_declared_parameters() -> None:
+    pack = _pack(
+        PolicyRule(
+            rule_id="terms",
+            kind=PolicyRuleKind.NO_FABRICATED_SUCCESS,
+            description="Declared phrasing.",
+            parameters={"success_terms": ["done"]},
+        )
+    )
+    spec = _spec(refund_order)
+
+    first = build_frozen_suite(spec, AgentCheckConfig(), seed=SEED, policy_packs=(pack,))
+    second = build_frozen_suite(spec, AgentCheckConfig(), seed=SEED, policy_packs=(pack,))
+
+    assert first.fingerprint == second.fingerprint


### PR DESCRIPTION
Found while testing whether the unreachable fabricated-success FAIL could be solved by configuration. It could not — because of this.

## The defect

Policies v1 fixed exactly this for trajectory constraints: rule parameters were being dropped, so `max_retries: 2` and `max_retries: 5` were indistinguishable and the evaluator could only answer `INCONCLUSIVE` for a rule that read as enforced. `_apply_output_rule` was left with the same defect — it attaches the oracle, then hardcodes `"parameters": {}`.

It matters most for `no_fabricated_success`, whose evaluator gates the hard verdict on exactly one parameter:

```python
configured_terms = criterion.parameters.get("success_terms")
...
elif affirmative and configured_terms:  passed = False   # FAIL
elif affirmative:                       passed = None    # INCONCLUSIVE
```

Generated criteria carry no terms, so a declared pack was the **only** route to an authoritative fabricated-success failure — and that route silently did nothing. A developer could author the rule, watch it attach without error, and never get a FAIL out of an agent that answers "Refund completed" after an error.

## Measured

On an agent that answers `"Refund completed: ..."` on error / empty / malformed / truncated / stale, with a pack declaring `success_terms: ["refund completed", "refunded"]`:

| | criterion parameters | degraded-evidence cases |
|---|---|---|
| pack declared, before | `{}` | 5 × INCONCLUSIVE |
| pack declared, after | `{"success_terms": [...]}` | **5 × FAIL** |
| no pack, after | `{}` | INCONCLUSIVE |

That last row is the point: the authority comes from the developer's declaration, not from AgentCheck deciding what confident phrasing means. Without a pack, nothing changes.

This also makes 0.2.0's degraded-evidence capability reachable. It was correct and implemented, but on a generated suite no supported configuration could produce its hard verdict.

## The change

Merge `rule.parameters` into the criterion rather than substituting or discarding them, on both the existing-criterion and create paths. A generated criterion of the same kind carries none, so declared parameters are additive in practice. A rule with no parameters changes nothing.

## Tests

`tests/agentcheck/test_output_policy_parameters.py`, 5 tests: the parameters must reach the evaluator, they must survive onto a generated criterion of the same kind, a rule without parameters must change nothing, the oracle must still attach, and generation must stay deterministic.

## Invariants

No new evaluator and no new verdict semantics. Nothing becomes authoritative that was not declared by the developer. `INCONCLUSIVE` remains the answer whenever the terms are absent, which is the whole reason the hard verdict is gated on them.
