### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,86 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## 0.2.1
+
+Six defects found by running 0.2.0 against public third-party agents. Five were
+silent: the suite generated, ran, and passed while asserting nothing.
+
+**Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. Two suites that
+were equivalent before remain byte-identical after, which is the documented
+condition for leaving it alone. Suites whose *content* genuinely changed — a spec
+with a zero-argument state-changing tool, or one large enough to have been
+truncated — move their own `suite_id`, as they should.
+
+**Breaking for PydanticAI targets:** the risk-marker fix changes the declared
+tool surface, and `spec_id` hashes that surface. A PydanticAI target now inspects
+under a different `spec_id`, so an existing frozen suite is rejected with
+"re-run agentcheck generate". Regenerating is the right action: the previous
+suite contained no fault cases at all. OpenAI Agents targets keep their
+`spec_id`; verified by measurement.
+
+### Fixed
+
+- **Zero-argument tools received no fault family.** A schema declaring no
+  parameters has one in-contract call — the empty one — but that was read as
+  "no valid call can be constructed", so arity rather than declared risk decided
+  which irreversible actions were tested. In the official OpenAI customer-support
+  sample, `cancel_trip()` produced one scenario carrying no fixtures, no
+  trajectory constraints and no output criteria; it could not fail. That target
+  goes from 30 cases to 44, and `cancel_trip` from 1 to 8 including the
+  ambiguous-timeout duplicate-side-effect case.
+- **A run that attempted no tool was scored FAIL.** `ControlledModel` never
+  chooses a tool by design, so every zero-argument tool on every target produced
+  a guaranteed failure under the documented offline configuration, and `gate`
+  returned exit 1. Confirmed by controlled experiment: same suite, same tool,
+  FAIL under `ControlledModel` and PASS under a scripted model that calls it.
+  Such a run is now `INCONCLUSIVE`. A call with the wrong arguments, a call to
+  another tool, or too many calls all remain `FAIL`. `gate` still refuses the
+  run, at exit 3 instead of exit 1.
+- **PydanticAI tools carried no risk markers.** The adapter hardcoded
+  `state_changing=False, destructive=False` and never called the shared
+  classifier the OpenAI adapter uses, so no PydanticAI target received any fault
+  family for any tool. It surfaced as a single `inspect` report contradicting
+  itself — a summary of zero state-changing actions above a capability listing
+  describing the same tool as destructive. Measured on a PydanticAI target: 13
+  cases and 0 fault cases before, 25 and 11 after.
+- **The fault family was bounded by the wrong cap.** Generation broke on
+  `_MAX_POSITIVE_SCENARIOS_PER_SPEC` (24), so the documented
+  `MAX_FAULT_VARIANT_SCENARIOS` (64) was unreachable. On tau-bench,
+  `modify_user_address` lost its entire fault family while 38 scenarios of the
+  real cap were still unused: 90 cases and 5 fault-covered tools before, 96 and
+  6 after.
+- **Declared output-rule parameters were discarded.** `_apply_output_rule`
+  hardcoded `"parameters": {}`, so a policy declaring `success_terms` attached
+  without error and did nothing. Since the evaluator gates the hard
+  fabricated-success verdict on exactly that parameter, 0.2.0's
+  degraded-evidence capability had no reachable configuration on a generated
+  suite. With the fix and a declared pack, an agent answering "Refund completed"
+  after an error moves from `INCONCLUSIVE` to `FAIL`; without a pack it stays
+  `INCONCLUSIVE`, because the authority is the developer's declaration.
+
+### Added
+
+- Handoff expectations are declarable. The evaluator already implemented five
+  deterministic handoff checks over recorded `HANDOFF` events, and the
+  generation lint already listed them as supported, but no policy rule kind
+  produced one — the only route was hand-written suite JSON. `required_handoff`,
+  `forbidden_handoff`, `max_handoffs`, `no_handoff_loop` and
+  `handoff_before_tool` now reach those evaluators. On the official
+  `customer_service` example, a pack that was previously rejected at parse time
+  attaches 26 constraints.
+
+### Documentation
+
+- Corrected the claim that fault generation follows a tool's *declared* risk.
+  It does for custom Python agents, which state it. For the OpenAI Agents SDK
+  and PydanticAI it is **inferred from the tool name**, reported as inferred and
+  never treated as authoritative. `docs/fault-testing.md` asserted names were
+  not trusted while citing, as justification, a real case where a name was
+  trusted and read wrongly. Both now say which adapter establishes risk how, and
+  that an unclassified tool receives no fault family — so an absent fault family
+  is not evidence a tool is safe.
+
 ## 0.2.0
 
 **Suite identity:** unchanged. `GENERATOR_COMPATIBILITY_VERSION` stays `1`, so

--- a/README.md
+++ b/README.md
@@ -92,10 +92,23 @@ failures are never presented as behavioral failures or passes.
 
 Generated suites also include fault cases — the tool errors, times out, or
 returns an empty, unparseable, truncated or stale payload — so the suite asks
