### PR TITLE
Concurrent execution safety: deterministic gateway dispatch + real-world validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,44 @@ Developer-declared tool risk, an explicit authority precedence for it, and a
 launch-group-aware concurrency oracle. Not yet released as a distribution
 version; recorded here for the next release to pick up.
 
+**Concurrent execution safety:** `ToolGateway` is split into a deterministic
+plan phase (`plan_batch`/`plan_one` -- decides budget consumption, invocation
+index, fixture selection and consumption, and resulting status, strictly in
+the order calls are given) and a commit phase (`commit` -- applies world-state
+effects and records the attempt/outcome for one already-planned reservation).
+A new `agentcheck.runner.launch_barrier.LaunchBarrier` forces a batch's
+commits into decision order under real concurrent dispatch.
+
+The OpenAI Agents adapter now dispatches a model response's tool calls as
+genuinely concurrent asyncio tasks (`max_function_tool_concurrency` moves
+from 1 to a bounded 8), planning the batch deterministically at `on_llm_end`
+before any task is created. The PydanticAI adapter -- which already dispatches
+concurrently by default, unaudited until now -- gets the same treatment via
+`_CapturingModel.request`. Both are proven, by running the same scripted
+same-stage batch many times, to produce identical fixture assignment and
+world-state commit order regardless of which task the event loop happens to
+run first. Custom Python agents remain synchronous and explicitly documented
+as unsupported for concurrent dispatch.
+
+Fixed a real, pre-existing defect surfaced while adding the first PydanticAI
+test to exercise state effects: `ToolOutcome.state_transition_ids` stored raw
+gateway transition IDs instead of the canonical run-scoped IDs `CanonicalRun`
+validation expects, so any PydanticAI run that actually produced a state
+transition failed to construct. Also fixed a regression introduced during
+this milestone's own development: `ToolGateway.commit` had stopped chaining
+`BudgetExceeded` as the `__cause__` of its raised `ToolCallBlockedError`,
+which the custom adapter's termination mapping depends on to report
+`MAX_TOOL_CALLS`/`WALL_CLOCK_TIMEOUT` instead of a generic `ADAPTER_ERROR`.
+
+Real-world validation against public OpenAI Agents SDK and PydanticAI
+examples plus tau-bench's retail tool schemas found no concurrency-related
+defects: fixture assignment and launch-group evidence matched decision order
+in every target, and no original tool handler executed.
+
+**Suite identity:** unaffected. This milestone changes execution/dispatch
+behaviour, not generation semantics -- `GENERATOR_COMPATIBILITY_VERSION`
+stays `1`, and no scenario or suite fingerprint moves.
+
 **Developer-declared risk:** `agentcheck.json` gains an optional `tool_risk`
 block declaring `state_changing`/`destructive` per tool, independently per
 axis. Precedence is fixed: developer declaration > genuine framework metadata

--- a/agentcheck/adapters/custom.py
+++ b/agentcheck/adapters/custom.py
@@ -639,6 +639,19 @@ class _GatewayToolRuntime:
       AgentCheck has no controlled answer, and returning a plausible one would
       be inventing the tool output that the run is supposed to be evidence
       about.
+
+    ``call`` is synchronous and, unlike the OpenAI Agents and PydanticAI
+    adapters, this one has no hook that sees a batch of tool calls before
+    dispatch: a custom agent's own orchestration decides, in its own code,
+    when and how to call ``call``. If that orchestration issues concurrent
+    calls itself -- multiple threads, or tasks that actually interleave
+    around a real ``await`` rather than calling this synchronously one at a
+    time -- fixture assignment and invocation-index ordering are not
+    guaranteed to follow any particular order. This is deliberately left
+    unsupported rather than guessed at: a custom agent that wants
+    deterministic concurrent dispatch must issue its own calls to ``call``
+    strictly in the order they were decided, matching what this class was
+    proven safe for. See ``docs/concurrent-tool-decisions.md``.
     """
 
     def __init__(

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -68,7 +68,9 @@ if TYPE_CHECKING:
     from agentcheck.config import ToolRiskDeclaration
 from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
 from agentcheck.runner.budgets import BudgetExceeded
+from agentcheck.runner.launch_barrier import LaunchBarrier
 from agentcheck.runner.network_guard import denied_destinations
+from agentcheck.runner.tool_gateway import CallReservation
 
 from .base import (
     portable_identity,
@@ -157,6 +159,18 @@ def _supported_sdk_version(version: str | None) -> bool:
         return False
 
 
+# The SDK dispatches function-tool invokers as concurrent asyncio tasks under
+# this cap (`asyncio.create_task` + `asyncio.wait`), never real OS threads --
+# confirmed by reading agents/run_internal/tool_execution.py for the pinned
+# SDK version. A model response rarely emits more than a handful of tool
+# calls at once, and ToolGateway.commit is forced back into decision order by
+# LaunchBarrier regardless of this cap, so raising it further would not
+# change gateway behaviour -- only how many invokers may have pre-commit work
+# (argument parsing, attempt recording) in flight at once. 8 is a small,
+# explicit bound rather than the unbounded default (`None`), chosen to
+# exercise genuine multi-task dispatch without inviting an unbounded number
+# of concurrently pending tasks for a single model response.
+_MAX_FUNCTION_TOOL_CONCURRENCY = 8
 _MAX_REACHABLE_AGENTS = 16
 _HANDOFF_FACTORY_MODULE = "agents.handoffs"
 _HANDOFF_FACTORY_WRAPPER = "_invoke_handoff_with_redaction"
@@ -731,6 +745,14 @@ class _Capture:
         default_factory=dict
     )
     agent_by_attempt: dict[str, str | None] = dataclasses.field(default_factory=dict)
+    # Populated once per model response, before any of its tool calls are
+    # dispatched: which reservation each call_id owns, and the barrier that
+    # keeps their commits in decision order under concurrent dispatch. See
+    # `_CapturingHooks.on_llm_end` and `_make_safe_invoker`.
+    pending_reservations: dict[str, "CallReservation"] = dataclasses.field(
+        default_factory=dict
+    )
+    pending_barrier: "LaunchBarrier | None" = None
 
     async def event(
         self,
@@ -918,9 +940,15 @@ _CapturingHooksBase: Any = RunHooksBase if _SDK_IMPORT_ERROR is None else object
 
 
 class _CapturingHooks(_CapturingHooksBase):
-    def __init__(self, capture: _Capture, budget_tracker: Any = None):
+    def __init__(
+        self,
+        capture: _Capture,
+        budget_tracker: Any = None,
+        gateway: "ToolGatewayProtocol | None" = None,
+    ):
         self.capture = capture
         self.budget_tracker = budget_tracker
+        self.gateway = gateway
 
     async def on_llm_start(
         self,
@@ -969,6 +997,7 @@ class _CapturingHooks(_CapturingHooksBase):
             },
         )
         self.capture.response_event_ids.append(response_event.event_id)
+        self._reserve_tool_calls(agent, response)
         for output in response.output:
             if isinstance(output, ResponseOutputMessage):
                 text = ItemHelpers.extract_text(output)
@@ -1012,6 +1041,63 @@ class _CapturingHooks(_CapturingHooksBase):
                     and not isinstance(raw_cost, bool)
                     else None
                 )
+
+    def _reserve_tool_calls(self, agent: Any, response: Any) -> None:
+        """Deterministically plan this response's tool calls before dispatch.
+
+        Called synchronously from ``on_llm_end``, before the SDK creates any
+        task to run an individual tool invoker -- so which reservation each
+        call gets can never depend on how the SDK schedules those tasks
+        afterwards, however many it runs concurrently. A gateway that does
+        not support batch planning (anything implementing only the minimal
+        ``ToolGatewayProtocol``) is left alone: invokers fall back to calling
+        it directly, exactly as they always have.
+        """
+
+        gateway = self.gateway
+        if not hasattr(gateway, "plan_batch"):
+            return
+        function_calls = [
+            output
+            for output in response.output
+            if isinstance(output, ResponseFunctionToolCall)
+        ]
+        if not function_calls:
+            return
+        schema_by_tool: dict[str, dict[str, Any]] = {
+            tool.name: tool.params_json_schema
+            for tool in getattr(agent, "tools", ())
+            if isinstance(tool, FunctionTool)
+        }
+        plannable: list[tuple[str, str, dict[str, Any]]] = []
+        for call in function_calls:
+            call_id = str(getattr(call, "call_id", "") or "")
+            schema = schema_by_tool.get(call.name)
+            if not call_id or schema is None:
+                # No schema means this call is not one of the reconstructed
+                # tools this adapter knows about (or the agent's tool list
+                # could not be read here); leave it to the invoker's own
+                # fallback path rather than guessing.
+                continue
+            arguments, validation_errors = _parse_arguments(call.arguments, schema)
+            if validation_errors:
+                # The invoker will take its own malformed-argument path
+                # without ever reaching the gateway; planning a reservation
+                # for it would consume a fixture/budget slot for a call that
+                # never commits, which could steal that slot from a sibling
+                # call actually reaching the gateway.
+                continue
+            plannable.append((call_id, call.name, arguments))
+        if not plannable:
+            return
+        reservations = cast(Any, gateway).plan_batch(
+            [(name, arguments) for _, name, arguments in plannable]
+        )
+        self.capture.pending_reservations = {
+            call_id: reservation
+            for (call_id, _, _), reservation in zip(plannable, reservations)
+        }
+        self.capture.pending_barrier = LaunchBarrier(len(reservations))
 
 
 def _schema_validation_errors(schema: Mapping[str, Any], arguments: Any) -> list[str]:
@@ -1198,6 +1284,35 @@ async def _invoke_gateway(
     return result
 
 
+async def _invoke_reserved_or_direct(
+    *,
+    gateway: ToolGatewayProtocol,
+    capture: "_Capture",
+    call_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    world_state: Any,
+) -> Any:
+    """Commit this call's pre-planned reservation, in decision order, if one
+    exists; otherwise fall back to invoking the gateway directly.
+
+    The fallback covers a gateway that does not support batch planning, and
+    any call `_reserve_tool_calls` deliberately left unplanned (an unknown
+    schema, or arguments that will take the invoker's own malformed-argument
+    path without reaching the gateway at all). Popping the reservation makes
+    each one committable at most once.
+    """
+
+    reservation = capture.pending_reservations.pop(call_id, None)
+    barrier = capture.pending_barrier
+    if reservation is not None and barrier is not None and hasattr(gateway, "commit"):
+        return await barrier.run_in_order(
+            reservation.rank,
+            lambda: cast(Any, gateway).commit(reservation, world_state),
+        )
+    return await _invoke_gateway(gateway, tool_name, arguments, world_state)
+
+
 def _make_safe_invoker(
     *,
     tool_name: str,
@@ -1261,8 +1376,13 @@ def _make_safe_invoker(
             )
 
         try:
-            gateway_result = await _invoke_gateway(
-                gateway, tool_name, arguments, world_state
+            gateway_result = await _invoke_reserved_or_direct(
+                gateway=gateway,
+                capture=capture,
+                call_id=call_id,
+                tool_name=tool_name,
+                arguments=arguments,
+                world_state=world_state,
             )
         except BaseException as exc:
             controlled_outcome = getattr(exc, "outcome", None)
@@ -2732,12 +2852,14 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
             run_kwargs: dict[str, Any] = {
                 "max_turns": max_turns,
                 "hooks": _CapturingHooks(
-                    capture, getattr(prepared.gateway, "budgets", None)
+                    capture, getattr(prepared.gateway, "budgets", None), prepared.gateway
                 ),
                 "run_config": RunConfig(
                     tracing_disabled=True,
                     trace_include_sensitive_data=False,
-                    tool_execution=ToolExecutionConfig(max_function_tool_concurrency=1),
+                    tool_execution=ToolExecutionConfig(
+                        max_function_tool_concurrency=_MAX_FUNCTION_TOOL_CONCURRENCY
+                    ),
                     tool_not_found_behavior="raise_error",
                     tool_name_collision_policy="error",
                 ),

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -57,6 +57,10 @@ from agentcheck.domain.run import (
 from agentcheck.domain.scenario import ConversationRole, ConversationTurn
 from agentcheck.inspect.capabilities import extract_capabilities
 from agentcheck.inspect.risk_authority import declared_risk_for, resolve_tool_risk
+from agentcheck.runner.launch_barrier import LaunchBarrier
+from agentcheck.runner.tool_gateway import CallReservation
+from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
+from jsonschema.exceptions import SchemaError  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from agentcheck.config import ToolRiskDeclaration
@@ -94,7 +98,7 @@ try:  # pragma: no cover - import guard mirrors the OpenAI adapter
         ToolCallPart,
     )
     from pydantic_ai.models import Model
-    from pydantic_ai.tools import Tool
+    from pydantic_ai.tools import RunContext, Tool
 except Exception as exc:  # pragma: no cover - exercised without the extra
     _SDK_IMPORT_ERROR = exc
     Agent = Any  # type: ignore[assignment,misc]
@@ -166,6 +170,18 @@ def _unknown_property(value: Any, *, locator: str, summary: str) -> AgentPropert
         confidence=0.0,
         authoritative=False,
     )
+
+
+def _schema_validation_errors(schema: Mapping[str, Any], arguments: Any) -> list[str]:
+    try:
+        validator = offline_validator(schema)
+    except (SchemaError, UnsafeSchemaReference) as exc:
+        return [f"invalid or unsafe tool schema: {exc}"]
+    errors = sorted(validator.iter_errors(arguments), key=lambda error: list(error.path))
+    return [
+        f"{'.'.join(str(item) for item in error.absolute_path) or '$'}: {error.message}"
+        for error in errors
+    ]
 
 
 def _agent_toolset(target: Any) -> Any | None:
@@ -319,6 +335,14 @@ class _Capture:
     outcomes: list[ToolOutcome] = dataclasses.field(default_factory=list)
     request_ids: list[str] = dataclasses.field(default_factory=list)
     usage: list[Any] = dataclasses.field(default_factory=list)
+    # Populated once per model response, before PydanticAI's own executor
+    # dispatches any of its tool calls -- which, unlike the OpenAI adapter,
+    # it does concurrently by default. See `_CapturingModel.request` and
+    # `_make_safe_tool`.
+    pending_reservations: dict[str, "CallReservation"] = dataclasses.field(
+        default_factory=dict
+    )
+    pending_barrier: "LaunchBarrier | None" = None
 
     async def event(
         self,
@@ -401,6 +425,23 @@ class _Capture:
         state_transition_ids: Sequence[str] = (),
         gateway_metadata: Mapping[str, Any] | None = None,
     ) -> ToolOutcome:
+        # Remapped here, not left for the caller to do afterwards: a gateway
+        # transition ID must become its canonical run-scoped ID before it is
+        # ever stored on a ToolOutcome, or two calls whose outcomes are
+        # recorded out of the order their `transition_links` entries were
+        # populated could end up with an outcome referencing an ID no
+        # `StateTransition` in the final run actually carries.
+        canonical_transition_ids: list[str] = []
+        for gateway_transition_id in state_transition_ids:
+            link = self.transition_links.get(gateway_transition_id)
+            if link is None:
+                canonical_transition_id = (
+                    f"{self.run_id}:transition:{len(self.transition_links):04d}"
+                )
+                link = (canonical_transition_id, attempt.attempt_id)
+                self.transition_links[gateway_transition_id] = link
+            canonical_transition_ids.append(link[0])
+
         ended_at = utc_now()
         index = len(self.outcomes)
         event = await self.event(
@@ -425,7 +466,7 @@ class _Capture:
             started_at=started_at,
             ended_at=ended_at,
             latency_ms=max(0.0, (ended_at - started_at).total_seconds() * 1_000),
-            state_transition_ids=tuple(state_transition_ids),
+            state_transition_ids=tuple(canonical_transition_ids),
             metadata=_json_object(dict(gateway_metadata or {}))
             | ({"gateway_outcome_id": gateway_outcome_id} if gateway_outcome_id else {}),
         )
@@ -518,6 +559,36 @@ def _gateway_result_parts(
     )
 
 
+async def _invoke_reserved_or_direct(
+    *,
+    gateway: ToolGatewayProtocol,
+    capture: "_Capture",
+    call_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    world_state: Any,
+) -> Any:
+    """Commit this call's pre-planned reservation, in decision order, if one
+    exists; otherwise fall back to invoking the gateway directly.
+
+    Mirrors the OpenAI adapter's helper of the same name. The fallback
+    covers a gateway without batch-planning support, and any call
+    `_CapturingModel._reserve_tool_calls` deliberately left unplanned.
+    """
+
+    reservation = capture.pending_reservations.pop(call_id, None)
+    barrier = capture.pending_barrier
+    if reservation is not None and barrier is not None and hasattr(gateway, "commit"):
+        return await barrier.run_in_order(
+            reservation.rank,
+            lambda: cast(Any, gateway).commit(reservation, world_state),
+        )
+    result = gateway.invoke(tool_name, arguments, world_state)
+    if _inspect.isawaitable(result):
+        return await result
+    return result
+
+
 def _model_visible_tool_output(
     status: ToolOutcomeStatus, result: Any, error: ToolError | None
 ) -> str:
@@ -606,7 +677,7 @@ def _make_safe_tool(
 
     name = definition.name
 
-    async def invoke(**kwargs: Any) -> str:
+    async def invoke(ctx: "RunContext[Any]", **kwargs: Any) -> str:
         capture = capture_holder.get("capture")
         if capture is None:
             raise RuntimeError(
@@ -616,20 +687,28 @@ def _make_safe_tool(
         raw_arguments = json.dumps(
             _json_value(arguments), ensure_ascii=False, sort_keys=True
         )
+        call_id = str(getattr(ctx, "tool_call_id", None) or "") or (
+            f"agentcheck-{name}-{len(capture.attempts) + 1}"
+        )
         attempt = await capture.tool_attempt(
             tool_name=name,
             arguments=arguments,
             raw_arguments=raw_arguments,
-            call_id=f"agentcheck-{name}-{len(capture.attempts) + 1}",
+            call_id=call_id,
             validation_errors=(),
             state_changing=state_changing,
             destructive=destructive,
         )
         started_at = utc_now()
         try:
-            result = gateway.invoke(name, arguments, world_state)
-            if _inspect.isawaitable(result):
-                result = await result
+            result = await _invoke_reserved_or_direct(
+                gateway=gateway,
+                capture=capture,
+                call_id=call_id,
+                tool_name=name,
+                arguments=arguments,
+                world_state=world_state,
+            )
         except BaseException as exc:
             controlled = getattr(exc, "outcome", None)
             if isinstance(controlled, ToolOutcome):
@@ -651,11 +730,6 @@ def _make_safe_tool(
                     state_transition_ids=transition_ids,
                     gateway_metadata=metadata,
                 )
-                for index, gateway_id in enumerate(transition_ids):
-                    capture.transition_links[gateway_id] = (
-                        f"{capture.run_id}:transition:{len(capture.transition_links):04d}",
-                        attempt.attempt_id,
-                    )
                 del outcome
                 return _model_visible_tool_output(status, value, error)
             await capture.event(
@@ -689,11 +763,6 @@ def _make_safe_tool(
             state_transition_ids=transition_ids,
             gateway_metadata=metadata,
         )
-        for gateway_id in transition_ids:
-            capture.transition_links[gateway_id] = (
-                f"{capture.run_id}:transition:{len(capture.transition_links):04d}",
-                attempt.attempt_id,
-            )
         return _model_visible_tool_output(status, value, error)
 
     invoke.__name__ = name
@@ -702,6 +771,7 @@ def _make_safe_tool(
         name=name,
         description=definition.description or "",
         json_schema=dict(definition.input_schema),
+        takes_ctx=True,
     )
 
 
@@ -713,10 +783,20 @@ class _CapturingModel(Model):
     interactive stages, exactly as they do for the first adapter.
     """
 
