### PR TITLE
PydanticAI multi-agent/delegation: audit finds no real gap

### DIFF
--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -1448,7 +1448,16 @@ class PydanticAIAdapter(FrameworkAdapter):
     def describe_topology(
         self, target: Any, *, source: str | None = None
     ) -> dict[str, Any] | None:
-        """No multi-agent topology is supported yet, so none is described."""
+        """No PydanticAI multi-agent topology exists to describe.
+
+        Unlike the OpenAI Agents SDK's `Handoff`, PydanticAI has no
+        framework-level object for "agent delegation" (an ordinary tool whose
+        body calls another `Agent.run()`, already safely unreachable like any
+        other tool body) or "programmatic hand-off" (application code
+        sequencing independent `Agent.run()` calls, which is not a single
+        `Agent` object at all). There is genuinely no structure here for
+        AgentCheck to introspect -- see docs/pydantic-ai.md.
+        """
 
         del target, source
         return None

--- a/docs/pydantic-ai.md
+++ b/docs/pydantic-ai.md
@@ -88,6 +88,34 @@ A callable `validation_context` is different and stays unsupported: unlike
 same way an output validator is. A non-callable `validation_context` value is
 inert data and is accepted.
 
+### Multi-agent patterns ("agent delegation" and "hand-off")
+
+PydanticAI's own documentation names two multi-agent patterns, and neither is
+a framework-level primitive the way the OpenAI Agents SDK's `Handoff` object
+is — there is no distinct type, and no attribute on `Agent` that names either
+pattern:
+
+- **Agent delegation** is an ordinary `@agent.tool` function whose *body*
+  happens to call `await other_agent.run(...)`. The sub-agent reference lives
+  entirely inside source code AgentCheck already replaces and never executes
+  — the delegating tool is indistinguishable from any other tool, and it is
+  already safely unreachable under the same guarantee every other tool has.
+  Nothing about it needs adapter support beyond what already exists, and
+  building a "delegation topology" abstraction for it would be inventing
+  structure the framework itself does not expose.
+- **Programmatic hand-off** is application code — a loop, a
+  human-in-the-loop prompt, arbitrary branching — calling one `Agent.run()`
+  after another. There is no single `Agent` object representing the hand-off
+  at all: it is two or more independent targets, each inspected and prepared
+  on its own. AgentCheck evaluates one exported `pydantic_ai.Agent` per
+  target; representing a hand-off would mean representing the *calling
+  code's* control flow, which is exactly the kind of target-owned
+  orchestration this adapter does not execute.
+
+`describe_topology` returns `None` for every PydanticAI target for this
+reason, not because topology detection is unfinished: there is no framework
+structure to describe.
+
 ## Configure and run
 
 The target directory must exist before `agentcheck init`; the command writes