-what the agent does when a tool does not cooperate, not only when it does. What
-gets generated follows the tool's *declared* risk, never its name. See
-[fault testing](docs/fault-testing.md) and, to declare your own contracts,
-[behavioral policies](docs/behavioral-policies.md).
+what the agent does when a tool does not cooperate, not only when it does.
+
+Which tools get them depends on how the tool's side-effect risk was
+established, and that differs by adapter. A [custom Python
+agent](docs/custom-agents.md) states it: `ToolDefinition(state_changing=True,
+destructive=True)` is a declaration, and AgentCheck treats it as authoritative.
+For the OpenAI Agents SDK and PydanticAI, neither framework carries that
+information, so AgentCheck *infers* it from the tool's name, reports it as
+inferred with a confidence, and never calls it authoritative.
+
+Inference is conservative in one direction only: a tool it cannot classify is
+left non-state-changing and receives **no fault family**. Verb-shaped names such
+as `delete_account` or `cancel_order` are read correctly; neutral ones such as
+`bash`, `write` or `execute_command` are not, and are silently left untested.
+Coverage reports the gap as `risk_metadata_not_authoritative` rather than
+implying the tool was checked. See [fault testing](docs/fault-testing.md) and,
+to declare your own contracts, [behavioral policies](docs/behavioral-policies.md).
 
 ## What AgentCheck catches
 

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/docs/fault-testing.md
+++ b/docs/fault-testing.md
@@ -6,11 +6,31 @@ next.
 
 ## What gets generated
 
-A tool the target declares **state-changing** gets a fault family; a read-only
-tool gets none, because retrying a lookup is ordinary behaviour and calling it a
-defect would invent a failure. The classification comes from the declaration,
-never from the tool's name — a real target had `find_user_id_by_email` read as
-state-changing from its name alone, which is exactly why names are not trusted.
+A tool marked **state-changing** gets a fault family; a read-only tool gets
+none, because retrying a lookup is ordinary behaviour and calling it a defect
+would invent a failure.
+
+Where that marking comes from depends on the adapter, and the difference is not
+cosmetic. A custom Python agent *declares* it —
+`ToolDefinition(state_changing=True, destructive=True)` — and the declaration is
+authoritative. The OpenAI Agents SDK and PydanticAI carry no such field, so
+AgentCheck infers the marking from the tool's **name**, records it as inferred
+with a confidence, and refuses to treat it as authoritative anywhere a hard
+verdict depends on it.
+
+Name inference is wrong in both directions, and neither is hypothetical:
+
+- `find_user_id_by_email` in tau-bench is a pure lookup, and is read as
+  state-changing because of the tokens in its name.
+- `bash`, `execute_python`, `write` and `execute_command` are read as read-only,
+  because nothing in those names says otherwise. They receive no fault family
+  at all.
+
+A tool no rule matches stays unclassified and non-state-changing. That is the
+safe direction for *inventing* failures and the unsafe direction for *missing*
+them, so the gap is reported rather than hidden: behavioral coverage marks those
+tools `unknown` with the reason `risk_metadata_not_authoritative`. An absent
+fault family is not evidence that a tool is safe to retry.
 
 | Case | The tool… | The question asked |
 | --- | --- | --- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.2.0"
+version = "0.2.1"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Patch release. Six defects, all found by running 0.2.0 against public third-party agents rather than against our own examples. Five of them were silent — the suite generated, ran, and passed while asserting nothing.

## Fixed (all already merged)

| | defect | measured effect |
|---|---|---|
| #38 | zero-argument tools received no fault family | official OpenAI sample 30 → 44 cases; `cancel_trip()` 1 vacuous case → 8 |
| #41 | a run that attempted no tool was scored FAIL | 7 spurious FAILs removed across 4 independent targets |
| #39 | PydanticAI adapter discarded risk markers | 13 cases / 0 fault → 25 / 11 |
| #40 | handoff expectations were undeclarable | pack rejected at parse time → 26 constraints attached |
| #42 | fault family bounded by the positive-path cap | tau-bench 90 → 96 cases; `modify_user_address` 0 → 5 fault cases |
| #43 | declared output-rule parameters discarded | degraded-evidence cases INCONCLUSIVE → FAIL when the developer declares the terms |

## The documentation change is the one to review closely

It corrects a claim rather than a behaviour, and the claim was load-bearing.

README said *"what gets generated follows the tool's declared risk, never its name."* That holds only for custom Python agents, which state it. The OpenAI Agents SDK and PydanticAI carry no such field, so AgentCheck infers risk **from the tool name**.

`docs/fault-testing.md` was worse — it asserted names were not trusted, then cited as justification a real case where a name *was* trusted and read wrongly.

Both directions are measured, not hypothetical:

- `find_user_id_by_email` (tau-bench) is a pure lookup, read as state-changing from its name.
- `bash`, `execute_python`, `write`, `execute_command` — found across three independent repositories, one of them a security starter kit *about agent constraints* — are read as read-only and receive no fault family at all.

Both files now say which adapter establishes risk how, and state plainly that an absent fault family is not evidence a tool is safe to retry.

## Suite identity

`GENERATOR_COMPATIBILITY_VERSION` stays `1`, decided from semantics rather than the release number. Verified by generating the same spec on both sides: a suite that was equivalent before is byte-identical after. Suites whose content genuinely changed move their own `suite_id`.

**Breaking for PydanticAI targets.** `spec_id` hashes the declared tool surface, and the risk-marker fix changes it, so a PydanticAI target now inspects under a new `spec_id` and an existing frozen suite is rejected with "re-run agentcheck generate". Regenerating is the right action — the previous suite contained no fault cases at all. Measured: OpenAI Agents targets keep their `spec_id`.

## Validation

Full suite 1434 passed / 1 skipped. ruff, mypy (95 files), secret scan, workflow safety (8 hosted jobs), build, and distribution audit all pass. Clean-install smoke on the built wheel: `agentcheck 0.2.1`, base install framework-free, all 12 subcommands, `GENERATOR_COMPATIBILITY_VERSION` still `1`.

Three real targets re-run against this branch's base — official OpenAI customer-support, stock-tracker, project-manager — report **0 failures** where published 0.2.0 reported spurious ones, with no INFRA_ERROR, no handler execution and no provider calls.

The scenario fingerprint pin did not move across the 0.2.0 → 0.2.1 bump.