-    def __init__(self, inner: Any, capture: _Capture, budgets: Any) -> None:
+    def __init__(
+        self,
+        inner: Any,
+        capture: _Capture,
+        budgets: Any,
+        *,
+        gateway: "ToolGatewayProtocol | None" = None,
+        schema_by_tool: Mapping[str, dict[str, Any]] | None = None,
+    ) -> None:
         self._inner = inner
         self._capture = capture
         self._budgets = budgets
+        self._gateway = gateway
+        self._schema_by_tool = dict(schema_by_tool or {})
 
     @property
     def model_name(self) -> str:
@@ -792,7 +872,61 @@ class _CapturingModel(Model):
                     CanonicalEventType.ASSISTANT_OUTPUT,
                     {"text": text, "agent_name": None},
                 )
+        self._reserve_tool_calls(parts)
         return response
+
+    def _reserve_tool_calls(self, parts: Sequence[Any]) -> None:
+        """Deterministically plan this response's tool calls before dispatch.
+
+        Unlike the OpenAI adapter, PydanticAI dispatches a model response's
+        tool calls concurrently *by default* -- there is no serialized
+        baseline to opt out of. This runs synchronously, before returning
+        control to PydanticAI's own tool-execution graph, so which
+        reservation each call gets can never depend on how that graph
+        happens to schedule the resulting tasks.
+        """
+
+        gateway = self._gateway
+        if gateway is None or not hasattr(gateway, "plan_batch"):
+            return
+        calls = [part for part in parts if isinstance(part, ToolCallPart)]
+        if not calls:
+            return
+        plannable: list[tuple[str, str, dict[str, Any]]] = []
+        for call in calls:
+            call_id = str(getattr(call, "tool_call_id", "") or "")
+            schema = self._schema_by_tool.get(call.tool_name)
+            if not call_id or schema is None:
+                continue
+            raw_args = call.args
+            if isinstance(raw_args, str):
+                try:
+                    parsed_args: Any = json.loads(raw_args)
+                except (TypeError, ValueError):
+                    continue
+            elif raw_args is None:
+                parsed_args = {}
+            else:
+                parsed_args = raw_args
+            if not isinstance(parsed_args, dict):
+                continue
+            if _schema_validation_errors(schema, parsed_args):
+                # PydanticAI will not dispatch this call to our tool function
+                # at all -- it answers with its own retry prompt instead.
+                # Planning a reservation for it would consume a fixture/budget
+                # slot for a call that never commits.
+                continue
+            plannable.append((call_id, call.tool_name, parsed_args))
+        if not plannable:
+            return
+        reservations = cast(Any, gateway).plan_batch(
+            [(name, arguments) for _, name, arguments in plannable]
+        )
+        self._capture.pending_reservations = {
+            call_id: reservation
+            for (call_id, _, _), reservation in zip(plannable, reservations)
+        }
+        self._capture.pending_barrier = LaunchBarrier(len(reservations))
 
 
 def _usage_metrics(entries: Sequence[Any]) -> UsageMetrics:
@@ -1396,8 +1530,16 @@ class PydanticAIAdapter(FrameworkAdapter):
 
         budgets = getattr(prepared.gateway, "budgets", None)
         agent = prepared.runtime_agent
