### PR TITLE
PydanticAI dependency injection: safe RunContext[Deps] support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ Developer-declared tool risk, an explicit authority precedence for it, and a
 launch-group-aware concurrency oracle. Not yet released as a distribution
 version; recorded here for the next release to pick up.
 
+**PydanticAI dependency injection / `RunContext[Deps]`:** previously rejected
+outright at preflight. Real-world validation found this blocked most
+realistic PydanticAI examples, including both official ones AgentCheck's own
+prior campaign had tried. Now supported: AgentCheck never constructs a real
+dependency object (`deps_type` is a static type annotation the framework
+never instantiates or runtime-validates -- confirmed against the pinned SDK),
+and always passes a fail-closed `_InertDependencies` placeholder as `deps=`
+when it drives a run. The reconstructed tool invoker never reads `ctx.deps`;
+if anything ever did, attribute access on the placeholder raises immediately
+rather than returning fabricated data or reaching a live object. `ctx` itself
+was already excluded from the tool's declared JSON Schema by PydanticAI's own
+schema generation, so no schema-handling code needed to change. A newly
+identified, narrower gap -- a callable `Agent(validation_context=...)`, which
+the framework itself invokes with a `RunContext` -- gets its own new
+preflight rejection; a non-callable value is accepted.
+
+Validated against 8 real public PydanticAI examples (pydantic/pydantic-ai
+`41e503c91ee33a53c4d9529bd1a6425fff69dfca`): `weather_agent.py`,
+`data_analyst.py`, `roulette_wheel.py`, and `rag.py` now inspect, prepare, and
+run correctly end to end (including a cross-turn prerequisite chain and
+same-stage concurrent duplicate calls); `bank_support.py`, `sql_gen.py`, and
+`flight_booking.py` are still correctly refused, for unrelated, pre-existing
+reasons (dynamic instructions / output validators reading dependencies, not
+dependency injection itself); `medical_agent_delegation.py`'s multi-agent
+delegation stays out of scope, as this project's PydanticAI adapter does not
+support multi-agent topology at all. No milestone-related defects found; zero
+provider calls, zero original handler executions across every target.
+
+**Suite identity:** unaffected. `inspect()` (and therefore `spec_id`) is
+unchanged by this milestone; only `preflight()` and how `agent.run()` is
+invoked changed. `GENERATOR_COMPATIBILITY_VERSION` stays `1`.
+
 **Concurrent execution safety:** `ToolGateway` is split into a deterministic
 plan phase (`plan_batch`/`plan_one` -- decides budget consumption, invocation
 index, fixture selection and consumption, and resulting status, strictly in

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -184,6 +184,48 @@ def _schema_validation_errors(schema: Mapping[str, Any], arguments: Any) -> list
     ]
 
 
+class DependencyAccessError(RuntimeError):
+    """Raised when framework or reconstructed-tool code reaches simulated deps."""
+
+
+class _InertDependencies:
+    """Fail-closed stand-in for a PydanticAI agent's declared ``deps_type`` instance.
+
+    AgentCheck never constructs a real dependency object. ``deps_type`` is a
+    static type annotation the framework does not validate at runtime --
+    confirmed against the pinned SDK: ``Agent.run`` never calls ``deps_type()``
+    or isinstance-checks the supplied ``deps``, so any value can be passed
+    through ``RunContext.deps`` safely, whatever the declared type claims.
+    AgentCheck's own reconstructed tool invoker never reads ``ctx.deps`` --
+    ``ToolGateway`` fixtures are the only source of simulated tool behaviour --
+    so this object exists purely to satisfy the framework's ``RunContext.deps``
+    slot. A real attribute access is a sign that something AgentCheck did not
+    intend to run reached a "dependency", and fails loudly rather than
+    fabricating data or reaching a live object (an HTTP client, a database
+    session, credentials, ...).
+
+    Dunder-style lookups (``hasattr(x, "__iter__")`` and similar duck-typing
+    checks a framework might perform) raise a plain ``AttributeError`` instead,
+    so ordinary introspection is not itself treated as a violation -- only a
+    concrete attempt to *use* a dependency is.
+    """
+
+    def __repr__(self) -> str:
+        return "<AgentCheck simulated dependencies: no real dependency object is constructed>"
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        raise DependencyAccessError(
+            f"attempted to access {name!r} on AgentCheck's simulated dependency "
+            "placeholder. AgentCheck does not construct real target "
+            "dependencies (HTTP clients, database sessions, credentials, "
+            "queues, ...); no code path it controls should ever need to reach "
+            "one. If a tool actually ran to produce this, AgentCheck's "
+            "reconstructed invoker was bypassed -- report this as a bug."
+        )
+
+
 def _agent_toolset(target: Any) -> Any | None:
     """The agent's own function toolset, or None when the shape is unexpected."""
 