--- a/tests/agentcheck/test_pydantic_ai_delegation.py
+++ b/tests/agentcheck/test_pydantic_ai_delegation.py
@@ -1,0 +1,140 @@
+"""PydanticAI "agent delegation" / "programmatic hand-off": audit findings.
+
+Reading the pinned SDK's own documentation (docs/multi-agent-applications.md)
+establishes that neither pattern is a framework-level primitive comparable to
+the OpenAI Agents SDK's `Handoff`:
+
+- "Agent delegation" is an ordinary `@agent.tool` function whose *body*
+  happens to call `await other_agent.run(...)`. There is no distinct object
+  type, no registration on the parent `Agent`, and no attribute PydanticAI
+  itself exposes to say "this tool delegates". The sub-agent reference lives
+  entirely inside source code AgentCheck already replaces and never executes.
+- "Programmatic hand-off" is application code (a loop, a human-in-the-loop
+  prompt, arbitrary branching) calling one `Agent.run()` after another. There
+  is no single `Agent` object representing the hand-off at all -- it is two
+  or more independent targets driven by orchestration outside any single
+  `pydantic_ai.Agent`, which is what AgentCheck's PydanticAI adapter inspects
+  and prepares.
+
+Building a "multi-agent topology" abstraction for either pattern would be
+exactly the fake abstraction based on names this project's own standards
+warn against: there is no real structure to introspect, and the delegating
+tool's real behaviour is already unreachable under the existing single-tool
+replacement guarantee. This file proves that directly: a delegating tool
+that genuinely would drive a second real `pydantic_ai.Agent`, with its own
+tripwired tool, never reaches either tripwire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import FunctionModel
+
+from agentcheck.adapters import PydanticAIAdapter
+from agentcheck.domain import SimulatedToolOutcome, SimulatedToolStatus, ToolFixture
+from agentcheck.runner import ToolGateway
+
+from tests.agentcheck.test_pydantic_ai_adapter import (
+    ORIGINAL_HANDLER_CALLS,
+    _prepare,
+    _run,
+    _script,
+)
+
+
+@dataclass
+class Deps:
+    token: str
+
+
+SUB_AGENT_HANDLER_CALLS: list[str] = []
+
+
+def _sub_agent_tripwire_model(messages: list, info) -> ModelResponse:  # type: ignore[no-untyped-def]
+    raise AssertionError("the delegate sub-agent's model must never be invoked")
+
+
+def test_a_delegating_tool_never_reaches_the_sub_agent_it_would_call() -> None:
+    """`joke_factory` here mirrors the SDK's own agent-delegation example
+    exactly: its real body calls a second, independent Agent. Both the
+    parent tool's own tripwire and the sub-agent's model/tool tripwires must
+    stay unreached -- proving the delegation is inert, not merely untested."""
+
+    ORIGINAL_HANDLER_CALLS.clear()
+    SUB_AGENT_HANDLER_CALLS.clear()
+
+    joke_generation_agent = Agent(FunctionModel(_sub_agent_tripwire_model), output_type=list[str])
+
+    @joke_generation_agent.tool_plain
+    def get_jokes(count: int) -> str:  # pragma: no cover
+        SUB_AGENT_HANDLER_CALLS.append("get_jokes")
+        raise AssertionError("the delegate sub-agent's own tool must never run")
+
+    joke_selection_agent = Agent(
+        _script(_message_response("joke_factory", {"count": 3}), _text_response("done")),
+        deps_type=Deps,
+    )
+
+    @joke_selection_agent.tool
+    async def joke_factory(ctx: RunContext[Deps], count: int) -> list[str]:
+        ORIGINAL_HANDLER_CALLS.append("joke_factory")
+        result = await joke_generation_agent.run(f"Please generate {count} jokes.")
+        return result.output
+
+    report = PydanticAIAdapter().preflight(joke_selection_agent)
+    assert report.supported, [(i.code, i.message) for i in report.issues]
+
+    gateway = ToolGateway(
+        [
+            item.value
+            for item in PydanticAIAdapter().inspect(joke_selection_agent).tools.items
+        ],
+        [
+            ToolFixture(
+                fixture_id="f",
+                tool_name="joke_factory",
+                outcome=SimulatedToolOutcome(
+                    status=SimulatedToolStatus.SUCCESS, result=["a simulated joke"]
+                ),
+            )
+        ],
+    )
+    prepared = _prepare(joke_selection_agent, gateway)
+    run = _run(prepared, "tell me a joke")
+
+    assert ORIGINAL_HANDLER_CALLS == []
+    assert SUB_AGENT_HANDLER_CALLS == []
+    assert run.tool_outcomes[0].result == ["a simulated joke"]
+
+
+def test_the_sub_agent_object_is_invisible_to_preflight_and_inspection() -> None:
+    """The parent agent's declared toolset/topology must not be polluted by
+    a sub-agent referenced only from inside a tool body -- there is no
+    connection PydanticAI itself exposes for AgentCheck to find, and none
+    should be invented."""
+
+    joke_generation_agent = Agent(FunctionModel(_sub_agent_tripwire_model), output_type=list[str])
+    joke_selection_agent = Agent(_script(_text_response("unused")))
+
+    @joke_selection_agent.tool
+    async def joke_factory(ctx: RunContext[None], count: int) -> list[str]:  # pragma: no cover
+        result = await joke_generation_agent.run("x")
+        return result.output
+
+    spec = PydanticAIAdapter().inspect(joke_selection_agent)
+
+    assert [item.value.name for item in spec.tools.items] == ["joke_factory"]
+    # No trace of the sub-agent's own tools, name, or model leaks into the
+    # parent's declared surface.
+    assert "get_jokes" not in {item.value.name for item in spec.tools.items}
+
+
+def _message_response(name: str, args: dict) -> ModelResponse:  # type: ignore[type-arg]
+    return ModelResponse(parts=[ToolCallPart(name, args)])
+
+
+def _text_response(value: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(value)])


### PR DESCRIPTION
## Summary

Audited whether PydanticAI's two documented multi-agent patterns ("agent delegation" and "programmatic hand-off") need new AgentCheck adapter support, per the milestone brief. Conclusion, backed by direct evidence from the pinned SDK (`pydantic-ai-slim` 2.32.x): **no real gap exists**.

- Read the pinned SDK's own `docs/multi-agent-applications.md` and inspected `dir(Agent)` directly — there is no framework-level "handoff"/"delegate"/"as_tool" object or method, unlike the OpenAI Agents SDK's `Handoff`.
- **Agent delegation** is an ordinary `@agent.tool` function whose body happens to call `await other_agent.run(...)`. The sub-agent reference lives entirely inside source code AgentCheck already replaces and never executes — already safely unreachable under the existing single-tool-replacement guarantee.
- **Programmatic hand-off** is application code sequencing independent `Agent.run()` calls — not a single `Agent` object at all, so there's nothing for a single-target adapter to represent.

Building a "multi-agent topology" abstraction for either pattern would be exactly the kind of fake abstraction based on names the project's standards warn against — there is no real framework structure to introspect. Zero behavioral code changes were needed.

## Changes

- `agentcheck/adapters/pydantic_ai.py`: `describe_topology` docstring now explains *why* it returns `None` for PydanticAI (no framework topology exists), instead of reading as unfinished work.
- `docs/pydantic-ai.md`: new "Multi-agent patterns" subsection explaining both patterns and why neither needs adapter support.
- `tests/agentcheck/test_pydantic_ai_delegation.py` (new): two proof tests using a real second `pydantic_ai.Agent` with its own tripwired model and tool, invoked from inside a delegating tool's body.
  - `test_a_delegating_tool_never_reaches_the_sub_agent_it_would_call`: asserts the delegating tool's own handler AND the sub-agent's model/tool are never invoked during a simulated run; the fixture-backed result is returned instead.
  - `test_the_sub_agent_object_is_invisible_to_preflight_and_inspection`: asserts the parent agent's declared tool surface contains only `joke_factory`, with no leakage of the sub-agent's own tool name.

## Validation

- `ruff check agentcheck tests` — clean
- `mypy agentcheck` — clean, 97 source files
- Full suite: `1504 passed, 1 skipped` (up from 1502 pre-branch, consistent with the 2 new tests)
- `python -m build` — clean sdist/wheel
- Zero provider calls, zero original-handler executions, zero PyPI publish (this is a milestone PR into `main`, not a release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)