### PR TITLE
Reliability sweep: misspelled tool_risk keys were a silent no-op

### DIFF
--- a/agentcheck/adapters/base.py
+++ b/agentcheck/adapters/base.py
@@ -78,6 +78,45 @@ def format_support_issues(
     return "\n".join(lines)
 
 
+def require_known_tool_risk_names(
+    spec: "AgentSpec", declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None"
+) -> None:
+    """Refuse a run whose ``tool_risk`` (``agentcheck.json``) names an unknown tool.
+
+    ``declared_risk_for`` looks an override up by name; a key that matches no
+    declared tool is never read by anything downstream, which makes a
+    misspelled tool name in ``tool_risk`` a silently ignored override rather
+    than the risk correction the developer asked for. Called from every
+    adapter's ``prepare``, once inspection has the full declared tool set, so
+    the mismatch is refused before any scenario runs rather than passed
+    through as if it had been applied.
+    """
+
+    from agentcheck.inspect.risk_authority import unmatched_tool_risk_names
+
+    unmatched = unmatched_tool_risk_names(
+        tuple(item.value.name for item in spec.tools.items), declared_tool_risk
+    )
+    if not unmatched:
+        return
+    raise UnsupportedTargetError(
+        [
+            SupportIssue(
+                code="unknown_tool_risk_declaration",
+                message=(
+                    f"agentcheck.json declares tool_risk for {name!r}, which is "
+                    "not one of this agent's declared tools. This override "
+                    "would never be applied, so AgentCheck refuses the run "
+                    "rather than silently ignoring it: fix the tool name, or "
+                    "remove the entry."
+                ),
+                location=f"config.tool_risk.{name}",
+            )
+            for name in unmatched
+        ]
+    )
+
+
 def encode_preflight_report(report: PreflightReport) -> dict[str, Any]:
     """JSON-safe inspect diagnostic payload; not part of AgentSpec."""
 

--- a/agentcheck/adapters/custom.py
+++ b/agentcheck/adapters/custom.py
@@ -98,6 +98,7 @@ from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
 
 from .base import (
     portable_identity,
+    require_known_tool_risk_names,
     AdapterRuntimeError,
     EventSinkProtocol,
     FrameworkAdapter,
@@ -1324,6 +1325,7 @@ class CustomAgentAdapter(FrameworkAdapter):
             identity_locator=identity_locator,
             declared_tool_risk=declared_tool_risk,
         )
+        require_known_tool_risk_names(spec, declared_tool_risk)
 
         tool_risks: dict[str, tuple[bool, bool]] = {}
         for item in spec.tools.items:

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -74,6 +74,7 @@ from agentcheck.runner.tool_gateway import CallReservation
 
 from .base import (
     portable_identity,
+    require_known_tool_risk_names,
     AdapterDependencyError,
     AdapterRuntimeError,
     EventSinkProtocol,
@@ -2685,6 +2686,7 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
             identity_locator=identity_locator,
             declared_tool_risk=declared_tool_risk,
         )
+        require_known_tool_risk_names(spec, declared_tool_risk)
         graph = _reachable_graph(target)
         capture_holder: dict[str, _Capture | None] = {"capture": None}
         tool_risks: dict[str, tuple[bool, bool]] = {}

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
 
 from .base import (
     portable_identity,
+    require_known_tool_risk_names,
     AdapterDependencyError,
     EventSinkProtocol,
     FrameworkAdapter,
@@ -1483,6 +1484,7 @@ class PydanticAIAdapter(FrameworkAdapter):
             identity_locator=identity_locator,
             declared_tool_risk=declared_tool_risk,
         )
+        require_known_tool_risk_names(spec, declared_tool_risk)
 
         capture_holder: dict[str, _Capture | None] = {"capture": None}
         tool_risks: dict[str, tuple[bool, bool]] = {}

--- a/agentcheck/inspect/risk_authority.py
+++ b/agentcheck/inspect/risk_authority.py
@@ -22,7 +22,7 @@ still resolves deterministically.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 from agentcheck.domain import RiskAuthority, RiskAxis, SpecEvidence, ToolRiskAssertion
 
@@ -189,7 +189,29 @@ def declared_risk_for(
     return tool_risk.get(name)
 
 
+def unmatched_tool_risk_names(
+    declared_tool_names: "Sequence[str]",
+    tool_risk: "Mapping[str, ToolRiskDeclaration] | None",
+) -> tuple[str, ...]:
+    """Names in ``tool_risk`` (``agentcheck.json``) that name no declared tool.
+
+    A ``tool_risk`` entry is looked up by name only (see ``declared_risk_for``):
+    a key that matches no declared tool is never read by anything, so a
+    developer who misspells a tool name there gets a silently ignored
+    override rather than the risk correction they asked for. Every adapter's
+    ``prepare`` calls this after inspection has the full declared tool set,
+    and refuses the run rather than proceeding on a declaration that was
+    never actually applied.
+    """
+
+    if not tool_risk:
+        return ()
+    known = set(declared_tool_names)
+    return tuple(name for name in sorted(tool_risk) if name not in known)
+
+
 __all__ = [
     "declared_risk_for",
     "resolve_tool_risk",
+    "unmatched_tool_risk_names",
 ]

--- a/docs/fault-testing.md
+++ b/docs/fault-testing.md
@@ -27,6 +27,10 @@ Where that marking comes from is now explicit, with a fixed precedence:
 
    Each axis (`state_changing`, `destructive`) is independently optional, and a
    declared axis always wins over whatever the adapter would otherwise infer.
+   Every key must name a tool the agent actually declares -- a misspelled name
+   here would otherwise be a silently ignored override, so `prepare` refuses
+   the run instead (`unknown_tool_risk_declaration`), naming the exact key
+   that matched nothing.
 2. **Framework metadata**, when a framework genuinely exposes an authoritative
    side-effect flag. No adapter AgentCheck currently supports does; the tier
    exists in the model so one that does can use it without a new contract.

--- a/tests/agentcheck/test_tool_risk_authority.py
+++ b/tests/agentcheck/test_tool_risk_authority.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 import pytest
 from agents import Agent, function_tool
 
-from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.adapters import CustomAgentAdapter, OpenAIAgentsAdapter, UnsupportedTargetError
 from agentcheck.config import ToolRiskDeclaration
-from agentcheck.domain import RiskAuthority
+from agentcheck.domain import RiskAuthority, ToolDefinition
 from agentcheck.generate.boundaries import build_outcome_variant_cases
-from agentcheck.inspect.risk_authority import resolve_tool_risk
+from agentcheck.inspect.risk_authority import resolve_tool_risk, unmatched_tool_risk_names
 from agentcheck.policies.derived import derive_tool_risk_pack
+
+from tests.agentcheck.test_openai_adapter import RecordingGateway
 
 
 SEED = 1729
@@ -242,3 +244,90 @@ def test_derived_pack_wording_is_unchanged_for_a_purely_inferred_target():
         "delete_nothing must not repeat an identical call: it is inferred "
         "state-changing from its declared name and description."
     )
+
+
+# --- an unmatched tool_risk key is a silent no-op if nothing refuses it -----
+#
+# ``declared_risk_for`` looks an override up by name. A key that names no
+# declared tool is never read by anything: a developer who misspells a tool
+# name in agentcheck.json's tool_risk block gets no error and an override that
+# silently never applies. These prove every adapter's prepare() refuses that,
+# rather than only the resolver-level helper being correct in isolation.
+
+
+def test_unmatched_tool_risk_names_reports_every_name_that_matches_nothing():
+    assert unmatched_tool_risk_names(
+        ("cancel_order", "get_order"),
+        {
+            "cancel_order": ToolRiskDeclaration(destructive=True),
+            "cancle_order": ToolRiskDeclaration(destructive=False),
+            "delete_user": ToolRiskDeclaration(destructive=True),
+        },
+    ) == ("cancle_order", "delete_user")
+
+
+def test_unmatched_tool_risk_names_is_empty_when_every_key_matches():
+    assert (
+        unmatched_tool_risk_names(
+            ("cancel_order",), {"cancel_order": ToolRiskDeclaration(destructive=True)}
+        )
+        == ()
+    )
+
+
+def test_unmatched_tool_risk_names_tolerates_no_declaration_at_all():
+    assert unmatched_tool_risk_names(("cancel_order",), None) == ()
+
+
+def test_a_misspelled_tool_risk_name_refuses_prepare_for_the_openai_adapter() -> None:
+    agent = Agent(
+        name="T",
+        instructions="Assist.",
+        tools=[delete_nothing],
+        model="gpt-4.1-mini",
+    )
+    adapter = OpenAIAgentsAdapter()
+
+    with pytest.raises(UnsupportedTargetError) as excinfo:
+        adapter.prepare(
+            agent,
+            RecordingGateway(),
+            declared_tool_risk={"delet_nothing": ToolRiskDeclaration(destructive=True)},
+        )
+    assert "unknown_tool_risk_declaration" in {issue.code for issue in excinfo.value.issues}
+
+
+CANCEL_ORDER = ToolDefinition(
+    name="cancel_order",
+    description="Cancel one order.",
+    input_schema={
+        "type": "object",
+        "properties": {"order_id": {"type": "string"}},
+        "required": ["order_id"],
+        "additionalProperties": False,
+    },
+    state_changing=True,
+    destructive=True,
+)
+
+
+class _MinimalCustomAgent:
+    tools = (CANCEL_ORDER,)
+
+    def start(self, message, tools):  # pragma: no cover - never reached
+        raise AssertionError("prepare() must refuse before any turn runs")
+
+    def resume(self, state, message, tools):  # pragma: no cover - never reached
+        raise AssertionError("prepare() must refuse before any turn runs")
+
+
+def test_a_misspelled_tool_risk_name_refuses_prepare_for_a_custom_agent() -> None:
+    adapter = CustomAgentAdapter()
+
+    with pytest.raises(UnsupportedTargetError) as excinfo:
+        adapter.prepare(
+            _MinimalCustomAgent(),
+            RecordingGateway(),
+            declared_tool_risk={"cancle_order": ToolRiskDeclaration(destructive=False)},
+        )
+    assert "unknown_tool_risk_declaration" in {issue.code for issue in excinfo.value.issues}


### PR DESCRIPTION
## Summary

Stage F: an evidence-driven reliability sweep across all four supported integration styles (OpenAI Agents SDK, PydanticAI, custom sync agents, custom async agents), per the standing milestone brief's list — false PASS/FAIL, silent no-ops, unreachable policies, misleading coverage, unsupported-reported-as-supported, source/provenance mistakes, fixture reachability, concurrency mistakes, dependency-context mistakes, handoff/delegation mistakes, installation/onboarding, CLI ambiguity.

Method: read every adapter (`openai_agents.py`, `pydantic_ai.py`, `custom.py`), the gateway/launch-barrier/inspect/evaluate/generate layers, and the CLI; then built and ran small offline worked examples through the **real CLI** (`init`/`inspect`/`fixtures init`/`generate`/`test`), not just unit-level adapter calls, specifically probing the boundaries between this session's shipped milestones (declared risk, concurrent dispatch, dependency injection, async custom agents).

## Real defect found and fixed

**A misspelled `tool_risk` key in `agentcheck.json` was a silent no-op.** `declared_risk_for` looks an override up by tool name; nothing anywhere checked that every key in the `tool_risk` block actually names a declared tool. A developer who typos a tool name there (`"cancle_order"` instead of `"cancel_order"`) got no error and no warning — the override was silently never applied.

Reproduced end to end, not just read from code: built a real custom async-agent example, added `"tool_risk": {"cancle_order": {"destructive": false}}` to its config, and ran `agentcheck test .` — all 10 scenarios ran to completion using purely inferred risk, with no indication the declared override was ever ignored. Exactly the "silent no-op" category this sweep was scoped to find.

**Fix**: `unmatched_tool_risk_names` (`agentcheck/inspect/risk_authority.py`) plus a shared `require_known_tool_risk_names` (`agentcheck/adapters/base.py`), called from all three adapters' `prepare()` once inspection has produced the full declared tool set (for OpenAI Agents, this correctly includes every tool reachable through a handoff graph, not just the primary agent's own tools). A mismatched key now refuses the run before any scenario executes, as `unknown_tool_risk_declaration`, naming the exact key.