@@ -1319,16 +1361,30 @@ class PydanticAIAdapter(FrameworkAdapter):
                     location="agent.output_validator",
                 )
             )
-        deps_type = getattr(target, "_deps_type", object)
-        if deps_type is not object and deps_type is not type(None):
+        # deps_type itself is not rejected: it is a static type annotation the
+        # framework never instantiates or validates at runtime (confirmed
+        # against the pinned SDK), so AgentCheck always supplies its own
+        # fail-closed `_InertDependencies` placeholder as `deps=` regardless of
+        # what deps_type declares. See `_InertDependencies` and `adapter.run`.
+        #
+        # `validation_context` is different: the framework's own docs and
+        # source (`Agent._validation_context`, threaded into
+        # `_agent_graph.build_validation_context`) allow it to be a *callable*
+        # taking a `RunContext`, invoked by the framework itself to validate
+        # tool arguments and output -- genuine target code that would run
+        # during a scenario. A non-callable value is inert data passed through
+        # pydantic validation and is not rejected.
+        validation_context = getattr(target, "_validation_context", None)
+        if callable(validation_context):
             issues.append(
                 SupportIssue(
-                    code="dependency_injection_required",
+                    code="unsupported_validation_context",
                     message=(
-                        "The agent declares deps_type, so a run needs dependencies "
-                        "AgentCheck cannot fabricate safely."
+                        "The agent declares a callable validation_context, which "
+                        "is target code the framework invokes with a RunContext "
+                        "during validation and is not replaced by this adapter."
                     ),
-                    location="agent.deps_type",
+                    location="agent.validation_context",
                 )
             )
         root = getattr(target, "_root_capability", None)
@@ -1373,17 +1429,11 @@ class PydanticAIAdapter(FrameworkAdapter):
                 )
             )
         for name, tool in sorted(_agent_tools(target).items()):