+        schema_by_tool = {
+            item.value.name: dict(item.value.input_schema)
+            for item in prepared.spec.tools.items
+        }
         agent.model = _CapturingModel(
-            prepared.metadata.get("inner_model"), capture, budgets
+            prepared.metadata.get("inner_model"),
+            capture,
+            budgets,
+            gateway=prepared.gateway,
+            schema_by_tool=schema_by_tool,
         )
 
         termination = RunTermination.COMPLETED

--- a/agentcheck/runner/__init__.py
+++ b/agentcheck/runner/__init__.py
@@ -6,6 +6,7 @@ from .network_guard import (
     denied_destinations,
     install_network_guard,
 )
+from .launch_barrier import LaunchBarrier
 from .orchestrator import (
     ProcessResult,
     WorkerProcessError,
@@ -13,6 +14,7 @@ from .orchestrator import (
     run_scenario_in_subprocess,
 )
 from .tool_gateway import (
+    CallReservation,
     FixtureDefinitionError,
     FixtureNotFoundError,
     ToolCallBlockedError,
@@ -27,8 +29,10 @@ __all__ = [
     "BudgetExceeded",
     "BudgetTracker",
     "BudgetUsage",
+    "CallReservation",
     "FixtureDefinitionError",
     "FixtureNotFoundError",
+    "LaunchBarrier",
     "NetworkAccessDenied",
     "ProcessResult",
     "ToolCallBlockedError",

--- a/agentcheck/runner/launch_barrier.py
+++ b/agentcheck/runner/launch_barrier.py
@@ -1,0 +1,83 @@
+"""Deterministic commit ordering for one batch of concurrently dispatched calls.
+
+``ToolGateway.plan_batch`` decides fixture ownership, invocation index, and
+retry classification once, in call order -- none of that depends on when a
+reservation is actually committed. Applying a fixture's world-state effects
+is different: two reservations whose effects touch overlapping simulated
+state would still leave the final world state depending on whichever one's
+``commit`` call happens to run first, if nothing constrains that order.
+
+``LaunchBarrier`` gates a batch's commits to happen in the same order they
+were planned (``rank`` order), while leaving everything a participant does
+*before* committing -- argument parsing, guardrails, attempt recording -- free
+to interleave under real concurrent dispatch. It is built from plain
+``asyncio.Event`` objects: no thread locks, no sleeps, no timing assumptions,
+and no behaviour that depends on which OS thread or task the event loop
+happens to run first. It only orders cooperative coroutines within one event
+loop; it does not (and cannot) order real OS threads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class LaunchBarrier:
+    """Serializes a fixed number of ranked participants to rank order."""
+
+    def __init__(self, size: int) -> None:
+        if size < 0:
+            raise ValueError("size must be non-negative")
+        self._events = [asyncio.Event() for _ in range(size)]
+        if size:
+            self._events[0].set()
+
+    @property
+    def size(self) -> int:
+        return len(self._events)
+
+    async def wait_for_rank(self, rank: int) -> None:
+        """Suspend until every rank before ``rank`` has called ``release``."""
+
+        self._check_rank(rank)
+        await self._events[rank].wait()
+
+    def release(self, rank: int) -> None:
+        """Allow the next rank to proceed. Idempotent for a given rank."""
+
+        self._check_rank(rank)
+        if rank + 1 < len(self._events):
+            self._events[rank + 1].set()
+
+    async def run_in_order(self, rank: int, action: Callable[[], T]) -> T:
+        """Run ``action`` (a plain synchronous callable) once this rank's turn
+        arrives, then release the next rank -- even if ``action`` raises."""
+
+        await self.wait_for_rank(rank)
+        try:
+            return action()
+        finally:
+            self.release(rank)
+
+    async def run_in_order_async(
+        self, rank: int, action: Callable[[], Awaitable[T]]
+    ) -> T:
+        """Same as ``run_in_order``, for an ``action`` that is itself async."""
+
+        await self.wait_for_rank(rank)
+        try:
+            return await action()
+        finally:
+            self.release(rank)
+
+    def _check_rank(self, rank: int) -> None:
+        if not isinstance(rank, int) or isinstance(rank, bool) or not (
+            0 <= rank < len(self._events)
+        ):
+            raise ValueError(f"rank {rank!r} is out of range for a barrier of size {len(self._events)}")
+
+
+__all__ = ["LaunchBarrier"]

--- a/agentcheck/runner/tool_gateway.py
+++ b/agentcheck/runner/tool_gateway.py
@@ -1072,6 +1072,7 @@ class ToolGateway:
 
 
 __all__ = [
+    "CallReservation",
     "FixtureDefinitionError",
     "FixtureNotFoundError",
     "ToolCallBlockedError",

--- a/agentcheck/runner/tool_gateway.py
+++ b/agentcheck/runner/tool_gateway.py
@@ -80,6 +80,75 @@ class _FixtureConfig:
     priority: int
 
 
+@dataclass(frozen=True)
+class _PlannedOutcome:
+    """What committing a reservation will do to the world and the record.
+
+    Decided entirely during planning, from the fixture and tool configuration
+    alone -- nothing here depends on wall-clock timing or which reservation in
+    a batch happens to commit first.
+    """
+
+    status: ToolOutcomeStatus
+    result: Any
+    error: ToolError | None
+    latency_ms: float
+    effects: tuple[Any, ...]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _BlockedPlan:
+    """A call that will not reach a fixture, decided at plan time.
+
+    ``exception_type`` is ``None`` for the one blocked case that has always
+    been returned as an ordinary ``BLOCKED`` outcome rather than raised
+    (invalid arguments): every other blocked reason raises a
+    ``ToolCallBlockedError`` subclass carrying the same outcome, exactly as
+    ``invoke`` always has.
+    """
+
+    exception_type: type[ToolCallBlockedError] | None
+    exception_message: str
+    code: str
+    message: str
+    retryable: bool
+    details: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CallReservation:
+    """One call's deterministic bookkeeping, decided independently of commit timing.
+
+    Everything that must not depend on execution/completion order --
+    budget consumption, invocation index, fixture ownership, and the
+    resulting status -- is decided when the reservation is created
+    (`ToolGateway.plan_batch`/`plan_one`), in the order the calls are
+    presented. Two reservations from one batch may be committed in any
+    relative order without changing which fixture either received, whether
+    a single-use fixture is double-consumed, or which one crossed a shared
+    budget first: all of that was already decided at plan time.
+
+    What ``commit`` still does -- applying the fixture's world-state effects
+    and recording the attempt/outcome -- is the one part that can still
+    observe scheduling if the caller does not serialize it: two reservations
+    whose effects touch the same simulated state will still produce a
+    completion-order-dependent final world state unless the caller commits
+    them in ``rank`` order. See ``agentcheck.runner.launch_barrier`` for the
+    utility the adapters use to guarantee that.
+    """
+
+    rank: int
+    tool_name: str
+    arguments: dict[str, Any]
+    started_at: datetime
+    tool: _ToolConfig | None
+    invocation_index: int
+    blocked: _BlockedPlan | None
+    planned: _PlannedOutcome | None
+
+
 _HANDLER_FIELDS = (
     "handler",
     "function",
@@ -493,34 +562,12 @@ class ToolGateway:
             metadata=safe_metadata,
         )
         self._outcomes.append(outcome)
-        signature = (
-            attempt.tool_name,
-            json.dumps(attempt.arguments, sort_keys=True, separators=(",", ":")),
-        )
-        self._signature_status[signature] = status
+        # `_signature_status` is deliberately not updated here. It must reflect
+        # decision order (set once, deterministically, in `_plan_one`), not
+        # commit order: two reservations sharing a signature can commit in
+        # either order under concurrent dispatch, and whichever commits last
+        # must not get to decide what a later call's retry-budget check sees.
         return outcome
-
-    def _blocked(
-        self,
-        attempt: ToolAttempt,
-        *,
-        code: str,
-        message: str,
-        started_at: datetime,
-        details: Mapping[str, Any] | None = None,
-    ) -> ToolOutcome:
-        return self._record_outcome(
-            attempt,
-            status=ToolOutcomeStatus.BLOCKED,
-            error=ToolError(
-                code=code,
-                message=message,
-                retryable=False,
-                details=_json_value(dict(details or {}), label="blocked tool details"),
-            ),
-            metadata={"blocked": True},
-            started_at=started_at,
-        )
 
     def _select_fixture(
         self,
@@ -662,14 +709,37 @@ class ToolGateway:
             timestamp=timestamp,
         )
 
-    def invoke(
-        self,
-        tool_name: str,
-        arguments: Mapping[str, Any],
-        world_state: WorldSimulator | Mapping[str, Any] | None = None,
-    ) -> ToolOutcome:
-        """Simulate one tool call; no path in this method invokes application code."""
+    def plan_batch(
+        self, calls: Sequence[tuple[str, Mapping[str, Any]]]
+    ) -> list[CallReservation]:
+        """Deterministically plan every call in ``calls``, in the given order.
 
+        This is the "decision known" step: budget consumption, invocation
+        index assignment, fixture selection and consumption, and the
+        resulting status are all decided here, strictly in the order the
+        calls are listed -- never in whatever order their reservations are
+        later committed. Two batches built from the same calls in the same
+        order always produce reservations with the same fixture and
+        invocation-index assignment, regardless of what commits them or when.
+
+        Committing every returned reservation in order (``commit`` called for
+        index 0, then 1, then ...) reproduces exactly what calling ``invoke``
+        for each call in this same order would have done.
+        """
+
+        return [
+            self._plan_one(rank, tool_name, arguments)
+            for rank, (tool_name, arguments) in enumerate(calls)
+        ]
+
+    def plan_one(self, tool_name: str, arguments: Mapping[str, Any]) -> CallReservation:
+        """Plan a single call. Equivalent to ``plan_batch([(tool_name, arguments)])[0]``."""
+
+        return self._plan_one(0, tool_name, arguments)
+
+    def _plan_one(
+        self, rank: int, tool_name: str, arguments: Mapping[str, Any]
+    ) -> CallReservation:
         started_at = self._now()
         if not isinstance(tool_name, str) or not tool_name:
             raise ValueError("tool_name must be a non-empty string")
@@ -682,26 +752,57 @@ class ToolGateway:
             raise ValueError("tool arguments must be a JSON object")
 
         tool = self._tools.get(tool_name)
-        try:
-            self.budgets.consume_tool_call()
-        except BudgetExceeded as exc:
-            attempt = self._record_attempt(tool_name, safe_arguments, tool, started_at)
-            outcome = self._blocked(
-                attempt,
-                code=f"{exc.resource}_budget_exceeded",
-                message=f"{exc.resource} budget exceeded",
-                details={"limit": exc.limit, "observed": exc.observed},
-                started_at=started_at,
-            )
-            raise ToolCallBlockedError(str(exc), outcome) from exc
-        attempt = self._record_attempt(tool_name, safe_arguments, tool, started_at)
-        self._invocations[tool_name] += 1
-        invocation_index = self._invocations[tool_name]
-
         signature = (
             tool_name,
             json.dumps(safe_arguments, sort_keys=True, separators=(",", ":")),
         )
+
+        def blocked(
+            *,
+            exception_type: type[ToolCallBlockedError] | None,
+            exception_message: str = "",
+            code: str,
+            message: str,
+            retryable: bool = False,
+            details: Mapping[str, Any] | None = None,
+            metadata: Mapping[str, Any] | None = None,
+        ) -> CallReservation:
+            # Matches decision order, not commit order -- see the note on
+            # `_record_outcome` about why this write moved here.
+            self._signature_status[signature] = ToolOutcomeStatus.BLOCKED
+            return CallReservation(
+                rank=rank,
+                tool_name=tool_name,
+                arguments=safe_arguments,
+                started_at=started_at,
+                tool=tool,
+                invocation_index=0,
+                blocked=_BlockedPlan(
+                    exception_type=exception_type,
+                    exception_message=exception_message,
+                    code=code,
+                    message=message,
+                    retryable=retryable,
+                    details=dict(details or {}),
+                    metadata=dict(metadata or {"blocked": True}),
+                ),
+                planned=None,
+            )
+
+        try:
+            self.budgets.consume_tool_call()
+        except BudgetExceeded as exc:
+            return blocked(
+                exception_type=ToolCallBlockedError,
+                exception_message=str(exc),
+                code=f"{exc.resource}_budget_exceeded",
+                message=f"{exc.resource} budget exceeded",
+                details={"limit": exc.limit, "observed": exc.observed},
+            )
+
+        self._invocations[tool_name] += 1
+        invocation_index = self._invocations[tool_name]
+
         if self._signature_status.get(signature) in {
             ToolOutcomeStatus.ERROR,
             ToolOutcomeStatus.TIMEOUT,
@@ -709,26 +810,21 @@ class ToolGateway:
             try:
                 self.budgets.consume_retry()
             except BudgetExceeded as exc:
-                outcome = self._blocked(
-                    attempt,
+                return blocked(
+                    exception_type=ToolCallBlockedError,
+                    exception_message="tool retry budget exceeded",
                     code="retry_budget_exceeded",
                     message="tool retry budget exceeded",
                     details={"limit": exc.limit, "observed": exc.observed},
-                    started_at=started_at,
                 )
-                raise ToolCallBlockedError(
-                    "tool retry budget exceeded", outcome
-                ) from exc
         if tool is None:
-            outcome = self._blocked(
-                attempt,
+            return blocked(
+                exception_type=UnknownToolError,
+                exception_message=(
+                    f"tool {tool_name!r} is not in the AgentCheck allowlist"
+                ),
                 code="unknown_tool",
                 message="tool is not in the AgentCheck allowlist",
-                started_at=started_at,
-            )
-            raise UnknownToolError(
-                f"tool {tool_name!r} is not in the AgentCheck allowlist",
-                outcome,
             )
 
         validation_errors = sorted(
@@ -738,34 +834,26 @@ class ToolGateway:
         if validation_errors:
             schema_error = validation_errors[0]
             path = ".".join(str(part) for part in schema_error.absolute_path)
-            return self._record_outcome(
-                attempt,
-                status=ToolOutcomeStatus.BLOCKED,
-                error=ToolError(
-                    code="invalid_arguments",
-                    message="tool arguments do not satisfy the declared JSON Schema",
-                    retryable=True,
-                    details={
-                        "path": path,
-                        "validator": str(schema_error.validator),
-                    },
-                ),
+            return blocked(
+                exception_type=None,
+                code="invalid_arguments",
+                message="tool arguments do not satisfy the declared JSON Schema",
+                retryable=True,
+                details={"path": path, "validator": str(schema_error.validator)},
                 metadata={"schema_valid": False},
-                started_at=started_at,
             )
 
         fixture = self._select_fixture(tool_name, safe_arguments, invocation_index)
         if fixture is None:
-            outcome = self._blocked(
-                attempt,
+            return blocked(
+                exception_type=FixtureNotFoundError,
+                exception_message=(
+                    f"no controlled fixture matched invocation {invocation_index} "
+                    f"for {tool_name!r}"
+                ),
                 code="fixture_not_found",
                 message="no controlled fixture matched this invocation",
                 details={"invocation_index": invocation_index},
-                started_at=started_at,
-            )
-            raise FixtureNotFoundError(
-                f"no controlled fixture matched invocation {invocation_index} for {tool_name!r}",
-                outcome,
             )
 
         configured = self._fixture_outcome(fixture)
@@ -835,21 +923,14 @@ class ToolGateway:
         try:
             self.budgets.add_simulated_time(latency_ms / 1_000.0)
         except BudgetExceeded as exc:
-            outcome = self._blocked(
-                attempt,
+            return blocked(
+                exception_type=ToolCallBlockedError,
+                exception_message=str(exc),
                 code="wall_time_budget_exceeded",
                 message="simulated tool latency exceeded the wall-time budget",
                 details={"limit": exc.limit, "observed": exc.observed},
-                started_at=started_at,
             )
-            raise ToolCallBlockedError(str(exc), outcome) from exc
-        active_world = self._resolve_world(world_state)
-        transitions = self._apply_effects(
-            effect_values or (),
-            world=active_world,
-            attempt=attempt,
-            timestamp=self._now(),
-        )
+
         metadata = {
             "fixture_id": fixture.fixture_id,
             "schema_valid": True,
@@ -862,16 +943,106 @@ class ToolGateway:
             metadata["partial"] = True
         elif status == ToolOutcomeStatus.MALFORMED:
             metadata["malformed"] = True
+
+        # The signature's status is fixed here, at plan time, in call order --
+        # not when this reservation happens to commit -- so a later same-batch
+        # duplicate's retry-budget check above sees exactly the status this
+        # call is heading toward, the same as if both had run serially.
+        self._signature_status[signature] = status
+
+        return CallReservation(
+            rank=rank,
+            tool_name=tool_name,
+            arguments=safe_arguments,
+            started_at=started_at,
+            tool=tool,
+            invocation_index=invocation_index,
+            blocked=None,
+            planned=_PlannedOutcome(
+                status=status,
+                result=result,
+                error=outcome_error,
+                latency_ms=latency_ms,
+                effects=tuple(effect_values or ()),
+                metadata=metadata,
+            ),
+        )
+
+    def commit(
+        self,
+        reservation: CallReservation,
+        world_state: WorldSimulator | Mapping[str, Any] | None = None,
+    ) -> ToolOutcome:
+        """Apply one previously planned call's effects and record it.
+
+        Safe to call the reservations from one ``plan_batch`` in any order
+        with respect to each other's *timing* -- fixture ownership and
+        budget consumption were already fixed at plan time. It is the
+        caller's responsibility to actually invoke ``commit`` in ``rank``
+        order for reservations whose effects could touch overlapping
+        simulated state, or the resulting world state reflects whatever
+        order they were committed in rather than the order they were
+        decided in. ``agentcheck.runner.launch_barrier`` provides a
+        deterministic way to guarantee that ordering under real concurrent
+        dispatch.
+        """
+
+        attempt = self._record_attempt(
+            reservation.tool_name,
+            reservation.arguments,
+            reservation.tool,
+            reservation.started_at,
+        )
+        if reservation.blocked is not None:
+            plan = reservation.blocked
+            outcome = self._record_outcome(
+                attempt,
+                status=ToolOutcomeStatus.BLOCKED,
+                error=ToolError(
+                    code=plan.code,
+                    message=plan.message,
+                    retryable=plan.retryable,
+                    details=plan.details,
+                ),
+                metadata=plan.metadata,
+                started_at=reservation.started_at,
+            )
+            if plan.exception_type is not None:
+                raise plan.exception_type(plan.exception_message, outcome)
+            return outcome
+
+        planned = reservation.planned
+        assert planned is not None  # noqa: S101 - invariant: blocked xor planned
+        active_world = self._resolve_world(world_state)
+        transitions = self._apply_effects(
+            planned.effects,
+            world=active_world,
+            attempt=attempt,
+            timestamp=self._now(),
+        )
         return self._record_outcome(
             attempt,
-            status=status,
-            result=result,
-            error=outcome_error,
-            latency_ms=latency_ms,
+            status=planned.status,
+            result=planned.result,
+            error=planned.error,
+            latency_ms=planned.latency_ms,
             transitions=transitions,
-            metadata=metadata,
-            started_at=started_at,
+            metadata=planned.metadata,
+            started_at=reservation.started_at,
         )
+
+    def invoke(
+        self,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+        world_state: WorldSimulator | Mapping[str, Any] | None = None,
+    ) -> ToolOutcome:
+        """Simulate one tool call; no path in this method invokes application code.
+
+        Equivalent to ``commit(plan_one(tool_name, arguments), world_state)``.
+        """
+
+        return self.commit(self._plan_one(0, tool_name, arguments), world_state)
 
     def _resolve_world(
         self, world_state: WorldSimulator | Mapping[str, Any] | None

--- a/agentcheck/runner/tool_gateway.py
+++ b/agentcheck/runner/tool_gateway.py
@@ -115,6 +115,10 @@ class _BlockedPlan:
     retryable: bool
     details: dict[str, Any]
     metadata: dict[str, Any]
+    # Preserved so `commit` can re-raise with the same `__cause__` chain
+    # `invoke` always has -- a caller (custom.py's termination mapping) reads
+    # `BudgetExceeded.resource` off that chain to tell which budget was hit.
+    cause: BaseException | None = None
 
 
 @dataclass(frozen=True)
@@ -766,6 +770,7 @@ class ToolGateway:
             retryable: bool = False,
             details: Mapping[str, Any] | None = None,
             metadata: Mapping[str, Any] | None = None,
+            cause: BaseException | None = None,
         ) -> CallReservation:
             # Matches decision order, not commit order -- see the note on
             # `_record_outcome` about why this write moved here.
@@ -785,6 +790,7 @@ class ToolGateway:
                     retryable=retryable,
                     details=dict(details or {}),
                     metadata=dict(metadata or {"blocked": True}),
+                    cause=cause,
                 ),
                 planned=None,
             )
@@ -798,6 +804,7 @@ class ToolGateway:
                 code=f"{exc.resource}_budget_exceeded",
                 message=f"{exc.resource} budget exceeded",
                 details={"limit": exc.limit, "observed": exc.observed},
+                cause=exc,
             )
 
         self._invocations[tool_name] += 1
@@ -816,6 +823,7 @@ class ToolGateway:
                     code="retry_budget_exceeded",
                     message="tool retry budget exceeded",
                     details={"limit": exc.limit, "observed": exc.observed},
+                    cause=exc,
                 )
         if tool is None:
             return blocked(
@@ -929,6 +937,7 @@ class ToolGateway:
                 code="wall_time_budget_exceeded",
                 message="simulated tool latency exceeded the wall-time budget",
                 details={"limit": exc.limit, "observed": exc.observed},
+                cause=exc,
             )
 
         metadata = {
@@ -1008,7 +1017,7 @@ class ToolGateway:
                 started_at=reservation.started_at,
             )
             if plan.exception_type is not None:
-                raise plan.exception_type(plan.exception_message, outcome)
+                raise plan.exception_type(plan.exception_message, outcome) from plan.cause
             return outcome
 
         planned = reservation.planned

--- a/docs/concurrent-tool-decisions.md
+++ b/docs/concurrent-tool-decisions.md
@@ -1,99 +1,119 @@
 # Concurrent tool decisions
 
-A model response can carry several tool calls at once. AgentCheck can tell
-that they were *decided* together; it does not *execute* them concurrently.
-This document is about that gap, why it exists, and what each half actually
-buys you.
+A model response can carry several tool calls at once. AgentCheck has always
+been able to tell that they were *decided* together. As of this milestone it
+can also let the OpenAI Agents and PydanticAI adapters dispatch them as
+genuinely concurrent tasks without that concurrency corrupting fixture
+assignment, invocation-index bookkeeping, or simulated world state. This
+document explains what changed, what still hasn't, and why the boundary sits
+where it does.
 
 ## Three different things named "concurrency"
 
 1. **Concurrent decision / launch semantics.** Whether two tool calls were
-   chosen in the same model response, before either produced a result. This is
-   a fact about the recorded run, derived from event linkage
-   (`agentcheck/evaluate/launch.py`), and AgentCheck has understood it since
-   the launch-group work that added `LaunchAnalysis.same_launch_group` and
-   `.observed_before`.
-2. **Simulated execution scheduling.** The order `ToolGateway` actually
-   services calls the adapter hands it. Today this is strictly serial and
-   synchronous, regardless of launch grouping: two calls decided together
-   still run one after another inside the gateway.
-3. **Real wall-clock concurrent execution.** Actually dispatching two tool
-   invocations at once (multiple OS threads, an event loop running them
-   interleaved, or `max_function_tool_concurrency > 1` in the OpenAI Agents
-   SDK). AgentCheck does not do this.
+   chosen in the same model response, before either produced a result. A fact
+   about the recorded run, derived from event linkage
+   (`agentcheck/evaluate/launch.py`).
+2. **Dispatch concurrency.** Whether the framework actually runs the
+   resulting tool-call coroutines as more than one concurrently-scheduled
+   task. Both supported adapters do this via plain asyncio tasks
+   (`asyncio.create_task` + `asyncio.gather`/`asyncio.wait`) — never real OS
+   threads, confirmed by reading each pinned SDK's own tool-execution code.
+   The OpenAI Agents SDK does this once its `max_function_tool_concurrency`
+   allows more than one in flight (now 8, up from 1). PydanticAI does this
+   **by default**, for every tool call, with no equivalent setting to opt out
+   of — that was true before this milestone too, and it was previously
+   unaudited.
+3. **Completion/interleaving semantics.** Which outcomes actually finish
+   first, and what each call's committed effects see. This milestone forces
+   this to follow *decision* order, not real completion order, wherever it
+   would otherwise matter (see below) — it does not model genuine race
+   interleavings beyond that.
 
-(1) and (2) are already distinct today: a scenario can represent "these two
-were decided together" without them ever running out of order. (3) is the one
-this milestone deliberately did not add.
+These are not the same thing, and conflating them is exactly the mistake this
+milestone set out to avoid. (1) and (2) already existed independently before
+this work; what changed is that (2) is now something AgentCheck's own
+bookkeeping stays correct under, instead of something only made safe by
+accident (`max_function_tool_concurrency=1`) or left unaudited (PydanticAI).
 
-## Why (3) is not enabled
+## How dispatch concurrency was made safe
 
-`ToolGateway` (`agentcheck/runner/tool_gateway.py`) is a single synchronous
-object with mutable, unsynchronized per-call state: a `_used_fixtures` set
-that fixture matching depends on, and sequence counters that canonical event
-ordering depends on. Two callers entering it concurrently — real threads, or
-an event loop actually interleaving coroutines rather than awaiting them one
-at a time — would make fixture selection and event sequencing depend on
-whichever call happened to reach the gateway first. That is exactly the
-scheduling-dependent, non-deterministic harness behaviour AgentCheck exists to
-avoid: a suite's outcome would stop being a pure function of the target, the
-seed, and the fixtures, and would start depending on OS thread scheduling.
+`ToolGateway` (`agentcheck/runner/tool_gateway.py`) is now split into a
+deterministic **plan** phase and a **commit** phase:
 
-`max_function_tool_concurrency` stays `1` in the OpenAI Agents adapter, and
-the custom `ToolRuntime` stays synchronous, for this reason. Raising the
-concurrency cap without first making the gateway's internal state safe under
-concurrent access would not add a real capability — it would add flakiness.
-Making the gateway safe under real concurrent access (locking, or per-launch-
-group isolated fixture pools) is future work, not something this milestone
-does quietly under a version bump.
+- `plan_batch(calls)` decides everything that must not depend on execution
+  order — tool-call and retry budget consumption, invocation-index
+  assignment, fixture selection and consumption, the resulting status — for
+  every call in a batch, strictly in the order the calls are given. Two
+  reservations from one batch can be committed in either order without
+  changing any of that; it was already decided.
+- `commit(reservation)` applies the fixture's world-state effects and records
+  the attempt/outcome for one already-planned reservation.
 
-## What AgentCheck can test today
+Both adapters now use a hook that sees a model response's full, ordered list
+of tool calls *before* the framework dispatches any of them as a task (the
+OpenAI adapter's `on_llm_end`; PydanticAI's `_CapturingModel.request`). That
+hook calls `plan_batch` immediately, in the model's own emission order, so
+which reservation a call gets never depends on how the framework later
+schedules the coroutine that services it.
 
-Everything below is deterministic: no thread scheduling, no sleeps, no
-random interleaving, bounded generation.
+Because dispatch concurrency here is cooperative asyncio, not real OS
+threads, a synchronous method with no internal `await` (like `commit`) always
+runs to completion without another task's code interleaving inside it. What
+still needed forcing into a fixed order is *which reservation commits before
+which* when two calls in one batch touch overlapping simulated state (see
+"State conflicts" below) — `agentcheck/runner/launch_barrier.py`'s
+`LaunchBarrier` does that with a small `asyncio.Event`-based utility, gating
+each reservation's commit until every earlier-ranked one has finished. No
+thread locks (there is no real thread contention to lock against), no
+sleeps, no timing assumptions.
 
-- **`same_launch_group(a, b)`** — were two attempts decided in the same model
-  response.
-- **`observed_before(a, b)`** — was `a`'s result recorded before the model
-  response that launched `b`. `False` for same-stage attempts (neither could
-  have informed the other); `None` when the run does not record enough to
-  say — never treated as evidence of either answer.
-- **`ordering`** (a declared policy or generated constraint) — fails when a
-  same-stage pair violates a declared "observe X before deciding Y" rule.
-  A prerequisite and its dependent action launched together is exactly this
-  case, and it already fails correctly: see
-  `test_ordering_fails_when_both_calls_were_decided_together`.
-- **`no_same_stage_duplicate_action`** — fails when the *same* tool, with
-  identical arguments, is decided twice in one launch group (`delete_user()`
-  called twice in one response). Structurally unambiguous, unlike a repeat
-  across two later reasoning turns (which `no_duplicate_side_effect` already
-  covers, and which this rule does not fire on).
-- **Unrelated same-stage calls are not, by themselves, a finding.** Two reads
-  decided together, or one destructive tool decided alongside an unrelated
-  read, produce no failure unless a declared/authoritative rule actually
-  says something about the relationship. Sharing a launch group is evidence,
-  not a verdict.
+## What AgentCheck now supports
 
-## What AgentCheck cannot test yet
+- **Real concurrent tool-call dispatch** in the OpenAI Agents adapter
+  (`max_function_tool_concurrency=8`, a small explicit bound rather than the
+  SDK's unbounded default) and in PydanticAI (its own default, now made
+  safe rather than merely unaudited).
+- **Deterministic fixture/invocation-index assignment** regardless of which
+  task's coroutine the event loop happens to run first.
+- **Deterministic world-state commit order**: two same-stage calls whose
+  fixtures both mutate simulated state commit in decision order, every time —
+  proven by running the same scripted batch many times and checking the
+  final state is identical, not by inspecting one run.
+- **`same_launch_group(a, b)` / `observed_before(a, b)`** — unchanged from
+  before this milestone, and still correct under real concurrent dispatch.
+- **`ordering`** and **`no_same_stage_duplicate_action`** — both verdicts are
+  proven independent of completion order: repeated runs of the same
+  same-stage scenario produce the same verdict regardless of which
+  concurrently-dispatched call's task happens to finish first.
+- **Two same-stage calls racing for one single-use fixture fail closed**: the
+  second is refused at plan time (deterministically, by decision order), not
+  raced for at commit time.
 
-- **Real concurrent execution effects**: a genuine race between two
-  in-flight calls, one mutating state the other reads mid-flight. The
-  simulated world only ever sees calls one at a time.
+## What AgentCheck still cannot do
+
+- **Custom Python agents stay synchronous and unsupported for concurrent
+  dispatch.** `ToolRuntime.call` has no hook analogous to the two adapters'
+  above — a custom agent's own orchestration decides when to call it, and if
+  that orchestration issues genuinely concurrent calls (multiple threads, or
+  tasks that actually interleave around a real `await`), fixture and
+  invocation-index ordering are not guaranteed. This is deliberately left
+  unsupported rather than guessed at: see the docstring on
+  `_GatewayToolRuntime` in `agentcheck/adapters/custom.py`. A custom agent
+  that wants determinism must call `ToolRuntime.call` strictly in decision
+  order itself.
 - **Two different destructive tools targeting the same resource**, launched
   together, evaluated for whether that pairing itself is safe. Doing this
   honestly requires a declared resource/entity link between the two tools,
   which no current contract expresses; inferring one from names would be
-  exactly the kind of semantic guessing this milestone's tool-risk work was
-  written to stop doing. This stays `UNKNOWN`/unsupported rather than
-  invented.
+  exactly the kind of semantic guessing this project's tool-risk work exists
+  to stop doing. This stays `UNKNOWN`/unsupported rather than invented.
 - **Retry-after-concurrent-mutation**: "action A retried after concurrent
   action B already changed the state A depends on" needs state versioning
-  the simulated world does not yet have. Not built here.
-- **Async custom-agent tool calls.** `ToolRuntime` is synchronous by
-  contract; a custom agent that wants to issue tool calls from concurrent
-  tasks has no supported path today. This is documented as unsupported
-  rather than fabricated, per the same reasoning as (3) above — the
-  underlying gateway is not yet safe for it.
+  the simulated world does not have. Not built here.
+- **Genuine race-condition effects**: a real interleaving where one call
+  observes another's *partial* mutation mid-flight. The simulated world has
+  no partial states to observe — a commit either has happened or hasn't.
 
 If a scenario or policy needs one of the unsupported cases above, the honest
 answer is `INCONCLUSIVE`/generation refusing to invent the case, not a

--- a/tests/agentcheck/test_behavioral_launch.py
+++ b/tests/agentcheck/test_behavioral_launch.py
@@ -1042,3 +1042,67 @@ def test_same_stage_state_effects_commit_in_decision_order_under_concurrency() -
     # the final committed value must always be "second" -- never dependent on
     # which task's commit happened to run first under the event loop.
     assert gateway.world.get("holder") == "second"
+
+
+def test_same_stage_success_and_error_are_independent_under_concurrency() -> None:
+    """Two different same-stage tools, one succeeding and one erroring, must
+    each get their own outcome correctly under real concurrent dispatch --
+    neither call's status leaks into the other's."""
+
+    from agentcheck.domain import (
+        SimulatedToolOutcome,
+        SimulatedToolStatus,
+        ToolFixture,
+        ToolOutcomeStatus,
+    )
+    from agentcheck.runner import ToolGateway
+
+    agents = _agents()
+
+    @agents.function_tool
+    def verify_customer(order_id: str) -> str:
+        raise AssertionError("the original handler was invoked")
+
+    @agents.function_tool
+    def refund_order(order_id: str) -> str:
+        raise AssertionError("the original handler was invoked")
+
+    agent = agents.Agent(
+        name="Refunder",
+        instructions="Handle refunds.",
+        tools=[verify_customer, refund_order],
+        model=ScriptedModel(
+            [
+                [
+                    _tool_call("verify_customer", {"order_id": "o"}, "c1"),
+                    _tool_call("refund_order", {"order_id": "o"}, "c2"),
+                ],
+                [_message("done")],
+            ]
+        ),
+    )
+    adapter = OpenAIAgentsAdapter()
+    spec = adapter.inspect(agent)
+    fixtures = (
+        ToolFixture(
+            fixture_id="verify-ok",
+            tool_name="verify_customer",
+            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"verified": True}),
+        ),
+        ToolFixture(
+            fixture_id="refund-error",
+            tool_name="refund_order",
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.ERROR, error_code="card_declined", error_message="declined"
+            ),
+        ),
+    )
+    gateway = ToolGateway(spec.tools.items, fixtures, world={}, run_id="mixed-outcome-e2e")
+    prepared = adapter.prepare(agent, gateway, world_state=gateway.world)
+    run = asyncio.run(adapter.run(prepared, "verify then refund", run_id="mixed-outcome-run", max_turns=6))
+
+    outcomes_by_tool = {outcome.tool_name: outcome for outcome in run.tool_outcomes}
+    assert outcomes_by_tool["verify_customer"].status == ToolOutcomeStatus.SUCCESS
+    assert outcomes_by_tool["refund_order"].status == ToolOutcomeStatus.ERROR
+    assert outcomes_by_tool["refund_order"].error is not None
+    assert outcomes_by_tool["refund_order"].error.code == "card_declined"

--- a/tests/agentcheck/test_behavioral_launch.py
+++ b/tests/agentcheck/test_behavioral_launch.py
@@ -846,3 +846,199 @@ def test_different_arguments_in_one_stage_are_not_a_duplicate() -> None:
         item for item in evaluation_result.assertions if item.assertion_id == "dup-2"
     )
     assert assertion.result is Verdict.PASS
+
+
+# --------------------------------------------------------------------------
+# Real concurrent SDK dispatch: max_function_tool_concurrency > 1 must not
+# make fixture assignment, invocation index, or world-state commit order
+# depend on how the SDK happens to schedule the tool-call tasks it creates.
+# --------------------------------------------------------------------------
+
+
+def test_same_stage_duplicate_calls_get_correct_per_invocation_fixtures_under_real_concurrency() -> (
+    None
+):
+    """Two same-stage calls to the same tool, under the adapter's actual
+    (now > 1) max_function_tool_concurrency, must still each receive the
+    fixture matching their *decision* order (first call -> invocation_index
+    1, second -> invocation_index 2) -- not whichever the SDK's task
+    scheduling happens to run first."""
+
+    from agentcheck.domain import SimulatedToolOutcome, SimulatedToolStatus, ToolFixture
+    from agentcheck.runner import ToolGateway
+
+    agents = _agents()
+
+    @agents.function_tool
+    def refund_order(order_id: str) -> str:
+        HANDLER_RAN["value"] = True
+        raise AssertionError("the original handler was invoked")
+
+    HANDLER_RAN["value"] = False
+    agent = agents.Agent(
+        name="Refunder",
+        instructions="Handle refunds.",
+        tools=[refund_order],
+        model=ScriptedModel(
+            [
+                [
+                    _tool_call("refund_order", {"order_id": "o"}, "c1"),
+                    _tool_call("refund_order", {"order_id": "o"}, "c2"),
+                ],
+                [_message("done")],
+            ]
+        ),
+    )
+    adapter = OpenAIAgentsAdapter()
+    spec = adapter.inspect(agent)
+    fixtures = (
+        ToolFixture(
+            fixture_id="first",
+            tool_name="refund_order",
+            invocation_index=1,
+            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 1}),
+        ),
+        ToolFixture(
+            fixture_id="second",
+            tool_name="refund_order",
+            invocation_index=2,
+            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 2}),
+        ),
+    )
+    gateway = ToolGateway(spec.tools.items, fixtures, world={}, run_id="concurrency-e2e")
+    prepared = adapter.prepare(agent, gateway, world_state=gateway.world)
+    run = asyncio.run(adapter.run(prepared, "refund it twice", run_id="concurrency-e2e-run", max_turns=6))
+
+    assert HANDLER_RAN["value"] is False
+    outcomes_by_call: dict[str, Any] = {}
+    for attempt in run.tool_attempts:
+        outcome = next(o for o in run.tool_outcomes if o.attempt_id == attempt.attempt_id)
+        outcomes_by_call[attempt.arguments.get("order_id", "")] = outcome
+
+    results = [outcome.result for outcome in run.tool_outcomes]
+    # Decision order (the order the model emitted the two calls) must map to
+    # invocation_index 1 then 2, regardless of SDK task scheduling.
+    assert results == [{"call": 1}, {"call": 2}]
+
+
+def test_repeated_concurrent_dispatch_is_deterministic_across_runs() -> None:
+    """The same scripted same-stage batch, run several times, must always
+    produce the same fixture assignment -- proves the result does not
+    depend on asyncio task-scheduling variance."""
+
+    from agentcheck.domain import SimulatedToolOutcome, SimulatedToolStatus, ToolFixture
+    from agentcheck.runner import ToolGateway
+
+    agents = _agents()
+
+    def build_and_run() -> tuple[Any, ...]:
+        @agents.function_tool
+        def refund_order(order_id: str) -> str:
+            raise AssertionError("the original handler was invoked")
+
+        agent = agents.Agent(
+            name="Refunder",
+            instructions="Handle refunds.",
+            tools=[refund_order],
+            model=ScriptedModel(
+                [
+                    [
+                        _tool_call("refund_order", {"order_id": "o"}, "c1"),
+                        _tool_call("refund_order", {"order_id": "o"}, "c2"),
+                    ],
+                    [_message("done")],
+                ]
+            ),
+        )
+        adapter = OpenAIAgentsAdapter()
+        spec = adapter.inspect(agent)
+        fixtures = (
+            ToolFixture(
+                fixture_id="first",
+                tool_name="refund_order",
+                invocation_index=1,
+                outcome=SimulatedToolOutcome(
+                    status=SimulatedToolStatus.SUCCESS, result={"call": 1}
+                ),
+            ),
+            ToolFixture(
+                fixture_id="second",
+                tool_name="refund_order",
+                invocation_index=2,
+                outcome=SimulatedToolOutcome(
+                    status=SimulatedToolStatus.SUCCESS, result={"call": 2}
+                ),
+            ),
+        )
+        gateway = ToolGateway(spec.tools.items, fixtures, world={}, run_id="det-e2e")
+        prepared = adapter.prepare(agent, gateway, world_state=gateway.world)
+        run = asyncio.run(
+            adapter.run(prepared, "refund it twice", run_id="det-e2e-run", max_turns=6)
+        )
+        return tuple(outcome.result["call"] for outcome in run.tool_outcomes)
+
+    results = {build_and_run() for _ in range(8)}
+    assert results == {(1, 2)}
+
+
+def test_same_stage_state_effects_commit_in_decision_order_under_concurrency() -> None:
+    """Two same-stage calls whose fixtures each mutate the same world path
+    must apply in decision order, not completion order: the final state must
+    match what serialized execution in decision order would have produced,
+    every time."""
+
+    from agentcheck.domain import SimulatedToolOutcome, SimulatedToolStatus, ToolFixture, WorldStateEffect
+    from agentcheck.runner import ToolGateway
+
+    agents = _agents()
+
+    @agents.function_tool
+    def reserve_inventory(order_id: str) -> str:
+        raise AssertionError("the original handler was invoked")
+
+    agent = agents.Agent(
+        name="Reserver",
+        instructions="Reserve inventory.",
+        tools=[reserve_inventory],
+        model=ScriptedModel(
+            [
+                [
+                    _tool_call("reserve_inventory", {"order_id": "o"}, "c1"),
+                    _tool_call("reserve_inventory", {"order_id": "o"}, "c2"),
+                ],
+                [_message("done")],
+            ]
+        ),
+    )
+    adapter = OpenAIAgentsAdapter()
+    spec = adapter.inspect(agent)
+    fixtures = (
+        ToolFixture(
+            fixture_id="first",
+            tool_name="reserve_inventory",
+            invocation_index=1,
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS,
+                result={"reserved_by": "first"},
+                state_effects=(WorldStateEffect(path="holder", after="first"),),
+            ),
+        ),
+        ToolFixture(
+            fixture_id="second",
+            tool_name="reserve_inventory",
+            invocation_index=2,
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS,
+                result={"reserved_by": "second"},
+                state_effects=(WorldStateEffect(path="holder", after="second"),),
+            ),
+        ),
+    )
+    gateway = ToolGateway(spec.tools.items, fixtures, world={"holder": None}, run_id="state-e2e")
+    prepared = adapter.prepare(agent, gateway, world_state=gateway.world)
+    asyncio.run(adapter.run(prepared, "reserve it twice", run_id="state-e2e-run", max_turns=6))
+
+    # Decision order was call1 (sets "first") then call2 (sets "second"), so
+    # the final committed value must always be "second" -- never dependent on
+    # which task's commit happened to run first under the event loop.
+    assert gateway.world.get("holder") == "second"

--- a/tests/agentcheck/test_gateway_concurrency.py
+++ b/tests/agentcheck/test_gateway_concurrency.py
@@ -1,0 +1,246 @@
+"""Adversarial coverage for ToolGateway's plan/commit reservation split.
+
+The central claim under test: fixture ownership, invocation-index assignment,
+and budget consumption are decided once, deterministically, when a batch is
+planned -- and nothing about committing those reservations later, in any
+order, can change what was already decided. This is what makes it safe for an
+adapter to let several simulated calls from one launch group be dispatched
+concurrently: whichever one's task happens to run first, the gateway's
+bookkeeping already knows the answer.
+
+No threads, no sleeps, no timing assumptions: every test drives ordering
+explicitly to prove the result does not depend on it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentcheck.domain.agent_spec import ToolDefinition
+from agentcheck.domain.run import ToolOutcomeStatus
+from agentcheck.runner import (
+    FixtureNotFoundError,
+    ToolCallBlockedError,
+    ToolGateway,
+)
+
+
+def _tool(name: str, *, state_changing: bool = True, destructive: bool = False) -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        input_schema={
+            "type": "object",
+            "properties": {"user_id": {"type": "integer"}},
+            "required": ["user_id"],
+            "additionalProperties": False,
+        },
+        state_changing=state_changing,
+        destructive=destructive,
+        replaceable=True,
+    )
+
+
+def _gateway(tools: list[ToolDefinition], fixtures: list[dict[str, Any]]) -> ToolGateway:
+    return ToolGateway(tools, fixtures, world={}, run_id="concurrency-test")
+
+
+# --- fixture/invocation-index assignment is decided at plan time -----------
+
+
+def test_two_calls_to_the_same_tool_get_distinct_invocation_indices_regardless_of_commit_order() -> (
+    None
+):
+    gateway = _gateway(
+        [_tool("delete_user")],
+        [
+            {
+                "fixture_id": "first",
+                "tool_name": "delete_user",
+                "invocation_index": 1,
+                "outcome": {"status": "success", "result": {"call": 1}},
+            },
+            {
+                "fixture_id": "second",
+                "tool_name": "delete_user",
+                "invocation_index": 2,
+                "outcome": {"status": "success", "result": {"call": 2}},
+            },
+        ],
+    )
+    calls = [("delete_user", {"user_id": 7}), ("delete_user", {"user_id": 7})]
+    reservations = gateway.plan_batch(calls)
+
+    assert reservations[0].invocation_index == 1
+    assert reservations[1].invocation_index == 2
+
+    # Commit in reverse order: the *plan* already decided who owns which
+    # fixture, so this must not change which result each call gets.
+    second_outcome = gateway.commit(reservations[1])
+    first_outcome = gateway.commit(reservations[0])
+
+    assert first_outcome.result == {"call": 1}
+    assert second_outcome.result == {"call": 2}
+
+
+def test_a_single_use_fixture_is_never_assigned_to_two_reservations() -> None:
+    """Two same-stage calls competing for one single-use fixture: the second
+    must fail closed at plan time, not race for it at commit time."""
+
+    gateway = _gateway(
+        [_tool("charge_card")],
+        [
+            {
+                "fixture_id": "only-one",
+                "tool_name": "charge_card",
+                "outcome": {"status": "success", "result": {"charged": True}},
+            }
+        ],
+    )
+    calls = [("charge_card", {"user_id": 1}), ("charge_card", {"user_id": 1})]
+    reservations = gateway.plan_batch(calls)
+
+    assert reservations[0].blocked is None
+    assert reservations[1].blocked is not None
+    assert reservations[1].blocked.code == "fixture_not_found"
+
+    first_outcome = gateway.commit(reservations[0])
+    assert first_outcome.result == {"charged": True}
+    with pytest.raises(FixtureNotFoundError):
+        gateway.commit(reservations[1])
+
+
+def test_planning_is_deterministic_and_order_is_not_inferred_from_commit_calls() -> None:
+    """Planning the same batch twice on independent gateways yields identical
+    fixture/invocation-index assignment -- the plan does not consult anything
+    about how or when commit will later be called."""
+
+    def build() -> ToolGateway:
+        return _gateway(
+            [_tool("reserve_inventory")],
+            [
+                {
+                    "fixture_id": f"slot-{index}",
+                    "tool_name": "reserve_inventory",
+                    "invocation_index": index,
+                    "outcome": {"status": "success", "result": {"slot": index}},
+                }
+                for index in (1, 2, 3)
+            ],
+        )
+
+    calls = [("reserve_inventory", {"user_id": 42})] * 3
+    left = build().plan_batch(calls)
+    right = build().plan_batch(calls)
+
+    assert [r.invocation_index for r in left] == [r.invocation_index for r in right]
+    assert [r.blocked for r in left] == [r.blocked for r in right]
+
+
+# --- budget/retry bookkeeping follows decision order, not commit order -----
+
+
+def _signature_status(gateway: ToolGateway, tool_name: str, arguments: dict[str, Any]) -> Any:
+    import json
+
+    key = (tool_name, json.dumps(arguments, sort_keys=True, separators=(",", ":")))
+    return gateway._signature_status.get(key)  # white-box: internal bookkeeping under test
+
+
+def _charge_card_gateway() -> ToolGateway:
+    return _gateway(
+        [_tool("charge_card")],
+        [
+            {
+                "fixture_id": "err",
+                "tool_name": "charge_card",
+                "invocation_index": 1,
+                "outcome": {"status": "error"},
+            },
+            {
+                "fixture_id": "ok",
+                "tool_name": "charge_card",
+                "invocation_index": 2,
+                "outcome": {"status": "success", "result": {"charged": True}},
+            },
+        ],
+    )
+
+
+def test_retry_budget_reflects_decision_order_even_when_committed_in_reverse() -> None:
+    """call1 errors; call2 (same signature, same stage) is planned right
+    after, so its retry check sees call1's decided status immediately --
+    exactly as it would if both had run serially. Which one *commits* first
+    afterwards must not change that."""
+
+    gateway = _charge_card_gateway()
+    calls = [("charge_card", {"user_id": 9}), ("charge_card", {"user_id": 9})]
+    reservations = gateway.plan_batch(calls)
+    assert reservations[0].blocked is None
+    assert reservations[1].blocked is None
+
+    # Decision order already fixed the final signature status.
+    assert _signature_status(gateway, "charge_card", {"user_id": 9}) == ToolOutcomeStatus.SUCCESS
+
+    # Commit call 2 first, then call 1 -- reversed from decision order.
+    second_outcome = gateway.commit(reservations[1])
+    first_outcome = gateway.commit(reservations[0])
+
+    assert first_outcome.status == ToolOutcomeStatus.ERROR
+    assert second_outcome.status == ToolOutcomeStatus.SUCCESS
+
+    # Committing in reverse order must not have disturbed the decision-order
+    # status a later call would see.
+    assert _signature_status(gateway, "charge_card", {"user_id": 9}) == ToolOutcomeStatus.SUCCESS
+
+
+def test_commit_order_cannot_reintroduce_a_stale_retry_budget_charge() -> None:
+    """Guards the specific bug this design exists to prevent: if commit order
+    were allowed to drive `_signature_status` (as it did before this split),
+    committing the erroring call *last* would leave the signature looking
+    like it still needs a retry charge, even though decision order says
+    otherwise."""
+
+    gateway = _charge_card_gateway()
+    calls = [("charge_card", {"user_id": 9}), ("charge_card", {"user_id": 9})]
+    reservations = gateway.plan_batch(calls)
+
+    # Commit the *second* (success) reservation first, then the error.
+    gateway.commit(reservations[1])
+    gateway.commit(reservations[0])
+
+    # If commit order (not decision order) drove `_signature_status`, this
+    # would now read ERROR -- the last one committed -- instead of SUCCESS.
+    assert _signature_status(gateway, "charge_card", {"user_id": 9}) == ToolOutcomeStatus.SUCCESS
+
+
+# --- invoke() stays exactly equivalent to plan_one + commit -----------------
+
+
+def test_invoke_is_still_exactly_plan_one_then_commit() -> None:
+    gateway = _gateway(
+        [_tool("read_balance", state_changing=False)],
+        [
+            {
+                "fixture_id": "f1",
+                "tool_name": "read_balance",
+                "outcome": {"status": "success", "result": {"balance": 5}},
+            }
+        ],
+    )
+    outcome = gateway.invoke("read_balance", {"user_id": 1})
+    assert outcome.result == {"balance": 5}
+    assert outcome.status == ToolOutcomeStatus.SUCCESS
+    assert len(gateway.attempts) == 1
+    assert len(gateway.outcomes) == 1
+
+
+def test_blocked_reservation_from_unknown_tool_still_raises_on_commit() -> None:
+    gateway = _gateway([_tool("read_balance", state_changing=False)], [])
+    reservation = gateway.plan_one("delete_everything", {"user_id": 1})
+    assert reservation.blocked is not None
+    with pytest.raises(ToolCallBlockedError):
+        gateway.commit(reservation)
+    assert len(gateway.attempts) == 1
+    assert gateway.outcomes[0].status == ToolOutcomeStatus.BLOCKED

--- a/tests/agentcheck/test_launch_barrier.py
+++ b/tests/agentcheck/test_launch_barrier.py
@@ -1,0 +1,133 @@
+"""Adversarial coverage for LaunchBarrier: commit order must follow rank,
+never whichever task happens to reach the barrier first.
+
+Every test drives ordering with explicit ``asyncio.Event``/``asyncio.sleep(0)``
+yields rather than real timing, so a fast or slow machine cannot change the
+outcome and there is nothing here for a flaky sleep to depend on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentcheck.runner import LaunchBarrier
+
+
+def test_higher_rank_waits_even_when_it_reaches_the_barrier_first() -> None:
+    """Task for rank 1 does its pre-work fast and arrives at the barrier well
+    before rank 0 even starts -- rank 0 must still commit first."""
+
+    order: list[int] = []
+    barrier = LaunchBarrier(2)
+    rank0_may_start = asyncio.Event()
+
+    async def participant(rank: int, *, delay_start: bool) -> None:
+        if delay_start:
+            await rank0_may_start.wait()
+        await barrier.wait_for_rank(rank)
+        order.append(rank)
+        barrier.release(rank)
+
+    async def scenario() -> None:
+        second = asyncio.create_task(participant(1, delay_start=False))
+        # Let rank 1's task run all the way up to (and block on) the barrier
+        # before rank 0 even begins.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        first = asyncio.create_task(participant(0, delay_start=True))
+        rank0_may_start.set()
+        await asyncio.gather(first, second)
+
+    asyncio.run(scenario())
+    assert order == [0, 1]
+
+
+def test_barrier_orders_three_participants_regardless_of_arrival_order() -> None:
+    order: list[int] = []
+    barrier = LaunchBarrier(3)
+
+    async def participant(rank: int, arrival_yields: int) -> None:
+        for _ in range(arrival_yields):
+            await asyncio.sleep(0)
+        await barrier.wait_for_rank(rank)
+        order.append(rank)
+        barrier.release(rank)
+
+    async def scenario() -> None:
+        # Rank 2 arrives first, rank 0 last -- the reverse of commit order.
+        await asyncio.gather(
+            participant(2, arrival_yields=0),
+            participant(1, arrival_yields=2),
+            participant(0, arrival_yields=4),
+        )
+
+    asyncio.run(scenario())
+    assert order == [0, 1, 2]
+
+
+def test_run_in_order_releases_the_next_rank_even_if_the_action_raises() -> None:
+    barrier = LaunchBarrier(2)
+    order: list[str] = []
+
+    def failing_action() -> None:
+        order.append("rank0-ran")
+        raise RuntimeError("boom")
+
+    def second_action() -> None:
+        order.append("rank1-ran")
+
+    async def scenario() -> None:
+        async def run_rank0() -> None:
+            with pytest.raises(RuntimeError):
+                await barrier.run_in_order(0, failing_action)
+
+        async def run_rank1() -> None:
+            await barrier.run_in_order(1, second_action)
+
+        await asyncio.gather(run_rank0(), run_rank1())
+
+    asyncio.run(scenario())
+    assert order == ["rank0-ran", "rank1-ran"]
+
+
+def test_run_in_order_async_supports_coroutine_actions() -> None:
+    barrier = LaunchBarrier(2)
+    order: list[int] = []
+
+    async def make_action(rank: int):
+        async def action() -> int:
+            await asyncio.sleep(0)
+            order.append(rank)
+            return rank
+
+        return action
+
+    async def scenario() -> None:
+        action1 = await make_action(1)
+        action0 = await make_action(0)
+
+        async def run(rank: int, action):
+            return await barrier.run_in_order_async(rank, action)
+
+        results = await asyncio.gather(run(1, action1), run(0, action0))
+        assert results == [1, 0]
+
+    asyncio.run(scenario())
+    assert order == [0, 1]
+
+
+def test_zero_size_barrier_accepts_no_ranks() -> None:
+    barrier = LaunchBarrier(0)
+    assert barrier.size == 0
+    with pytest.raises(ValueError):
+        asyncio.run(barrier.wait_for_rank(0))
+
+
+def test_out_of_range_rank_is_rejected() -> None:
+    barrier = LaunchBarrier(2)
+    with pytest.raises(ValueError):
+        asyncio.run(barrier.wait_for_rank(2))
+    with pytest.raises(ValueError):
+        barrier.release(-1)

--- a/tests/agentcheck/test_pydantic_ai_adapter.py
+++ b/tests/agentcheck/test_pydantic_ai_adapter.py
@@ -37,6 +37,7 @@ from agentcheck.domain import (
     SimulatedToolStatus,
     ToolFixture,
     ToolOutcomeStatus,
+    WorldStateEffect,
 )
 from agentcheck.runner import ToolGateway
 from agentcheck.runner.budgets import BudgetTracker
@@ -313,7 +314,7 @@ def test_the_prepared_tool_refuses_to_run_outside_adapter_run() -> None:
     safe = prepared.runtime_agent.toolsets[0].tools["cancel_order"]
 
     with pytest.raises(RuntimeError, match="outside adapter.run"):
-        asyncio.run(safe.function(order_id="o_1", reason="x"))
+        asyncio.run(safe.function(None, order_id="o_1", reason="x"))
     assert ORIGINAL_HANDLER_CALLS == []
 
 
@@ -840,3 +841,108 @@ def test_a_plain_agent_passes_preflight() -> None:
     report = PydanticAIAdapter().preflight(_agent(lookup_order, cancel_order))
 
     assert report.supported, [(i.code, i.message) for i in report.issues]
+
+
+# --------------------------------------------------------------------------
+# Concurrent dispatch: PydanticAI runs one response's tool calls concurrently
+# by default (no equivalent of the OpenAI adapter's max_function_tool_
+# concurrency to opt out of). Fixture/invocation-index assignment and
+# world-state commit order must still follow decision order, not whichever
+# task PydanticAI's own executor happens to run first.
+# --------------------------------------------------------------------------
+
+
+def _same_stage_response(name: str, args: dict[str, Any], *, count: int = 2) -> ModelResponse:
+    return ModelResponse(parts=[ToolCallPart(name, dict(args)) for _ in range(count)])
+
+
+def test_same_stage_duplicate_calls_get_correct_fixtures_under_concurrent_dispatch() -> None:
+    """Two same-stage calls to one tool must each receive the fixture
+    matching their decision order, regardless of PydanticAI's own
+    concurrent task scheduling."""
+
+    agent = _agent(cancel_order, model=_script(_same_stage_response("cancel_order", {"order_id": "o", "reason": "dup"}), _text("done")))
+    fixtures = [
+        ToolFixture(
+            fixture_id="first",
+            tool_name="cancel_order",
+            invocation_index=1,
+            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 1}),
+        ),
+        ToolFixture(
+            fixture_id="second",
+            tool_name="cancel_order",
+            invocation_index=2,
+            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 2}),
+        ),
+    ]
+    gateway = ToolGateway(_definitions(agent), fixtures)
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "cancel it twice")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    results = [outcome.result for outcome in run.tool_outcomes]
+    assert results == [{"call": 1}, {"call": 2}]
+
+
+def test_repeated_concurrent_dispatch_is_deterministic_across_runs() -> None:
+    def build_and_run() -> tuple[Any, ...]:
+        agent = _agent(
+            cancel_order,
+            model=_script(_same_stage_response("cancel_order", {"order_id": "o", "reason": "dup"}), _text("done")),
+        )
+        fixtures = [
+            ToolFixture(
+                fixture_id="first",
+                tool_name="cancel_order",
+                invocation_index=1,
+                outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 1}),
+            ),
+            ToolFixture(
+                fixture_id="second",
+                tool_name="cancel_order",
+                invocation_index=2,
+                outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 2}),
+            ),
+        ]
+        gateway = ToolGateway(_definitions(agent), fixtures)
+        prepared = _prepare(agent, gateway)
+        run = _run(prepared, "cancel it twice")
+        return tuple(outcome.result["call"] for outcome in run.tool_outcomes)
+
+    results = {build_and_run() for _ in range(8)}
+    assert results == {(1, 2)}
+
+
+def test_same_stage_state_effects_commit_in_decision_order() -> None:
+    agent = _agent(
+        cancel_order,
+        model=_script(_same_stage_response("cancel_order", {"order_id": "o", "reason": "dup"}), _text("done")),
+    )
+    fixtures = [
+        ToolFixture(
+            fixture_id="first",
+            tool_name="cancel_order",
+            invocation_index=1,
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS,
+                result={"by": "first"},
+                state_effects=(WorldStateEffect(path="holder", after="first"),),
+            ),
+        ),
+        ToolFixture(
+            fixture_id="second",
+            tool_name="cancel_order",
+            invocation_index=2,
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS,
+                result={"by": "second"},
+                state_effects=(WorldStateEffect(path="holder", after="second"),),
+            ),
+        ),
+    ]
+    gateway = ToolGateway(_definitions(agent), fixtures, world={"holder": None})
+    prepared = _prepare(agent, gateway)
+    _run(prepared, "cancel it twice")
+
+    assert gateway.world.get("holder") == "second"


### PR DESCRIPTION
## Summary

Previously, `ToolGateway` was strictly serialized, and that serialization was the only thing keeping fixture assignment, invocation-index bookkeeping, and per-signature retry classification deterministic. This PR makes those correct under real concurrent tool-call dispatch instead of relying on serialization to hide the risk, and enables that dispatch for both supported frameworks.

**Why AgentCheck previously serialized tool execution.** `ToolGateway.invoke()` mutated several pieces of shared state inline — a per-tool invocation counter, a single-use-fixture tracking set, and a per-signature retry-status map — with no synchronization. As long as every call was fully serialized (`max_function_tool_concurrency=1` in the OpenAI adapter), nothing raced. Reading `agents/run_internal/tool_execution.py` (pinned SDK) and `pydantic_ai/_tool_execution.py` (pinned SDK) confirmed both frameworks dispatch a model response's tool-call coroutines via plain `asyncio.create_task`/`asyncio.gather` — cooperative, single-threaded, never real OS threads. That meant the actual risk was never a bytecode-level race; it was that *which* reservation-sensitive decision happened first depended on unrelated task-scheduling order rather than the order the model actually decided the calls in. PydanticAI, notably, already dispatches concurrently **by default** with no equivalent of `max_function_tool_concurrency` to opt out of — this was true before this PR and was unaudited.

**What gateway race risks existed.** Two same-stage calls to one tool could receive fixtures/invocation-indices in whichever order their tasks happened to reach the gateway; two same-stage calls whose fixtures both mutated overlapping simulated state could commit in either order; retry-budget classification for a signature could be corrupted by which of two same-stage duplicate calls happened to record its outcome last.

**Concurrency safety model now in place.** `ToolGateway` splits into a deterministic **plan** phase (`plan_batch`/`plan_one`: budget consumption, invocation index, fixture selection+consumption, resulting status, and per-signature retry classification — all decided strictly in the order calls are given) and a **commit** phase (`commit`: applies a fixture's world-state effects and records the attempt/outcome for one already-planned reservation). `invoke()` is now exactly `commit(plan_one(...))`, verified byte-identical to the prior implementation by the existing gateway suite. A new `LaunchBarrier` (`agentcheck/runner/launch_barrier.py`) — plain `asyncio.Event`s, no thread locks, no sleeps — forces a batch's commits into decision (`rank`) order even when dispatched as genuinely concurrent tasks.

**Fixture assignment stays deterministic** because both adapters now use a hook that sees a model response's *full, ordered* list of tool calls before the framework dispatches any of them as a task — the OpenAI adapter's `on_llm_end`, PydanticAI's `_CapturingModel.request` — and calls `plan_batch` there, in the model's own emission order, before any task exists to race for a reservation.

**OpenAI Agents:** now uses real concurrent dispatch. `max_function_tool_concurrency` moves from the hardcoded `1` to a named constant of `8` — small and explicit, not the SDK's unbounded default, since the actual commit order is forced back to decision order by the barrier regardless of the cap.

**PydanticAI:** was already dispatching concurrently by default; this PR makes that safe rather than merely unaudited. The invoker now takes `ctx: RunContext` (`takes_ctx=True`) to read the framework's real `tool_call_id` (previously a synthetic counter), used to look up its reservation.

**Custom Python agents:** unchanged and explicitly documented as unsupported for concurrent dispatch — there is no hook analogous to the two SDK adapters, since a custom agent's own orchestration decides when to call `ToolRuntime.call`. See the docstring on `_GatewayToolRuntime` and `docs/concurrent-tool-decisions.md`.

**Decision vs. execution concurrency.** Unchanged and still distinct: AgentCheck has understood *decision* concurrency (`same_launch_group`/`observed_before`, from PR #45) since before this milestone. This PR is about *execution* concurrency — whether the framework's dispatch of already-decided calls can be trusted not to corrupt gateway bookkeeping. No new completion-order/interleaving model was added beyond forcing commit order to match decision order; genuine race-condition effects (observing a partial mutation mid-flight) remain out of scope, since the simulated world has no partial states.

**New behavioral guarantees, proven by test:** same-stage duplicate calls get fixtures matching decision order regardless of completion order; world-state effects commit in decision order; the same scripted same-stage batch produces byte-identical results across 8 repeated runs; `no_same_stage_duplicate_action` and `ordering` verdicts are unaffected by which concurrently-dispatched call finishes first; two same-stage calls racing for one single-use fixture fail closed at plan time, not raced for at commit time; same-stage success+error stay independent under real concurrent dispatch.

## Real-world validation

4 targets across 3 public repositories, no provider calls:

| Target | Pinned SHA | Framework | Topology | Result |
|---|---|---|---|---|
| openai/openai-agents-python `examples/customer_service` | `a40ae9803e6b7a79faa246293f56adb100d5868b` | OpenAI Agents | 3-agent handoff (triage→FAQ, triage→seat-booking); destructive `update_seat` | PASS — correct fixture assignment, correct launch-group evidence, no handler executed |
| pydantic/pydantic-ai `examples/weather_agent.py` | `41e503c91ee33a53c4d9529bd1a6425fff69dfca` | PydanticAI | prerequisite/dependent pair (`get_lat_lng`→`get_weather`) | Preflight-refused: uses `deps_type`/`RunContext[Deps]`, correctly outside current adapter support (pre-existing, documented limitation, not a regression) |
| pydantic/pydantic-ai `examples/data_analyst.py` | same | PydanticAI | 3 tools | Same dependency-injection refusal — confirms this is the dominant real-world pattern the adapter doesn't yet support |
| sierra-research/tau-bench retail tool schemas | `59a200c6d575d595120f1cb70fea53cef0632f6b` | OpenAI Agents (reconstructed `FunctionTool`s) | lookup + duplicate destructive `cancel_pending_order` | PASS — correct decision-order fixture assignment for the duplicate pair, no handler executed |

No milestone-related defects found in this pass. One real, pre-existing bug *was* found and fixed while adding the first PydanticAI test to exercise state effects at all (see below) — not from the external campaign, but from this milestone's own test development, which the campaign's questions (specifically "does an adapter lose correctness under a real state-effect path") are exactly aimed at.

## Bugs found and fixed on this branch

1. **PydanticAI transition-ID remap bug (real, pre-existing).** `_Capture.tool_result` stored a fixture's *raw* gateway transition IDs directly on `ToolOutcome`, while `_state_transitions` separately remapped the run's own transitions to canonical run-scoped IDs — so any PydanticAI run producing a state transition failed `CanonicalRun` validation outright. No existing test exercised state effects for this adapter before. Fixed by remapping inside `tool_result` itself, matching how the OpenAI adapter already did it.
2. **`BudgetExceeded.__cause__` chain regression (introduced and caught within this same milestone).** The plan/commit split initially dropped the `from exc` chain when re-raising a blocked reservation, which the custom adapter's termination mapping depends on to report `MAX_TOOL_CALLS`/timeout budgets correctly instead of a generic `ADAPTER_ERROR`. Caught by the existing custom-agent test suite and fixed by preserving the causing exception through the reservation.

## Compatibility

- `GENERATOR_COMPATIBILITY_VERSION` unaffected — this milestone changes execution/dispatch behavior, not generation semantics. No scenario or suite fingerprint moves.
- No serialized contract changes.

## Safety invariants

Verified by the full local suite: original tool handlers never execute (explicit tripwire assertions in every new concurrency test, plus the real-world campaign's tripwired targets), unknown tools/missing fixtures/invalid arguments still fail closed, worker isolation and network deny-by-default untouched, `INCONCLUSIVE`/`INFRA_ERROR` never collapse into `PASS`, no widened wall-clock budget, replay claims unchanged.

## Test plan

- [x] `python -m pytest tests -q -n 2` — 1476 passed, 1 skipped (up from 1455 before this milestone)
- [x] `python -m ruff check agentcheck tests`
- [x] `python -m mypy agentcheck`
- [x] `python -m build`
- [x] New/extended tests: `test_gateway_concurrency.py` (7), `test_launch_barrier.py` (6), plus concurrency-specific additions to `test_behavioral_launch.py` and `test_pydantic_ai_adapter.py` covering fixture-race prevention, decision-order determinism across repeated runs, world-state commit ordering, and same-stage fault independence
- [x] Zero provider spend across both development and the real-world validation campaign

## What remains unsupported

- Custom Python agent concurrent tool dispatch (documented, not built).
- Two different destructive tools targeting a declared shared resource evaluated for conflict — no current contract expresses a resource/entity link between tools; inferring one from names would be exactly the guessing this project's tool-risk work exists to stop.
- Retry-after-concurrent-mutation (needs state versioning the simulated world doesn't have).
- Genuine race-condition/partial-mutation effects — the simulated world has no partial states to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)