## Checked and found sound — no fix needed

- **LaunchBarrier / concurrent-dispatch determinism** stays confined to the OpenAI Agents and PydanticAI adapters; grepped to confirm `custom.py` never imports or engages it, sync or async.
- **`describe_topology` on the OpenAI Agents adapter** (which has real `Handoff` objects, unlike PydanticAI per the prior milestone's audit) already has real end-to-end coverage — `test_handoffs.py`, `test_handoff_callbacks.py`, `test_example_handoff_agent.py` — not just unit-level mocking.
- No `TODO`/`FIXME`/`XXX` markers anywhere in `agentcheck/`; the two existing test skips are legitimate runtime-conditional skips, not disabled coverage.
- The custom-agent confirmation-gated action-path-coverage behavior (a scenario with no scripted follow-up reports 0/N tool calls "not exercised") is intentional, documented design — the CLI names it explicitly and the bundled `custom_agent` example is built around exactly this pattern — not a silent no-op.

## Noted, deliberately left alone

`agentcheck.json`'s `suite` field currently only accepts the literal `"account_support_v1"`; a wrong value surfaces as a raw pydantic validation error rather than a friendlier one. Low severity, not a correctness or safety defect — left out of this PR to keep it to the one real defect found, rather than an unrelated error-message refactor.

No fourth framework adapter, no dashboard/UI work, and no forced "capability" additions — this sweep found one real bug and fixed it; it does not manufacture busywork where the audit came back clean.

## Changes

- `agentcheck/inspect/risk_authority.py`: new `unmatched_tool_risk_names`.
- `agentcheck/adapters/base.py`: new shared `require_known_tool_risk_names`.
- `agentcheck/adapters/{custom,openai_agents,pydantic_ai}.py`: call it from `prepare()`.
- `docs/fault-testing.md`: documents the new refusal.
- `tests/agentcheck/test_tool_risk_authority.py`: unit tests for the helper plus `prepare()`-level refusal tests for the OpenAI Agents and custom adapters (the PydanticAI wiring is identical, one-line, and covered by mypy/ruff plus manual verification; a third near-duplicate adapter test wasn't worth the marginal coverage).

## Validation

- `ruff check agentcheck tests` — clean
- `mypy agentcheck` — clean, 97 source files
- Full suite: `1514 passed, 1 skipped` (up from 1509, the 5 new tests)
- `python -m build` — clean sdist/wheel
- Zero provider calls, zero PyPI publish (milestone PR into `main`, not a release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)