-            if getattr(tool, "takes_ctx", False):
-                issues.append(
-                    SupportIssue(
-                        code="tool_requires_run_context",
-                        message=(
-                            "The tool takes a RunContext, which carries target "
-                            "dependencies AgentCheck does not construct."
-                        ),
-                        location=f"agent.tools[{name}]",
-                    )
-                )
+            # A tool taking RunContext is supported: PydanticAI's own schema
+            # generation already excludes `ctx` from `parameters_json_schema`
+            # (verified against the pinned SDK), and the reconstructed
+            # invoker built from that schema never reads `ctx.deps` -- see
+            # `_InertDependencies` and `_make_safe_tool`.
             schema = getattr(getattr(tool, "tool_def", None), "parameters_json_schema", None)
             if not isinstance(schema, Mapping):
                 issues.append(
@@ -1554,7 +1604,11 @@ class PydanticAIAdapter(FrameworkAdapter):
             while True:
                 message_start = len(history)
                 stages_executed += 1
-                result = await agent.run(prompt, message_history=list(history) or None)
+                result = await agent.run(
+                    prompt,
+                    message_history=list(history) or None,
+                    deps=_InertDependencies(),
+                )
                 history = list(result.all_messages())
                 blocked = await _record_blocked_tool_calls(
                     capture, prepared, history, message_start

--- a/docs/pydantic-ai.md
+++ b/docs/pydantic-ai.md
@@ -53,17 +53,40 @@ agent = Agent(
 uses a local `FunctionModel`, needs no API key, and is runnable without a
 provider.
 
-The V1 adapter requires:
+The adapter requires:
 
 - an exact `pydantic_ai.Agent`;
 - static instructions;
 - ordinary function tools with JSON Schema;
-- no `RunContext` / `deps_type` dependency injection;
-- no output validators, target capabilities, event-stream handler, or external
-  toolsets.
+- no output validators, a callable `validation_context`, target capabilities,
+  event-stream handler, or external toolsets.
 
 Those unsupported surfaces are executable target behavior that cannot be
 reconstructed safely. Preflight names each one and refuses the run.
+
+### Dependency injection / `RunContext[Deps]`
+
+`deps_type` and tools that take `ctx: RunContext[Deps]` are supported. Real
+public PydanticAI examples use this pattern heavily, so rejecting it outright
+would leave most realistic agents unevaluable.
+
+AgentCheck never constructs a real dependency object. `deps_type` is a static
+type annotation the framework itself does not instantiate or validate at
+runtime, so AgentCheck always passes its own fail-closed placeholder as
+`deps=` when it drives a run. A tool's reconstructed AgentCheck-owned invoker
+never reads `ctx.deps` — `ToolGateway` fixtures remain the only source of
+simulated tool behavior — so the placeholder is never touched on the intended
+path. If something unexpected ever reached it (an HTTP client, a database
+session, credentials), attribute access raises immediately rather than
+returning fabricated data or reaching a live object. `ctx` itself never
+appears in the declared tool schema or a generated fixture: PydanticAI's own
+schema generation already excludes it.
+
+A callable `validation_context` is different and stays unsupported: unlike
+`deps_type`, it is target code the framework itself invokes with a
+`RunContext` to validate tool arguments and output, so it is rejected the
+same way an output validator is. A non-callable `validation_context` value is
+inert data and is accepted.
 
 ## Configure and run
 

--- a/tests/agentcheck/test_pydantic_ai_adapter.py
+++ b/tests/agentcheck/test_pydantic_ai_adapter.py
@@ -238,7 +238,10 @@ def test_an_output_validator_is_rejected() -> None:
     assert "output_validator" in {issue.code for issue in report.issues}
 
 
-def test_dependency_injection_is_rejected() -> None:
+def test_dependency_injection_and_run_context_tools_pass_preflight() -> None:
+    """AgentCheck never constructs deps_type, so declaring it -- and a tool
+    that takes RunContext -- is safe and supported, not rejected."""
+
     agent = Agent(_script(_text("x")), deps_type=Deps, name="C")
 
     @agent.tool
@@ -247,8 +250,30 @@ def test_dependency_injection_is_rejected() -> None:
 
     codes = {issue.code for issue in PydanticAIAdapter().preflight(agent).issues}
 
-    assert "dependency_injection_required" in codes
-    assert "tool_requires_run_context" in codes
+    assert "dependency_injection_required" not in codes
+    assert "tool_requires_run_context" not in codes
+
+
+def test_a_callable_validation_context_is_rejected() -> None:
+    """Unlike deps_type, a callable validation_context is target code the
+    framework itself invokes with a RunContext -- genuinely unsafe."""
+
+    def validate(ctx: RunContext[Any]) -> Any:  # pragma: no cover
+        raise AssertionError("must not run")
+
+    agent = Agent(_script(_text("x")), validation_context=validate, name="V")
+
+    codes = {issue.code for issue in PydanticAIAdapter().preflight(agent).issues}
+
+    assert "unsupported_validation_context" in codes
+
+
+def test_a_static_validation_context_value_is_not_rejected() -> None:
+    agent = Agent(_script(_text("x")), validation_context={"tenant": "acme"}, name="V")
+
+    codes = {issue.code for issue in PydanticAIAdapter().preflight(agent).issues}
+
+    assert "unsupported_validation_context" not in codes
 
 
 def test_an_unsupported_sdk_version_is_named() -> None:

--- a/tests/agentcheck/test_pydantic_ai_dependency_injection.py
+++ b/tests/agentcheck/test_pydantic_ai_dependency_injection.py
@@ -1,0 +1,442 @@
+"""PydanticAI dependency injection: real-world compatibility, kept safe.
+
+Real-world validation of PR #46 found that `deps_type`/`RunContext[Deps]` is
+the dominant pattern in realistic PydanticAI agents (both official examples
+inspected used it), and AgentCheck rejected all of them outright. This file
+proves the fix is genuinely safe, not merely permissive: every tool handler
+here raises immediately if the original ever runs, and every dependency
+placeholder raises immediately if anything actually reads it.
+
+No provider is contacted anywhere in this file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.messages import ModelResponse, ToolCallPart
+
+from agentcheck.adapters import PydanticAIAdapter
+from agentcheck.adapters.pydantic_ai import DependencyAccessError, _InertDependencies
+from agentcheck.domain import (
+    SimulatedToolOutcome,
+    SimulatedToolStatus,
+    ToolFixture,
+    ToolOutcomeStatus,
+    WorldStateEffect,
+)
+from agentcheck.runner import ToolGateway
+
+from tests.agentcheck.test_pydantic_ai_adapter import (
+    ORIGINAL_HANDLER_CALLS,
+    Deps,
+    _agent,
+    _definitions,
+    _prepare,
+    _run,
+    _same_stage_response,
+    _script,
+    _text,
+)
+
+
+# --- _InertDependencies itself: the fail-closed placeholder -----------------
+
+
+def test_inert_dependencies_blocks_ordinary_attribute_access() -> None:
+    deps = _InertDependencies()
+
+    with pytest.raises(DependencyAccessError, match="client"):
+        deps.client  # noqa: B018 - intentional access under test
+
+    with pytest.raises(DependencyAccessError, match="database"):
+        deps.database.query("select 1")  # never reaches .query
+
+
+def test_inert_dependencies_permits_dunder_duck_typing_checks() -> None:
+    """A framework doing `hasattr(deps, "__iter__")`-style introspection gets
+    an ordinary "no", not a crash -- only a concrete attribute name (a real
+    attempt to *use* a dependency) fails loudly."""
+
+    deps = _InertDependencies()
+
+    assert hasattr(deps, "__iter__") is False
+    assert hasattr(deps, "__len__") is False
+    assert repr(deps) == "<AgentCheck simulated dependencies: no real dependency object is constructed>"
+
+
+def test_inert_dependencies_treats_a_named_attribute_as_a_real_access_attempt() -> None:
+    """Unlike dunder introspection, `hasattr` on an ordinary name is not
+    silently False -- it is exactly the kind of access this must fail loudly
+    on, so `hasattr` itself propagates the error rather than swallowing it."""
+
+    deps = _InertDependencies()
+
+    with pytest.raises(DependencyAccessError):
+        hasattr(deps, "client")
+
+
+def test_inert_dependencies_never_performs_real_io() -> None:
+    """The placeholder itself proves nothing network/filesystem-shaped ever
+    runs -- there is no code path in it that could."""
+
+    deps = _InertDependencies()
+    for name in ("open", "connect", "request", "get", "post", "execute", "fetch"):
+        with pytest.raises(DependencyAccessError):
+            getattr(deps, name)
+
+
+# --- preflight + inspection: ctx is excluded from the model-facing schema --
+
+
+def test_ctx_first_argument_is_excluded_from_the_declared_schema() -> None:
+    agent = _agent()
+
+    @agent.tool
+    def get_weather(ctx: RunContext[Deps], city: str, units: str = "metric") -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    spec = PydanticAIAdapter().inspect(agent)
+    tool = next(item.value for item in spec.tools.items if item.value.name == "get_weather")
+
+    assert set(tool.input_schema["properties"]) == {"city", "units"}
+    assert "ctx" not in tool.input_schema["properties"]
+    assert tool.input_schema["required"] == ["city"]
+
+
+def test_zero_visible_parameters_besides_ctx_yields_an_empty_schema() -> None:
+    agent = _agent()
+
+    @agent.tool
+    def get_user_preferences(ctx: RunContext[Deps]) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    spec = PydanticAIAdapter().inspect(agent)
+    tool = next(item.value for item in spec.tools.items if item.value.name == "get_user_preferences")
+
+    assert tool.input_schema.get("properties", {}) == {}
+
+
+def test_multiple_context_aware_tools_all_pass_preflight() -> None:
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def get_lat_lng(ctx: RunContext[Deps], city: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    @agent.tool
+    def get_weather(ctx: RunContext[Deps], lat: float, lng: float) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    report = PydanticAIAdapter().preflight(agent)
+
+    assert report.supported, [(i.code, i.message) for i in report.issues]
+
+
+# --- end-to-end: reconstructed context-aware tools run safely --------------
+
+
+def test_a_context_aware_read_tool_runs_through_the_gateway_not_the_handler() -> None:
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def get_weather(ctx: RunContext[Deps], city: str) -> str:
+        ORIGINAL_HANDLER_CALLS.append("get_weather")
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(
+        ModelResponse(parts=[ToolCallPart("get_weather", {"city": "NYC"})]), _text("done")
+    )
+    gateway = ToolGateway(
+        _definitions(agent),
+        [ToolFixture(fixture_id="f", tool_name="get_weather", outcome=SimulatedToolOutcome(
+            status=SimulatedToolStatus.SUCCESS, result={"temp_c": 21}
+        ))],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "weather?")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert run.tool_outcomes[0].result == {"temp_c": 21}
+
+
+def test_a_context_aware_state_changing_tool_runs_through_the_gateway() -> None:
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def update_preferences(ctx: RunContext[Deps], units: str) -> str:
+        ORIGINAL_HANDLER_CALLS.append("update_preferences")
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(
+        ModelResponse(parts=[ToolCallPart("update_preferences", {"units": "metric"})]), _text("done")
+    )
+    gateway = ToolGateway(
+        _definitions(agent),
+        [ToolFixture(
+            fixture_id="f",
+            tool_name="update_preferences",
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS,
+                result={"ok": True},
+                state_effects=(WorldStateEffect(path="units", after="metric"),),
+            ),
+        )],
+        world={"units": None},
+    )
+    prepared = _prepare(agent, gateway)
+    _run(prepared, "set units")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert gateway.world.get("units") == "metric"
+    assert len(gateway.state_transitions) == 1
+
+
+def test_a_dependency_access_inside_the_original_handler_would_be_unreachable() -> None:
+    """Even a handler written to legitimately use ctx.deps never runs at all
+    -- the tripwire proves the reconstructed invoker is what actually
+    executes, never the target's function body."""
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def get_secret(ctx: RunContext[Deps], key: str) -> str:
+        ORIGINAL_HANDLER_CALLS.append("get_secret")
+        return ctx.deps.token  # would read a real dependency if this ever ran
+
+    agent.model = _script(ModelResponse(parts=[ToolCallPart("get_secret", {"key": "x"})]), _text("done"))
+    gateway = ToolGateway(
+        _definitions(agent),
+        [ToolFixture(fixture_id="f", tool_name="get_secret", outcome=SimulatedToolOutcome(
+            status=SimulatedToolStatus.SUCCESS, result={"masked": True}
+        ))],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "get it")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert run.tool_outcomes[0].result == {"masked": True}
+
+
+# --- fault families remain reachable for context-aware tools ---------------
+
+
+@pytest.mark.parametrize(
+    "status,kwargs",
+    [
+        (SimulatedToolStatus.ERROR, {"error_code": "boom", "error_message": "boom"}),
+        (SimulatedToolStatus.TIMEOUT, {"error_code": "timeout", "error_message": "timed out"}),
+        (SimulatedToolStatus.EMPTY, {}),
+        (SimulatedToolStatus.MALFORMED, {}),
+        (SimulatedToolStatus.PARTIAL, {}),
+        (SimulatedToolStatus.STALE, {}),
+    ],
+)
+def test_fault_statuses_reach_a_context_aware_tool(status: SimulatedToolStatus, kwargs: dict[str, Any]) -> None:
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def get_weather(ctx: RunContext[Deps], city: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(ModelResponse(parts=[ToolCallPart("get_weather", {"city": "NYC"})]), _text("done"))
+    gateway = ToolGateway(
+        _definitions(agent),
+        [ToolFixture(fixture_id="f", tool_name="get_weather", outcome=SimulatedToolOutcome(status=status, **kwargs))],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "weather?")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert run.tool_outcomes[0].status == status
+
+
+def test_ambiguous_timeout_still_applies_to_a_destructive_context_aware_tool() -> None:
+    from agentcheck.domain import ToolDefinition
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def cancel_subscription(ctx: RunContext[Deps], user_id: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(ModelResponse(parts=[ToolCallPart("cancel_subscription", {"user_id": "u1"})]), _text("done"))
+    definitions = [
+        d.model_copy(update={"state_changing": True, "destructive": True})
+        if isinstance(d, ToolDefinition) and d.name == "cancel_subscription"
+        else d
+        for d in _definitions(agent)
+    ]
+    gateway = ToolGateway(
+        definitions,
+        [ToolFixture(
+            fixture_id="f",
+            tool_name="cancel_subscription",
+            outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.TIMEOUT, error_code="timeout", error_message="timed out"
+            ),
+        )],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "cancel it")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    outcome = run.tool_outcomes[0]
+    assert outcome.status == ToolOutcomeStatus.TIMEOUT
+    assert outcome.error is not None
+    assert outcome.error.code == "ambiguous_timeout"
+
+
+# --- concurrent context-aware tools ------------------------------------------
+
+
+def test_two_context_aware_tools_in_one_launch_group_stay_independent() -> None:
+    """Mirrors the milestone's own example: get_lat_lng + get_user_preferences
+    decided together, both taking RunContext, dispatched concurrently."""
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def get_lat_lng(ctx: RunContext[Deps], city: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    @agent.tool
+    def get_user_preferences(ctx: RunContext[Deps]) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(
+        ModelResponse(
+            parts=[
+                ToolCallPart("get_lat_lng", {"city": "NYC"}, tool_call_id="c1"),
+                ToolCallPart("get_user_preferences", {}, tool_call_id="c2"),
+            ]
+        ),
+        _text("done"),
+    )
+    gateway = ToolGateway(
+        _definitions(agent),
+        [
+            ToolFixture(fixture_id="ll", tool_name="get_lat_lng", outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS, result={"lat": 40.7, "lng": -74.0}
+            )),
+            ToolFixture(fixture_id="prefs", tool_name="get_user_preferences", outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS, result={"units": "imperial"}
+            )),
+        ],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "weather please")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    by_tool = {outcome.tool_name: outcome for outcome in run.tool_outcomes}
+    assert by_tool["get_lat_lng"].result == {"lat": 40.7, "lng": -74.0}
+    assert by_tool["get_user_preferences"].result == {"units": "imperial"}
+
+    # Launch-group evidence must still be correct for context-aware calls.
+    from agentcheck.evaluate.launch import analyze_launches
+
+    analysis = analyze_launches(run)
+    attempts_by_tool = {a.tool_name: a for a in run.tool_attempts}
+    assert analysis.same_launch_group(
+        attempts_by_tool["get_lat_lng"].attempt_id,
+        attempts_by_tool["get_user_preferences"].attempt_id,
+    ) is True
+
+
+def test_two_context_aware_same_stage_calls_get_deterministic_fixtures_regardless_of_order() -> None:
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def cancel_subscription(ctx: RunContext[Deps], user_id: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(_same_stage_response("cancel_subscription", {"user_id": "u1"}), _text("done"))
+    gateway = ToolGateway(
+        _definitions(agent),
+        [
+            ToolFixture(fixture_id="first", tool_name="cancel_subscription", invocation_index=1,
+                        outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 1})),
+            ToolFixture(fixture_id="second", tool_name="cancel_subscription", invocation_index=2,
+                        outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 2})),
+        ],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "cancel it twice")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert [outcome.result for outcome in run.tool_outcomes] == [{"call": 1}, {"call": 2}]
+
+
+def test_repeated_concurrent_context_aware_runs_are_deterministic() -> None:
+    def build_and_run() -> tuple[Any, ...]:
+        agent = _agent(deps_type=Deps)
+
+        @agent.tool
+        def cancel_subscription(ctx: RunContext[Deps], user_id: str) -> str:  # pragma: no cover
+            raise AssertionError("original handler must never run")
+
+        agent.model = _script(_same_stage_response("cancel_subscription", {"user_id": "u1"}), _text("done"))
+        gateway = ToolGateway(
+            _definitions(agent),
+            [
+                ToolFixture(fixture_id="first", tool_name="cancel_subscription", invocation_index=1,
+                            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 1})),
+                ToolFixture(fixture_id="second", tool_name="cancel_subscription", invocation_index=2,
+                            outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 2})),
+            ],
+        )
+        prepared = _prepare(agent, gateway)
+        run = _run(prepared, "cancel it twice")
+        assert ORIGINAL_HANDLER_CALLS == []
+        return tuple(outcome.result["call"] for outcome in run.tool_outcomes)
+
+    results = {build_and_run() for _ in range(8)}
+    assert results == {(1, 2)}
+
+
+# --- prerequisite / dependent chains across turns, with deps ----------------
+
+
+def test_prerequisite_and_dependent_context_aware_calls_in_separate_turns_are_observed_before() -> None:
+    from agentcheck.evaluate.launch import analyze_launches
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def get_lat_lng(ctx: RunContext[Deps], city: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    @agent.tool
+    def get_weather(ctx: RunContext[Deps], lat: float, lng: float) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(
+        ModelResponse(parts=[ToolCallPart("get_lat_lng", {"city": "NYC"}, tool_call_id="c1")]),
+        ModelResponse(parts=[ToolCallPart("get_weather", {"lat": 1.0, "lng": 2.0}, tool_call_id="c2")]),
+        _text("done"),
+    )
+    gateway = ToolGateway(
+        _definitions(agent),
+        [
+            ToolFixture(fixture_id="ll", tool_name="get_lat_lng", outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS, result={"lat": 1.0, "lng": 2.0}
+            )),
+            ToolFixture(fixture_id="w", tool_name="get_weather", outcome=SimulatedToolOutcome(
+                status=SimulatedToolStatus.SUCCESS, result={"temp_c": 10}
+            )),
+        ],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "weather please", max_turns=8)
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    analysis = analyze_launches(run)
+    attempts_by_tool = {a.tool_name: a for a in run.tool_attempts}
+    assert analysis.same_launch_group(
+        attempts_by_tool["get_lat_lng"].attempt_id, attempts_by_tool["get_weather"].attempt_id
+    ) is False
+    assert analysis.observed_before(
+        attempts_by_tool["get_lat_lng"].attempt_id, attempts_by_tool["get_weather"].attempt_id
+    ) is True


