### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,24 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
-## Unreleased
+## 0.3.0 (2026-08-26)
 
-Developer-declared tool risk, an explicit authority precedence for it, and a
-launch-group-aware concurrency oracle. Not yet released as a distribution
-version; recorded here for the next release to pick up.
+Three accumulated milestones since 0.2.1: developer-declared tool risk with
+an explicit authority precedence, deterministic concurrent simulated tool
+execution for both supported frameworks, and safe PydanticAI dependency
+injection. A pre-release audit added a cross-milestone integration test
+(declared risk + concurrent dispatch + dependency injection composed on one
+target) and a further real-world validation pass found no release-blocking
+defects, including a real third-party dependency client (an async video-API
+SDK) and two previously-unexercised OpenAI Agents patterns (dynamic tool
+approval callbacks, handoff input filters) that were confirmed already
+correctly refused rather than silently allowed.
+
+**Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1` across this
+entire release. No default-generation behavior changed for a target that
+declares no risk and uses no new opt-in policy pack; where a target
+deliberately opts into new behavior (`derived_tool_risk_v1` against a
+destructive tool), only that target's own suite identity moves, as intended.
 
 **PydanticAI dependency injection / `RunContext[Deps]`:** previously rejected
 outright at preflight. Real-world validation found this blocked most

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.2.1"
+version = "0.3.0"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/agentcheck/test_integration_risk_concurrency_dependency_injection.py
+++ b/tests/agentcheck/test_integration_risk_concurrency_dependency_injection.py
@@ -1,0 +1,179 @@
+"""0.3.0 release-readiness: the three most recent milestones composed together.
+
+PR #45 (developer-declared risk), #46 (concurrent dispatch), and #47
+(PydanticAI dependency injection) were each validated independently. This
+file checks the actual release risk: a real target that exercises all three
+at once, on a single PydanticAI agent with `deps_type` and a `RunContext`-
+taking tool that is declared destructive, called twice in one launch group.
+
+If any milestone silently discarded another's guarantee -- declared risk
+lost across the context-aware reconstruction path, or the same-stage
+duplicate oracle blind to a call that also carries dependency context --
+this is where it would show up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import ModelResponse, ToolCallPart
+
+from agentcheck.adapters.pydantic_ai import PydanticAIAdapter
+from agentcheck.config import ToolRiskDeclaration
+from agentcheck.domain import (
+    ConversationRole,
+    ConversationTurn,
+    OracleProvenance,
+    OracleStrength,
+    RiskAuthority,
+    Scenario,
+    SimulatedToolOutcome,
+    SimulatedToolStatus,
+    ToolFixture,
+    TrajectoryConstraint,
+    TrajectoryConstraintKind,
+    Verdict,
+)
+from agentcheck.evaluate import evaluate_run
+from agentcheck.runner import ToolGateway
+
+from tests.agentcheck.test_pydantic_ai_adapter import (
+    ORIGINAL_HANDLER_CALLS,
+    _agent,
+    _prepare,
+    _run,
+    _same_stage_response,
+    _script,
+    _text,
+)
+
+
+@dataclass
+class Deps:
+    token: str
+
+
+def test_declared_risk_survives_the_context_aware_reconstruction_path() -> None:
+    """A tool whose name reads as a harmless lookup, but is explicitly
+    declared destructive, must keep that authority even though it also takes
+    RunContext[Deps] -- neither milestone may silently override the other."""
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def find_record(ctx: RunContext[Deps], record_id: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    spec = PydanticAIAdapter().inspect(
+        agent,
+        declared_tool_risk={"find_record": ToolRiskDeclaration(destructive=True)},
+    )
+    tool = next(item.value for item in spec.tools.items if item.value.name == "find_record")
+    assertion = next(item for item in spec.tool_risk.items if item.tool_name == "find_record")
+
+    assert tool.destructive is True
+    assert assertion.destructive.authority is RiskAuthority.DEVELOPER_DECLARED
+    assert "ctx" not in tool.input_schema.get("properties", {})
+
+
+def _same_stage_scenario() -> Scenario:
+    return Scenario(
+        scenario_id="di-risk-concurrency-case",
+        title="find_record must not be decided twice in one stage",
+        conversation_turns=(
+            ConversationTurn(turn_id="t1", role=ConversationRole.USER, content="Find it."),
+        ),
+        trajectory_constraints=(
+            TrajectoryConstraint(
+                criterion_id="dup-1",
+                kind=TrajectoryConstraintKind.NO_SAME_STAGE_DUPLICATE_ACTION,
+                description="find_record must not be called twice with identical arguments in one stage.",
+                parameters={"tool_name": "find_record"},
+                oracle_ids=("oracle-dup-1",),
+                required=True,
+            ),
+        ),
+        oracle_provenance=(
+            OracleProvenance(
+                oracle_id="oracle-dup-1",
+                strength=OracleStrength.EXPLICIT_INSTRUCTION,
+                source="The developer declared this same-stage duplicate rule.",
+                confidence=1.0,
+                evidence_ids=("declared-no-same-stage-duplicate",),
+                supports_hard_failure=True,
+            ),
+        ),
+        dimension_tags=("test:di-risk-concurrency",),
+        generation_seed=1,
+    )
+
+
+def test_same_stage_duplicate_oracle_fires_for_a_declared_destructive_context_aware_tool() -> None:
+    """The concurrency oracle from PR #46 must still correctly fire on a
+    tool whose risk was declared (not inferred) and which takes RunContext --
+    composing all three recent milestones on one call."""
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def find_record(ctx: RunContext[Deps], record_id: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(_same_stage_response("find_record", {"record_id": "r1"}), _text("done"))
+    gateway = ToolGateway(
+        [
+            item.value
+            for item in PydanticAIAdapter()
+            .inspect(agent, declared_tool_risk={"find_record": ToolRiskDeclaration(destructive=True)})
+            .tools.items
+        ],
+        [
+            ToolFixture(fixture_id="first", tool_name="find_record", invocation_index=1,
+                        outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 1})),
+            ToolFixture(fixture_id="second", tool_name="find_record", invocation_index=2,
+                        outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"call": 2})),
+        ],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "find it twice")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert [outcome.result for outcome in run.tool_outcomes] == [{"call": 1}, {"call": 2}]
+
+    evaluation = evaluate_run(_same_stage_scenario(), run)
+    assertion = next(item for item in evaluation.assertions if item.assertion_id == "dup-1")
+    assert assertion.result is Verdict.FAIL
+
+
+def test_a_single_declared_destructive_context_aware_call_does_not_false_fail() -> None:
+    """Sanity check on the other side: one call, decided once, must not be
+    mistaken for a same-stage duplicate merely because it is destructive and
+    context-aware."""
+
+    agent = _agent(deps_type=Deps)
+
+    @agent.tool
+    def find_record(ctx: RunContext[Deps], record_id: str) -> str:  # pragma: no cover
+        raise AssertionError("original handler must never run")
+
+    agent.model = _script(
+        ModelResponse(parts=[ToolCallPart("find_record", {"record_id": "r1"})]), _text("done")
+    )
+    gateway = ToolGateway(
+        [
+            item.value
+            for item in PydanticAIAdapter()
+            .inspect(agent, declared_tool_risk={"find_record": ToolRiskDeclaration(destructive=True)})
+            .tools.items
+        ],
+        [ToolFixture(fixture_id="f", tool_name="find_record",
+                     outcome=SimulatedToolOutcome(status=SimulatedToolStatus.SUCCESS, result={"ok": True}))],
+    )
+    prepared = _prepare(agent, gateway)
+    run = _run(prepared, "find it")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    evaluation = evaluate_run(_same_stage_scenario(), run)
+    assertion = next(item for item in evaluation.assertions if item.assertion_id == "dup-1")
+    assert assertion.result is Verdict.PASS


### PR DESCRIPTION
## Summary

Release 0.3.0 of `agentcheck-ai`, accumulating three milestones since the published 0.2.1:

1. **Developer-declared tool risk with explicit authority (#45).** `agentcheck.json` gains an optional `tool_risk` block, with a fixed precedence (developer declaration > genuine framework metadata > inference > unknown) and a new `no_same_stage_duplicate_action` concurrency oracle.
2. **Concurrent execution safety (#46).** `ToolGateway` splits into a deterministic plan/commit model; both the OpenAI Agents adapter (`max_function_tool_concurrency` 1→8) and PydanticAI (already concurrent by default, previously unaudited) now dispatch tool calls as genuinely concurrent asyncio tasks while fixture assignment and world-state commit order stay decision-order deterministic.
3. **Safe PydanticAI dependency injection (#47).** `deps_type`/`RunContext[Deps]` — previously rejected outright — is now supported via a fail-closed `_InertDependencies` placeholder AgentCheck always substitutes, since the framework never instantiates or runtime-validates the declared type.

## Release-readiness work on this branch

- **Cross-milestone integration test** (`test_integration_risk_concurrency_dependency_injection.py`): a PydanticAI agent with `deps_type`, a `RunContext`-taking tool explicitly declared destructive, called twice in one launch group. Confirms declared risk survives the context-aware reconstruction path and the same-stage duplicate oracle still fires correctly — proving the three milestones compose without one silently discarding another's guarantee.
- **A further real-world validation pass** (5 more targets, no provider calls): a real third-party async API client as a PydanticAI dependency (the exact "real client through deps" threat case this milestone exists to prevent) ran safely end-to-end; two previously-unexercised OpenAI Agents SDK patterns — a dynamic tool-approval callback and a handoff input-filter callback, both genuine target code — were confirmed already correctly refused at preflight rather than silently allowed. No release-blocking defects found.

## Compatibility

- `GENERATOR_COMPATIBILITY_VERSION` stays `1` for this entire release. Default generation is byte-identical for a target that declares no risk and opts into no new policy pack. Only a target that deliberately opts into `derived_tool_risk_v1` against a destructive tool sees its own suite identity move (intended — it now asserts something new).
- No serialized-contract changes.
- `inspect()`/`spec_id` are unaffected by the dependency-injection or concurrency work; only `preflight()` and runtime dispatch changed.

## Real-world validation (cumulative across #45–#47 plus this release branch)

Public targets exercised: OpenAI Agents SDK official examples (`customer_service` handoff topology, `human_in_the_loop`), PydanticAI official examples (`weather_agent`, `data_analyst`, `roulette_wheel`, `rag`, `bank_support`, `sql_gen`, `flight_booking`, `medical_agent_delegation`, `twelvelabs_video_agent`), and tau-bench's retail tool schemas. Zero provider calls, zero original target handler executions across every target in every campaign.

## Safety invariants

Verified across the full local suite: original tool handlers never execute, unknown tools/missing fixtures/invalid arguments fail closed, worker isolation and network deny-by-default intact, `INCONCLUSIVE`/`INFRA_ERROR` never collapse into `PASS`, no widened wall-clock budgets, no provider credentials required.

## Test plan

- [x] `python -m pytest tests -q -n 2` — 1502 passed, 1 skipped
- [x] `python -m ruff check agentcheck tests`
- [x] `python -m mypy agentcheck`
- [x] `python -m build` (produces `agentcheck_ai-0.3.0.tar.gz`/`.whl`)
- [x] `python scripts/check_distribution.py` — no unexpected files in either artifact
- [x] Provider spend: $0 across development, three prior milestone campaigns, and this release's validation pass

## What remains unsupported (unchanged from prior milestones, documented)

- Custom Python agent concurrent tool dispatch.
- Cross-tool shared-resource conflict semantics.
- Retry-after-concurrent-mutation / state-versioning.
- Genuine partial-state race effects.
- PydanticAI multi-agent/delegation topology.
- A callable `Agent(validation_context=...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)