### PR TITLE
Custom agents: async start/resume support (AsyncToolRuntime)

### DIFF
--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -1,10 +1,11 @@
 """AgentCheck: behavioral testing for AI agents."""
 
 from .config import AgentCheckConfig, load_config
-from .custom import CustomAgentProtocol, ToolRuntime, TurnResult
+from .custom import AsyncToolRuntime, CustomAgentProtocol, ToolRuntime, TurnResult
 
 __all__ = [
     "AgentCheckConfig",
+    "AsyncToolRuntime",
     "CustomAgentProtocol",
     "ToolRuntime",
     "TurnResult",

--- a/agentcheck/adapters/custom.py
+++ b/agentcheck/adapters/custom.py
@@ -618,40 +618,13 @@ def _world_snapshot(world: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-class _GatewayToolRuntime:
-    """The ``ToolRuntime`` a custom agent is handed. A bridge, not a second gateway.
+class _BaseGatewayToolRuntime:
+    """Shared plumbing for the sync and async ``ToolRuntime`` implementations.
 
-    Everything that decides what a tool call *means* -- schema validation,
-    fixture selection, invocation-index and prerequisite ordering, world-state
-    effects, the unknown-tool allowlist, the tool-call and retry budgets -- lives
-    in ``ToolGateway`` and is reached by exactly one call to ``invoke`` below.
-    This class adds two things and nothing else: canonical evidence for the
-    attempt and its outcome, and the raise/return split the ``ToolRuntime``
-    contract promises.
-
-    That split is the whole of the policy here:
-
-    * A *simulated* outcome is returned, whatever its status. ``error``,
-      ``timeout``, ``malformed``, ``empty``, ``partial`` and ``stale`` are things
-      a real tool does, so a custom loop must be able to see them and decide.
-    * A *refusal* is raised. An undeclared tool, arguments that violate the
-      declared schema, a missing fixture, an exhausted budget: in each case
-      AgentCheck has no controlled answer, and returning a plausible one would
-      be inventing the tool output that the run is supposed to be evidence
-      about.
-
-    ``call`` is synchronous and, unlike the OpenAI Agents and PydanticAI
-    adapters, this one has no hook that sees a batch of tool calls before
-    dispatch: a custom agent's own orchestration decides, in its own code,
-    when and how to call ``call``. If that orchestration issues concurrent
-    calls itself -- multiple threads, or tasks that actually interleave
-    around a real ``await`` rather than calling this synchronously one at a
-    time -- fixture assignment and invocation-index ordering are not
-    guaranteed to follow any particular order. This is deliberately left
-    unsupported rather than guessed at: a custom agent that wants
-    deterministic concurrent dispatch must issue its own calls to ``call``
-    strictly in the order they were decided, matching what this class was
-    proven safe for. See ``docs/concurrent-tool-decisions.md``.
+    Holds ``__init__`` and the actual gateway-invoking logic (``_do_call``).
+    Neither leaf subclass overrides the other's ``call``, so mypy sees two
+    unrelated, individually consistent method signatures rather than a sync
+    override of an async one or vice versa.
     """
 
     def __init__(
@@ -667,7 +640,7 @@ class _GatewayToolRuntime:
         self._capture_holder = capture_holder
         self._tool_risks = dict(tool_risks)
 
-    def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
+    def _do_call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
         capture = self._capture_holder.get("capture")
         if capture is None:
             raise RuntimeError(
@@ -764,6 +737,69 @@ class _GatewayToolRuntime:
             gateway_metadata=metadata,
         )
         return outcome
+
+
+class _GatewayToolRuntime(_BaseGatewayToolRuntime):
+    """The ``ToolRuntime`` a custom agent is handed. A bridge, not a second gateway.
+
+    Everything that decides what a tool call *means* -- schema validation,
+    fixture selection, invocation-index and prerequisite ordering, world-state
+    effects, the unknown-tool allowlist, the tool-call and retry budgets -- lives
+    in ``ToolGateway`` and is reached by exactly one call to ``invoke`` below.
+    This class adds two things and nothing else: canonical evidence for the
+    attempt and its outcome, and the raise/return split the ``ToolRuntime``
+    contract promises.
+
+    That split is the whole of the policy here:
+
+    * A *simulated* outcome is returned, whatever its status. ``error``,
+      ``timeout``, ``malformed``, ``empty``, ``partial`` and ``stale`` are things
+      a real tool does, so a custom loop must be able to see them and decide.
+    * A *refusal* is raised. An undeclared tool, arguments that violate the
+      declared schema, a missing fixture, an exhausted budget: in each case
+      AgentCheck has no controlled answer, and returning a plausible one would
+      be inventing the tool output that the run is supposed to be evidence
+      about.
+
+    ``call`` is synchronous and, unlike the OpenAI Agents and PydanticAI
+    adapters, this one has no hook that sees a batch of tool calls before
+    dispatch: a custom agent's own orchestration decides, in its own code,
+    when and how to call ``call``. If that orchestration issues concurrent
+    calls itself -- multiple threads, or tasks that actually interleave
+    around a real ``await`` rather than calling this synchronously one at a
+    time -- fixture assignment and invocation-index ordering are not
+    guaranteed to follow any particular order. This is deliberately left
+    unsupported rather than guessed at: a custom agent that wants
+    deterministic concurrent dispatch must issue its own calls to ``call``
+    strictly in the order they were decided, matching what this class was
+    proven safe for. See ``docs/concurrent-tool-decisions.md``.
+
+    An agent whose ``start``/``resume`` are coroutine functions is instead
+    handed ``_AsyncGatewayToolRuntime`` (below), which has the same real-thread
+    caveat but a different, provable guarantee for asyncio-native scheduling
+    -- see that class's docstring.
+    """
+
+    def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
+        return self._do_call(name, arguments)
+
+
+class _AsyncGatewayToolRuntime(_BaseGatewayToolRuntime):
+    """The ``AsyncToolRuntime`` given to an async ``start``/``resume`` pair.
+
+    ``call`` here has no ``await`` in its own body -- it returns exactly what
+    the synchronous ``_do_call`` (inherited unchanged) computes. That is the
+    whole of the safety argument: a coroutine with no internal yield point
+    cannot be paused mid-call by the event loop, so however the agent chooses
+    to schedule several of these (sequential ``await``, ``asyncio.gather``,
+    ``asyncio.create_task``) each call still runs to completion, in the order
+    it was scheduled, before the next one's body executes. See
+    ``agentcheck.custom.AsyncToolRuntime`` for what this does and does not
+    claim about concurrency.
+    """
+
+    async def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
+        return self._do_call(name, arguments)
 
 
 # ---------------------------------------------------------------------------
@@ -1173,6 +1209,7 @@ class CustomAgentAdapter(FrameworkAdapter):
     def _turn_method_issues(target: Any) -> list[SupportIssue]:
         issues: list[SupportIssue] = []
         expected_arity = {"start": _START_ARITY, "resume": _RESUME_ARITY}
+        found_methods: dict[str, Any] = {}
         for name in _REQUIRED_TURN_METHODS:
             method = _turn_method(target, name)
             if method is None or not callable(method):
@@ -1187,19 +1224,7 @@ class CustomAgentAdapter(FrameworkAdapter):
                     )
                 )
                 continue
-            if _inspect.iscoroutinefunction(method):
-                issues.append(
-                    SupportIssue(
-                        code="async_turn_method",
-                        message=(
-                            f"{name}() is a coroutine function. The custom contract is "
-                            "synchronous, because ToolRuntime.call is; run your own "
-                            "event loop inside the turn instead."
-                        ),
-                        location=name,
-                    )
-                )
-                continue
+            found_methods[name] = method
             arity = _non_self_arity(method)
             if arity == expected_arity[name]:
                 continue
@@ -1219,6 +1244,28 @@ class CustomAgentAdapter(FrameworkAdapter):
                     location=name,
                 )
             )
+        if len(found_methods) == len(_REQUIRED_TURN_METHODS):
+            is_coroutine = {
+                name: _inspect.iscoroutinefunction(method)
+                for name, method in found_methods.items()
+            }
+            if len(set(is_coroutine.values())) > 1:
+                described = ", ".join(
+                    f"{name}() is {'async' if coro else 'sync'}"
+                    for name, coro in sorted(is_coroutine.items())
+                )
+                issues.append(
+                    SupportIssue(
+                        code="mismatched_turn_method_concurrency",
+                        message=(
+                            "start() and resume() must both be synchronous or both be "
+                            f"coroutine functions, not a mix ({described}). AgentCheck "
+                            "picks one ToolRuntime shape (sync or async) for the whole "
+                            "agent and cannot switch between turns."
+                        ),
+                        location="start/resume",
+                    )
+                )
         return issues
 
     # -- preparation --------------------------------------------------------
@@ -1296,7 +1343,12 @@ class CustomAgentAdapter(FrameworkAdapter):
         self._require_matching_surface(gateway, tuple(sorted(tool_risks)))
 
         capture_holder: dict[str, _Capture | None] = {"capture": None}
-        runtime = _GatewayToolRuntime(
+        runtime_cls = (
+            _AsyncGatewayToolRuntime
+            if _inspect.iscoroutinefunction(_turn_method(target, "start"))
+            else _GatewayToolRuntime
+        )
+        runtime = runtime_cls(
             gateway=gateway,
             world_state=world_state,
             capture_holder=capture_holder,
@@ -1431,13 +1483,22 @@ class CustomAgentAdapter(FrameworkAdapter):
         state: Any = None
         last_output: Any = None
         completed = False
+        is_async = _inspect.iscoroutinefunction(agent.start)
         try:
             while True:
                 stages_executed += 1
                 if stages_executed == 1:
-                    result = agent.start(prompt, runtime)
+                    result = (
+                        await agent.start(prompt, runtime)
+                        if is_async
+                        else agent.start(prompt, runtime)
+                    )
                 else:
-                    result = agent.resume(state, prompt, runtime)
+                    result = (
+                        await agent.resume(state, prompt, runtime)
+                        if is_async
+                        else agent.resume(state, prompt, runtime)
+                    )
                 turn_result = _require_turn_result(result, stage=stages_executed)
                 state = turn_result.state
                 last_output = turn_result.output

--- a/agentcheck/custom.py
+++ b/agentcheck/custom.py
@@ -33,7 +33,7 @@ from agentcheck.domain.agent_spec import ToolDefinition
 from agentcheck.domain.run import ToolOutcome
 
 
-__all__ = ["CustomAgentProtocol", "ToolRuntime", "TurnResult"]
+__all__ = ["AsyncToolRuntime", "CustomAgentProtocol", "ToolRuntime", "TurnResult"]
 
 
 @runtime_checkable
@@ -46,7 +46,9 @@ class ToolRuntime(Protocol):
     handlers are not involved at any point.
 
     Synchronous because ``ToolGateway.invoke`` is synchronous, and because a
-    custom loop should not have to become async to be testable.
+    custom loop should not have to become async to be testable. Given to a
+    ``start``/``resume`` pair that is itself synchronous; an async pair is
+    given ``AsyncToolRuntime`` instead.
     """
 
     def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
@@ -58,6 +60,41 @@ class ToolRuntime(Protocol):
         returning a plausible value when the tool is unknown or the arguments do
         not satisfy the declared schema: a harness that invents tool output
         invents passing runs.
+        """
+        ...
+
+
+@runtime_checkable
+class AsyncToolRuntime(Protocol):
+    """The tool runtime given to an async ``start``/``resume`` pair.
+
+    Exists so a custom loop that awaits a real async provider client (or any
+    other real ``await``) does not have to bridge into a synchronous turn
+    boundary to do it. It does **not** add support for genuinely concurrent
+    tool *dispatch*: ``call`` still runs the same synchronous
+    ``ToolGateway`` logic underneath, with no internal ``await`` of its own,
+    so one call always runs to completion before the next begins -- even if
+    the agent issues them through ``asyncio.gather`` or ``asyncio.create_task``.
+    Concurrent-looking syntax therefore still executes, and is fixture- and
+    world-state-deterministic, strictly in the order the calls were made, the
+    same guarantee the synchronous ``ToolRuntime`` gives.
+
+    What this does not, and cannot, give a custom agent is the same-stage
+    "launch group" semantics the OpenAI Agents and PydanticAI adapters support
+    for genuinely concurrent dispatch: those adapters derive decision order
+    from an observed model response listing several tool calls at once. A
+    custom agent's model calls are never observed by AgentCheck at all (see
+    ``CustomAgentAdapter``'s docstring), so there is no evidence from which to
+    derive a "these were decided together" fact -- inventing one would be
+    exactly the kind of guessed verdict this project does not produce. See
+    ``docs/concurrent-tool-decisions.md``.
+    """
+
+    async def call(self, name: str, arguments: Mapping[str, Any]) -> ToolOutcome:
+        """Simulate one tool call and return its canonical outcome.
+
+        Same contract as ``ToolRuntime.call``, awaited instead of called
+        directly.
         """
         ...
 
@@ -86,6 +123,14 @@ class CustomAgentProtocol(Protocol):
     becomes a ``resume`` -- which is what makes a confirmation flow expressible:
     the agent asks, the scenario answers, and the destructive call happens
     afterwards or not at all.
+
+    ``start``/``resume`` may both be ordinary functions, taking ``ToolRuntime``,
+    or both coroutine functions, taking ``AsyncToolRuntime`` instead -- an
+    agent whose own loop needs a real ``await`` (a genuine async provider
+    client, for example) does not have to fake a synchronous boundary around
+    it. The two methods must agree: one sync and one async is a contract
+    mismatch AgentCheck refuses at preflight, not a shape it guesses how to
+    drive.
     """
 
     tools: Sequence[ToolDefinition]

--- a/docs/concurrent-tool-decisions.md
+++ b/docs/concurrent-tool-decisions.md
@@ -92,16 +92,27 @@ sleeps, no timing assumptions.
 
 ## What AgentCheck still cannot do
 
-- **Custom Python agents stay synchronous and unsupported for concurrent
-  dispatch.** `ToolRuntime.call` has no hook analogous to the two adapters'
-  above — a custom agent's own orchestration decides when to call it, and if
-  that orchestration issues genuinely concurrent calls (multiple threads, or
-  tasks that actually interleave around a real `await`), fixture and
+- **Custom Python agents have no launch-group concurrency, sync or async.**
+  A custom `start`/`resume` pair may now be a coroutine function pair, given
+  an `AsyncToolRuntime` whose `call()` can be `await`-ed (see
+  `docs/custom-agents.md`). That closes a *different* gap — an agent whose own
+  loop needs a real `await` no longer has to fake a synchronous boundary — but
+  it does not add dispatch concurrency: `AsyncToolRuntime.call` has no
+  internal `await` of its own, so it always runs to completion before the next
+  call begins, even under `asyncio.gather`/`create_task`. Neither `ToolRuntime`
+  has a hook analogous to the two adapters' above — a custom agent's own
+  orchestration decides when to call it, and if that orchestration reaches a
+  call through real OS threads instead of asyncio, fixture and
   invocation-index ordering are not guaranteed. This is deliberately left
-  unsupported rather than guessed at: see the docstring on
-  `_GatewayToolRuntime` in `agentcheck/adapters/custom.py`. A custom agent
-  that wants determinism must call `ToolRuntime.call` strictly in decision
-  order itself.
+  unsupported rather than guessed at: see the docstrings on
+  `_GatewayToolRuntime` and `_AsyncGatewayToolRuntime` in
+  `agentcheck/adapters/custom.py`. More fundamentally, a custom agent's model
+  calls are never observed by AgentCheck at all (no `model_request`/
+  `model_response` events), so there is no evidence from which to derive that
+  two tool calls were *decided together* — the fact same-stage/launch-group
+  semantics are built on for the other two adapters. Inventing that fact for a
+  custom agent would be exactly the guessed verdict this project does not
+  produce, so it stays unsupported regardless of how the calls are dispatched.
 - **Two different destructive tools targeting the same resource**, launched
   together, evaluated for whether that pairing itself is safe. Doing this
   honestly requires a declared resource/entity link between the two tools,

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -63,9 +63,28 @@ The configured object must expose:
 - `start(message, tools) -> TurnResult`: the opening user turn;
 - `resume(state, message, tools) -> TurnResult`: each later scripted user turn.
 
-Both methods are synchronous. `ToolRuntime.call()` is synchronous, so an async
-turn method is refused during preflight. A custom loop that uses async provider
-code must own and complete that work inside its synchronous turn boundary.
+Both methods are ordinarily synchronous, but may both instead be coroutine
+functions -- `async def start(...)` / `async def resume(...)` -- if the loop
+needs a real `await` (a genuine async provider client, for example). An async
+pair is handed an `AsyncToolRuntime` whose `call()` is `async def` instead of
+`def`; everything else about the contract is unchanged. `start` and `resume`
+must agree: mixing one sync and one async method is refused at preflight as
+`mismatched_turn_method_concurrency`, because AgentCheck picks one
+`ToolRuntime` shape for the whole agent and cannot switch between turns.
+
+`AsyncToolRuntime.call()` does not add support for genuinely concurrent tool
+*dispatch*. It still runs the same synchronous gateway logic underneath, with
+no `await` of its own, so one call always finishes before the next begins --
+even if the agent issues them through `asyncio.gather()` or
+`asyncio.create_task()`. That is a real, provable guarantee (the coroutine has
+no internal yield point, so the event loop cannot pause it mid-call), but it
+is not the same-stage "launch group" concurrency the OpenAI Agents and
+PydanticAI adapters support: those derive decision order from an observed
+model response listing several tool calls at once, and a custom agent's model
+calls are never observed by AgentCheck at all, so there is no equivalent
+evidence to derive that from. See `docs/concurrent-tool-decisions.md`. Real OS
+threads calling into either `ToolRuntime` remain unsupported, exactly as
+before.
 
 `TurnResult.output` may be text or a JSON-compatible structured value.
 `TurnResult.state` is opaque: AgentCheck passes the same object from `start()`

--- a/tests/agentcheck/test_custom_agent_adapter.py
+++ b/tests/agentcheck/test_custom_agent_adapter.py
@@ -418,14 +418,27 @@ def test_preflight_rejects_a_turn_method_with_the_wrong_arity() -> None:
     assert "incompatible_start_signature" in _codes(WrongShape())
 
 
-def test_preflight_rejects_an_async_turn_method() -> None:
-    """``ToolRuntime.call`` is synchronous, so a turn cannot be a coroutine."""
+def test_preflight_rejects_mismatched_sync_and_async_turn_methods() -> None:
+    """start()/resume() must agree: both sync or both coroutine functions."""
 
-    class AsyncAgent(SupportAgent):
+    class MixedAgent(SupportAgent):
         async def start(self, message: str, tools: ToolRuntime) -> TurnResult:  # type: ignore[override]
             ...
 
-    assert "async_turn_method" in _codes(AsyncAgent())
+    assert "mismatched_turn_method_concurrency" in _codes(MixedAgent())
+
+
+def test_preflight_accepts_a_consistently_async_turn_pair() -> None:
+    """A start()/resume() pair that are both coroutine functions is supported."""
+
+    class AsyncAgent(SupportAgent):
+        async def start(self, message: str, tools: ToolRuntime) -> TurnResult:  # type: ignore[override]
+            return SupportAgent.start(self, message, tools)
+
+        async def resume(self, state: Any, message: str, tools: ToolRuntime) -> TurnResult:  # type: ignore[override]
+            return SupportAgent.resume(self, state, message, tools)
+
+    assert _codes(AsyncAgent()) == set()
 
 
 def test_prepare_refuses_an_unsupported_target_before_any_turn_runs() -> None:

--- a/tests/agentcheck/test_custom_agent_async.py
+++ b/tests/agentcheck/test_custom_agent_async.py
@@ -1,0 +1,164 @@
+"""An async ``start``/``resume`` pair: what it can do, and what it still can't.
+
+A custom agent whose own loop needs a real ``await`` (a genuine async
+provider client, for example) no longer has to fake a synchronous boundary
+around it -- ``start``/``resume`` may both be coroutine functions, given an
+``AsyncToolRuntime`` whose ``call()`` is awaited instead of called directly.
+
+That is a real capability gap closed (today, ANY async turn method is
+rejected outright at preflight, even one that never touches concurrent
+dispatch). It is deliberately *not* the same thing as concurrent tool-call
+dispatch: ``AsyncToolRuntime.call`` has no internal ``await`` of its own, so
+even "concurrent-looking" syntax (``asyncio.gather``, ``asyncio.create_task``)
+still executes each call to completion, strictly in the order it was
+scheduled, before the next begins. This file proves both halves: the new
+capability works end to end, and the old determinism guarantee survives
+being wrapped in `gather`-style syntax rather than being silently upgraded
+into something AgentCheck cannot actually prove.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Sequence
+
+from agentcheck import AsyncToolRuntime, TurnResult
+from agentcheck.domain import ToolDefinition
+
+from tests.agentcheck.test_custom_agent_adapter import (
+    CANCEL_ORDER,
+    GET_ORDER,
+    _fixture,
+    _prepare,
+    _run,
+    _turn,
+)
+
+
+def _codes(target: Any) -> set[str]:
+    from agentcheck.adapters import CustomAgentAdapter
+
+    return {issue.code for issue in CustomAgentAdapter().preflight(target).issues}
+
+
+class AsyncSupportAgent:
+    """Mirrors ``SupportAgent`` from test_custom_agent_adapter.py, but async.
+
+    ``start`` awaits a fake async "model" call (``asyncio.sleep(0)``) before
+    calling a tool -- proving a real ``await`` inside the turn boundary works,
+    which is exactly what the synchronous contract could not offer.
+    """
+
+    tools: Sequence[ToolDefinition] = (GET_ORDER, CANCEL_ORDER)
+
+    def __init__(self) -> None:
+        self.turns: list[str] = []
+
+    async def start(self, message: str, tools: AsyncToolRuntime) -> TurnResult:
+        self.turns.append(message)
+        await asyncio.sleep(0)  # stands in for a real async provider call
+        order = await tools.call("get_order", {"order_id": "W123"})
+        status = (order.result or {}).get("status")
+        return TurnResult(
+            output=f"Order W123 is {status}. Cancelling is permanent -- confirm?",
+            state={"order_id": "W123"},
+        )
+
+    async def resume(self, state: Any, message: str, tools: AsyncToolRuntime) -> TurnResult:
+        self.turns.append(message)
+        await asyncio.sleep(0)
+        if "yes" not in message.lower():
+            return TurnResult(output="Leaving the order in place.", state=state)
+        outcome = await tools.call("cancel_order", {"order_id": state["order_id"]})
+        return TurnResult(
+            output=f"Cancelled W123 ({outcome.status.value}).",
+            state={**state, "cancelled": True},
+        )
+
+
+def test_a_consistently_async_agent_is_supported() -> None:
+    assert _codes(AsyncSupportAgent()) == set()
+
+
+def test_an_async_agent_runs_end_to_end_through_the_real_gateway() -> None:
+    agent = AsyncSupportAgent()
+    adapter, prepared, _gateway = _prepare(
+        agent,
+        [
+            _fixture("get_order", {"status": "pending"}),
+            _fixture("cancel_order", {"cancelled": True}),
+        ],
+    )
+    run = _run(
+        adapter,
+        prepared,
+        "Please cancel order W123.",
+        followups=[_turn("t1", "yes, cancel it")],
+    )
+
+    assert agent.turns == ["Please cancel order W123.", "yes, cancel it"]
+    assert [outcome.tool_name for outcome in run.tool_outcomes] == [
+        "get_order",
+        "cancel_order",
+    ]
+    assert run.final_output == "Cancelled W123 (success)."
+
+
+class GatherAgent:
+    """A single turn that issues two independent tool calls via ``asyncio.gather``.
+
+    Nothing here claims the two calls were "decided together" -- there is no
+    model event for AgentCheck to derive that from for a custom agent, so no
+    same-stage/launch-group fact is produced either way. What this proves is
+    narrower and provable: however the agent chooses to *schedule* the two
+    coroutines, they still execute strictly in the order given to ``gather``,
+    every time, because ``AsyncToolRuntime.call`` never yields mid-call.
+    """
+
+    tools: Sequence[ToolDefinition] = (GET_ORDER, CANCEL_ORDER)
+
+    async def start(self, message: str, tools: AsyncToolRuntime) -> TurnResult:
+        first, second = await asyncio.gather(
+            tools.call("get_order", {"order_id": "A"}),
+            tools.call("get_order", {"order_id": "B"}),
+        )
+        return TurnResult(
+            output=f"{first.result} then {second.result}",
+            state={},
+        )
+
+    async def resume(self, state: Any, message: str, tools: AsyncToolRuntime) -> TurnResult:
+        return TurnResult(output="unused", state=state)
+
+
+def test_gather_dispatched_calls_still_execute_in_scheduling_order() -> None:
+    """Repeated runs must all observe the same order: proof, not one sample."""
+
+    for _ in range(25):
+        adapter, prepared, _gateway = _prepare(
+            GatherAgent(),
+            [
+                _fixture("get_order", "order-A", invocation_index=1),
+                _fixture("get_order", "order-B", invocation_index=2),
+            ],
+        )
+        run = _run(adapter, prepared, "look up both orders")
+
+        assert [outcome.result for outcome in run.tool_outcomes] == [
+            "order-A",
+            "order-B",
+        ]
+        assert run.final_output == "order-A then order-B"
+
+
+def test_preflight_reports_a_mismatched_sync_async_pair_before_any_turn_runs() -> None:
+    class Mixed:
+        tools: Sequence[ToolDefinition] = (GET_ORDER,)
+
+        async def start(self, message: str, tools: AsyncToolRuntime) -> TurnResult:  # type: ignore[override]
+            return TurnResult(output="unused")
+
+        def resume(self, state: Any, message: str, tools: Any) -> TurnResult:
+            return TurnResult(output="unused", state=state)
+
+    assert "mismatched_turn_method_concurrency" in _codes(Mixed())

--- a/tests/agentcheck/test_custom_agent_contract.py
+++ b/tests/agentcheck/test_custom_agent_contract.py
@@ -218,7 +218,12 @@ def test_custom_contracts_are_importable_from_both_paths() -> None:
     assert custom.ToolRuntime is ToolRuntime
     assert custom.TurnResult is TurnResult
     assert custom.CustomAgentProtocol is CustomAgentProtocol
-    assert set(custom.__all__) == {"CustomAgentProtocol", "ToolRuntime", "TurnResult"}
+    assert set(custom.__all__) == {
+        "AsyncToolRuntime",
+        "CustomAgentProtocol",
+        "ToolRuntime",
+        "TurnResult",
+    }
 
 
 def test_custom_agent_execution_is_wired_through_the_normal_runtime() -> None:

--- a/tests/agentcheck/test_custom_agent_ux.py
+++ b/tests/agentcheck/test_custom_agent_ux.py
@@ -706,7 +706,9 @@ def test_an_unsafe_tool_schema_is_reported(tmp_path: Path) -> None:
     assert "invalid_tool_schema" in _issue_codes(tmp_path)
 
 
-def test_an_async_turn_method_is_reported(tmp_path: Path) -> None:
+def test_a_mismatched_async_turn_method_is_reported(tmp_path: Path) -> None:
+    """Only `start` turned async, `resume` left sync -- a contract mismatch."""
+
     _write_target(
         tmp_path,
         CUSTOM_TARGET.replace(
@@ -714,7 +716,7 @@ def test_an_async_turn_method_is_reported(tmp_path: Path) -> None:
         ),
     )
 
-    assert "async_turn_method" in _issue_codes(tmp_path)
+    assert "mismatched_turn_method_concurrency" in _issue_codes(tmp_path)
 
 
 def test_no_contract_error_requires_running_the_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Audited whether custom Python agents could safely get an additive async API, per the milestone brief's constraint: only support what can actually be proven safe, and don't fake decision-order concurrency if there's no trustworthy way to establish it.

**Finding**: today, ANY coroutine `start()`/`resume()` is rejected outright at preflight (`async_turn_method`) — even an agent that never touches concurrent dispatch and just needs a real `await` for its own provider client. That's a real, unnecessary gap, closed here. Genuine concurrent *dispatch* with same-stage/launch-group semantics (what the OpenAI Agents and PydanticAI adapters support) is a different question, and the answer there is still no — explained below.

## What's new

- `start()`/`resume()` may now both be coroutine functions, given a new `AsyncToolRuntime` whose `call()` is awaited instead of called directly. The two methods must agree: mixing one sync and one async is refused at preflight as `mismatched_turn_method_concurrency` (AgentCheck picks one `ToolRuntime` shape for the whole agent).
- `agentcheck/adapters/custom.py`: `_GatewayToolRuntime`'s call-handling logic was factored into a shared `_BaseGatewayToolRuntime._do_call` (no behavioral change) so a new `_AsyncGatewayToolRuntime` can reuse it verbatim — `async def call` just returns `self._do_call(...)`, with no `await` in its own body.
- `agentcheck/custom.py`: new `AsyncToolRuntime` protocol, exported from `agentcheck.__init__`.
- `docs/custom-agents.md`, `docs/concurrent-tool-decisions.md`: updated to describe the new capability and its exact boundary.

## What this explicitly does NOT claim

`AsyncToolRuntime.call` has no internal `await` of its own, so even "concurrent-looking" dispatch via `asyncio.gather`/`asyncio.create_task` still executes each call to completion, strictly in the order it was scheduled — proven in `test_gather_dispatched_calls_still_execute_in_scheduling_order`, which runs the same gather-based scenario 25 times and asserts the order never varies.

More fundamentally: a custom agent's model calls are never observed by AgentCheck at all (no `model_request`/`model_response` events), unlike the OpenAI Agents/PydanticAI adapters, which derive "these tool calls were decided together" from an observed model response. There is no equivalent evidence for a custom agent, so no same-stage/launch-group fact is invented — that would be exactly the guessed verdict this project's tool-risk and concurrency work exists to stop producing. Real OS threads calling into either `ToolRuntime` remain unsupported, unchanged from before.

## Changes

- `agentcheck/custom.py`: new `AsyncToolRuntime` protocol; `CustomAgentProtocol` docstring updated.
- `agentcheck/adapters/custom.py`: `_BaseGatewayToolRuntime`/`_GatewayToolRuntime`/`_AsyncGatewayToolRuntime` split; `_turn_method_issues` now accepts a consistently-async pair and rejects only a mismatched one; `prepare()`/`run()` dispatch to the async path when `start` is a coroutine function.
- `agentcheck/__init__.py`: export `AsyncToolRuntime`.
- `docs/custom-agents.md`, `docs/concurrent-tool-decisions.md`: updated.
- `tests/agentcheck/test_custom_agent_async.py` (new): a full async agent run end-to-end through the real gateway (including a real `await asyncio.sleep(0)` standing in for a provider call), the gather-order determinism proof, and a preflight mismatch check.
- `tests/agentcheck/test_custom_agent_adapter.py`, `test_custom_agent_ux.py`, `test_custom_agent_contract.py`: updated to reflect the new preflight codes and the new `__all__` export, replacing the old blanket-rejection assertions.

## Validation

- `ruff check agentcheck tests` — clean
- `mypy agentcheck` — clean, 97 source files
- Full suite: `1509 passed, 1 skipped` (up from 1504, the 5 new tests)
- `python -m build` — clean sdist/wheel
- Zero provider calls, zero breaking changes to the existing synchronous contract, zero PyPI publish (milestone PR into `main`, not a release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)