### PR DESCRIPTION
## Summary

**What was unsupported.** `deps_type` and any tool taking `ctx: RunContext[Deps]` were rejected outright at preflight. Real-world validation in PR #46 found both official PydanticAI examples it tried (`weather_agent.py`, `data_analyst.py`) blocked by exactly this.

**Real examples that proved the gap.** `pydantic/pydantic-ai` @ `41e503c91ee33a53c4d9529bd1a6425fff69dfca` — dependency injection is the dominant pattern in that repo's own `examples/` directory (`weather_agent.py`, `data_analyst.py`, `bank_support.py`, `sql_gen.py`, `rag.py`, `roulette_wheel.py`, `flight_booking.py`, `medical_agent_delegation.py` all use it).

**Why it's safe to support, not just permissive.** Reading the pinned SDK (2.32.x) establishes that `deps_type` is a static type annotation the framework never instantiates or runtime-validates: `Agent.run()` accepts whatever `deps=` value the *caller* supplies and threads it straight into `RunContext.deps`, with no `isinstance` check anywhere in the run path (there is no call anywhere in the framework that does `self._deps_type(...)`). Since AgentCheck's own adapter is the one calling `agent.run(...)` — not the target's own harness — it fully controls what value tools actually receive as `ctx.deps`, regardless of what `deps_type` claims.

**How dependency objects are prevented from performing real actions.** `_InertDependencies` is a fail-closed placeholder AgentCheck always passes as `deps=`. Its `__getattr__` raises `DependencyAccessError` for any concrete attribute name (an HTTP client, a database session, credentials, a queue, ...), while answering plain dunder-style `hasattr` introspection (`__iter__`, `__len__`, ...) with an ordinary `False` rather than crashing unrelated framework duck-typing. There is no constructor to worry about: AgentCheck never builds a real instance of the declared `deps_type` at all.

**How original handlers remain unreachable.** Unchanged from every existing adapter guarantee: AgentCheck's reconstructed tool invoker replaces the target's function entirely and never calls it. Critically, it also never reads `ctx.deps` itself — `ToolGateway` fixtures remain the only source of simulated tool behavior — so on the intended path `_InertDependencies` is never even touched; it exists purely to satisfy the framework's `RunContext.deps` slot.

**Tool schema handling for `ctx`.** No code changed here at all. PydanticAI's own schema generation already excludes `ctx` from `tool_def.parameters_json_schema` — the same field this adapter already read before this PR — confirmed against the pinned SDK and against a real example (`rag.py`) whose context parameter isn't even named `ctx` (proving exclusion is positional, not name-matched).

**A newly identified, narrower gap fixed alongside this:** `Agent(validation_context=...)` may be a *callable* the framework itself invokes with a `RunContext` to validate tool arguments and output — genuine target code that would run. Unlike `deps_type`, this is rejected with a new `unsupported_validation_context` preflight issue. A non-callable `validation_context` value is inert data and is accepted.

**Concurrent context-aware tools.** No concurrency-specific code changed. `deps` flows entirely through the framework's own `RunContext` construction, outside AgentCheck's `plan_batch`/`commit`/`LaunchBarrier` reservation path added in PR #46, so two context-aware tools decided in one launch group already work correctly — proven by new tests and by the real-world campaign's `weather_agent.py` same-stage duplicate-call test (independent success/error outcomes, correct `tool_call_id` attribution, correct `same_launch_group` evidence).

**State transitions and fault testing.** A context-aware tool with a fixture that produces `state_effects` participates in canonical transitions exactly like any other tool (new test with `WorldStateEffect`). All existing fault statuses (`error`, `timeout`, `empty`, `malformed`, `partial`, `stale`, and destructive-only `ambiguous_timeout`) are proven reachable for a `RunContext`-taking tool.

## Real-world validation

8 targets, `pydantic/pydantic-ai` @ `41e503c91ee33a53c4d9529bd1a6425fff69dfca`, zero provider calls, zero original handler executions:

| Example | deps_type | Tools | Concurrent/multi-tool tested | Result |
|---|---|---|---|---|
| `weather_agent.py` | `Deps(client)` | 2 | Yes — cross-turn prerequisite (`observed_before=True`) + same-stage duplicate calls | PASS |
| `data_analyst.py` | `AnalystAgentDeps` (real methods) | 3 | Yes — 3-tool prerequisite chain, incl. a timeout fault | PASS |
| `roulette_wheel.py` | `Deps(winning_number)` | 1 | No | PASS |
| `rag.py` | `Deps(openai, pool)` | 1 (ctx param named `context`, not `ctx`) | No | PASS — confirms schema exclusion is positional |
| `bank_support.py` | `SupportDependencies(db)` | 1 | not reached | Correctly still refused (`dynamic_instructions`, unrelated) |
| `sql_gen.py` | `Deps` | 0 ctx-tools | not reached | Correctly still refused (`dynamic_instructions`, `output_validator`) |
| `flight_booking.py` | `Deps` | 1 | not reached | Correctly still refused (`output_validator`) |
| `medical_agent_delegation.py` | per-agent | multi-agent | not tested | Out of scope — no multi-agent topology support exists in this adapter, correctly not exercised |

No milestone-related bugs found in this pass.

## Compatibility

- `inspect()` and `spec_id` are unchanged by this milestone — only `preflight()` (two rejections removed, one added) and how `agent.run()` is invoked (a `deps=` argument added) changed. No fingerprint impact for any existing target, with or without dependency injection.
- `GENERATOR_COMPATIBILITY_VERSION` stays `1` — no generation-semantics change.
- No serialized-contract changes.

## Safety invariants

Verified by the full local suite and the real-world campaign: original tool handlers never execute (explicit tripwires in every new test and every real-world target), a real dependency object never enters evaluation (the placeholder is always substituted, regardless of `deps_type`), unknown tools/missing fixtures/invalid arguments still fail closed, worker isolation and network deny-by-default untouched, `INCONCLUSIVE`/`INFRA_ERROR` never collapse into `PASS`.

## Test plan

- [x] `python -m pytest tests -q -n 2` — 1499 passed, 1 skipped (up from 1476 before this milestone)
- [x] `python -m ruff check agentcheck tests`
- [x] `python -m mypy agentcheck`
- [x] `python -m build`
- [x] New: `tests/agentcheck/test_pydantic_ai_dependency_injection.py` (21 tests) — placeholder fail-closed behavior, `ctx` schema exclusion, end-to-end context-aware runs (read + state-changing), all fault statuses, ambiguous-timeout on a destructive context-aware tool, concurrent context-aware same-stage calls (deterministic across 8 repeated runs), cross-turn prerequisite/dependent launch-group evidence
- [x] Updated `tests/agentcheck/test_pydantic_ai_adapter.py` for the intentional preflight behavior change plus new `validation_context` tests
- [x] Zero provider spend across development and the real-world validation campaign

## What remains unsupported

- A callable `validation_context` (genuine target code invoked with a `RunContext`).
- Dynamic instructions, output validators, target capabilities, event-stream handlers, external toolsets — all pre-existing, unrelated to dependency injection.
- Multi-agent/delegation topology in the PydanticAI adapter (not added; out of scope for this milestone).
- Arbitrary/unconstrained dependency simulation beyond the fail-closed placeholder — this is not a general dependency-injection container, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)