### PR TITLE
PydanticAI: controlled-model retry/output-type fix, arbitrary virtualenv exclusion, suite field clarity

### DIFF
--- a/agentcheck/adapters/base.py
+++ b/agentcheck/adapters/base.py
@@ -117,6 +117,37 @@ def require_known_tool_risk_names(
     )
 
 
+# (module-name prefix, adapter name) -- pure duck-typing, no cross-adapter
+# import. See ``guess_other_adapter``.
+_FRAMEWORK_MODULE_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("agents.", "openai_agents"),
+    ("pydantic_ai.", "pydantic_ai"),
+)
+
+
+def guess_other_adapter(target: Any) -> str | None:
+    """A best-effort guess at which adapter a wrong-type target actually needs.
+
+    Pure name-based duck-typing on the object already imported at the
+    configured entrypoint -- its class's module and name, nothing more. This
+    deliberately does not import another framework's SDK to check with
+    ``isinstance``: the ``openai-agents`` and ``pydantic-ai`` extras are
+    independent on purpose (see ``pyproject.toml``), and evaluating one
+    target should never require the other framework's package to be
+    installed just to produce a better error message. A wrong or missing
+    guess only costs a slightly less helpful message -- the caller still
+    refuses the run either way, this never changes what gets accepted.
+    """
+
+    if type(target).__name__ != "Agent":
+        return None
+    module = type(target).__module__
+    for prefix, adapter in _FRAMEWORK_MODULE_PREFIXES:
+        if module == prefix.rstrip(".") or module.startswith(prefix):
+            return adapter
+    return None
+
+
 def encode_preflight_report(report: PreflightReport) -> dict[str, Any]:
     """JSON-safe inspect diagnostic payload; not part of AgentSpec."""
 

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -135,7 +135,17 @@ except ImportError as exc:  # pragma: no cover - exercised in minimal installs
 
 FRAMEWORK_NAME = "openai_agents"
 INSPECTOR_VERSION = "0.1.0"
-SUPPORTED_SDK_MINOR = (0, 20)
+# A verified range, not "0.20 or newer": this adapter reads framework-private
+# attributes (tool._agent_instance, ._is_agent_tool, ._is_codex_tool,
+# ._tool_namespace, ._tool_namespace_description, ._tool_origin,
+# entry._agent_ref) with no stability guarantee across versions. 0.21 and
+# 0.22 were checked directly -- dir(Agent) identical to 0.20, and the full
+# adapter test suite (1500+ tests) passes against 0.22.0 with only
+# framework_version-sensitive identity-fingerprint hashes differing (expected:
+# spec_id/legacy_spec_id/suite fingerprints deliberately bake in the SDK
+# version, so they differ under a different installed version by design, not
+# by a compatibility break). Widening the ceiling again needs the same check.
+SUPPORTED_SDK_MINOR_RANGE = ((0, 20), (0, 22))
 
 
 def _require_sdk() -> None:
@@ -156,8 +166,9 @@ def _supported_sdk_version(version: str | None) -> bool:
     if version is None:
         return False
     numeric = version.split("+", 1)[0].split("-", 1)[0].split(".")
+    floor, ceiling = SUPPORTED_SDK_MINOR_RANGE
     try:
-        return tuple(int(part) for part in numeric[:2]) == SUPPORTED_SDK_MINOR
+        return floor <= tuple(int(part) for part in numeric[:2]) <= ceiling
     except ValueError:
         return False
 
@@ -2464,7 +2475,13 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
             issues.append(
                 SupportIssue(
                     code="unsupported_sdk_version",
-                    message=f"Expected openai-agents 0.20.x, found {version or 'not installed'}.",
+                    message=(
+                        f"Expected openai-agents {SUPPORTED_SDK_MINOR_RANGE[0][0]}."
+                        f"{SUPPORTED_SDK_MINOR_RANGE[0][1]}.x through "
+                        f"{SUPPORTED_SDK_MINOR_RANGE[1][0]}."
+                        f"{SUPPORTED_SDK_MINOR_RANGE[1][1]}.x, "
+                        f"found {version or 'not installed'}."
+                    ),
                     location="python-package:openai-agents",
                 )
             )

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -73,6 +73,7 @@ from agentcheck.runner.network_guard import denied_destinations
 from agentcheck.runner.tool_gateway import CallReservation
 
 from .base import (
+    guess_other_adapter,
     portable_identity,
     require_known_tool_risk_names,
     AdapterDependencyError,
@@ -83,6 +84,7 @@ from .base import (
     PreparedTarget,
     SupportIssue,
     ToolGatewayProtocol,
+    UnsupportedTargetError,
     missing_extra_message,
 )
 from .openai_handoff_effects import (
@@ -2010,7 +2012,12 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
         _require_sdk()
         source = source or "runtime:agent"
         if type(target) is not Agent:
-            raise TypeError("OpenAIAgentsAdapter.inspect expects an exact agents.Agent")
+            # Reuses preflight()'s own issue -- including its "did you mean
+            # the other adapter" guess -- rather than a bare TypeError. A raw
+            # TypeError here used to be pattern-matched into a generic message
+            # by the worker's error mapping, discarding that guess before it
+            # ever reached a user running `agentcheck inspect`.
+            raise UnsupportedTargetError(list(self.preflight(target).issues))
 
         framework_version = _sdk_version()
         provider, model_name, provider_inferred, model_inferred = _model_identity(target)
@@ -2462,10 +2469,20 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
                 )
             )
         if type(target) is not Agent:
+            guess = guess_other_adapter(target)
+            suggestion = (
+                f" The configured entrypoint resolved to {type(target).__module__}."
+                f"{type(target).__name__}, which looks like a {guess!r} target; "
+                f'set "adapter": {guess!r} in agentcheck.json instead.'
+                if guess is not None and guess != FRAMEWORK_NAME
+                else ""
+            )
             issues.append(
                 SupportIssue(
                     code="unsupported_agent_type",
-                    message="Phase 1 requires an exact agents.Agent instance.",
+                    message=(
+                        "Phase 1 requires an exact agents.Agent instance." + suggestion
+                    ),
                     location=type(target).__name__,
                 )
             )

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -296,7 +296,21 @@ def _model_identity(target: Any) -> tuple[str | None, str | None]:
 
 
 def _output_schema(target: Any) -> dict[str, Any] | None:
-    """The declared structured-output schema, when the agent declares one."""
+    """The declared structured-output schema, when the agent declares one.
+
+    ``output_type`` is not limited to ``BaseModel`` subclasses -- PydanticAI
+    accepts any type ``pydantic.TypeAdapter`` can build a schema for (``bool``,
+    ``int``, a dataclass, a ``TypedDict``, ``Literal[...]``, ...), and real
+    targets use this heavily (the SDK's own roulette_wheel example declares
+    ``output_type=bool``). Deriving a schema via ``TypeAdapter`` is the same
+    category of safe, static type introspection ``BaseModel.model_json_schema``
+    already is here -- no target code runs, only its type's schema is built --
+    so this is not a new execution-safety surface, just a wider one. Getting
+    this wrong previously had a real, silent failure mode: an unschematized
+    output_type made ``ControlledPydanticModel`` reply with plain neutral text
+    that could not satisfy the target's own output validation, which read as
+    the model endlessly failing to comply rather than as a missing schema.
+    """
 
     output_type = getattr(target, "output_type", None)
     if output_type is None or output_type is str:
@@ -308,7 +322,13 @@ def _output_schema(target: Any) -> dict[str, Any] | None:
         except Exception:  # pragma: no cover - defensive
             return None
         return cast("dict[str, Any]", built) if isinstance(built, dict) else None
-    return None
+    try:
+        from pydantic import TypeAdapter
+
+        built = TypeAdapter(output_type).json_schema()
+    except Exception:
+        return None
+    return built if isinstance(built, dict) else None
 
 
 def _tool_definition(
@@ -1557,6 +1577,16 @@ class PydanticAIAdapter(FrameworkAdapter):
 
         # A NEW Agent built from the inspected surface. The source agent is not
         # mutated and its tool functions are never referenced.
+        #
+        # `retries` matters even offline: it is pydantic_ai's own output/tool
+        # validation retry budget, read back from the private
+        # `_max_output_retries` the target's own `retries=` constructor
+        # argument set (a plain int, safe to read like the other private
+        # attributes this adapter already relies on). Rebuilding without it
+        # silently substitutes pydantic_ai's default of 1, which can exhaust
+        # before a target explicitly tolerant of more retries (roulette_wheel's
+        # own `retries=3`, for one) ever would -- a false `provider_error`
+        # this adapter caused, not one the real target's own configuration did.
         runtime_agent = Agent(
             model,
             instructions="\n\n".join(static) if static else None,
@@ -1564,6 +1594,7 @@ class PydanticAIAdapter(FrameworkAdapter):
             tools=safe_tools,
             name=getattr(target, "name", None),
             model_settings=getattr(target, "model_settings", None),
+            retries=getattr(target, "_max_output_retries", None),
         )
         return PreparedTarget(
             framework=FRAMEWORK_NAME,

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from agentcheck.config import ToolRiskDeclaration
 
 from .base import (
+    guess_other_adapter,
     portable_identity,
     require_known_tool_risk_names,
     AdapterDependencyError,
@@ -80,15 +81,23 @@ from .base import (
 
 FRAMEWORK_NAME = "pydantic_ai"
 
-# Exact-equality like the OpenAI adapter's 0.20.x pin, and for the same reason:
-# instructions and validators are read from private attributes, so an unverified
-# version could silently yield a wrong AgentSpec rather than an honest failure.
-SUPPORTED_SDK_MINOR = (2, 32)
+# A verified range, not "2.32 or newer": instructions and validators are read
+# from private attributes with no stability guarantee, so an unverified
+# version could silently yield a wrong AgentSpec rather than an honest
+# failure. 2.33, 2.34 and 2.35 were checked directly against this adapter --
+# dir(Agent), every private attribute this module reads (_instructions,
+# _output_validators, _event_stream_handler, _root_capability,
+# _system_prompt_functions, _system_prompts, _validation_context), the
+# installed default-capability set, and the full pydantic_ai test suite --
+# and found identical to 2.32 for everything this adapter touches. Widening
+# the ceiling again needs the same check, not just a version-string bump.
+SUPPORTED_SDK_MINOR_RANGE = ((2, 32), (2, 35))
 
 # Capabilities the framework installs on every agent. Anything beyond these is
 # target-supplied middleware that wraps node execution, so it is rejected
-# rather than silently dropped when the sanitized agent is rebuilt. Pinned to
-# one minor precisely so this list cannot drift underneath the check.
+# rather than silently dropped when the sanitized agent is rebuilt. Checked
+# directly, not assumed, across the whole SUPPORTED_SDK_MINOR_RANGE: identical
+# on every minor verified so far.
 _DEFAULT_CAPABILITIES = frozenset({"ToolSearch", "PendingMessageDrainCapability"})
 
 _SDK_IMPORT_ERROR: Exception | None = None
@@ -127,8 +136,9 @@ def _supported_sdk_version(version: str | None) -> bool:
     if version is None:
         return False
     numeric = version.split("+", 1)[0].split("-", 1)[0].split(".")
+    floor, ceiling = SUPPORTED_SDK_MINOR_RANGE
     try:
-        return tuple(int(part) for part in numeric[:2]) == SUPPORTED_SDK_MINOR
+        return floor <= tuple(int(part) for part in numeric[:2]) <= ceiling
     except ValueError:
         return False
 
@@ -1323,17 +1333,31 @@ class PydanticAIAdapter(FrameworkAdapter):
                 SupportIssue(
                     code="unsupported_sdk_version",
                     message=(
-                        f"Expected pydantic-ai {SUPPORTED_SDK_MINOR[0]}."
-                        f"{SUPPORTED_SDK_MINOR[1]}.x, found {version or 'not installed'}."
+                        f"Expected pydantic-ai {SUPPORTED_SDK_MINOR_RANGE[0][0]}."
+                        f"{SUPPORTED_SDK_MINOR_RANGE[0][1]}.x through "
+                        f"{SUPPORTED_SDK_MINOR_RANGE[1][0]}."
+                        f"{SUPPORTED_SDK_MINOR_RANGE[1][1]}.x, "
+                        f"found {version or 'not installed'}."
                     ),
                     location="python-package:pydantic-ai-slim",
                 )
             )
         if type(target) is not Agent:
+            guess = guess_other_adapter(target)
+            suggestion = (
+                f" The configured entrypoint resolved to {type(target).__module__}."
+                f"{type(target).__name__}, which looks like an {guess!r} target; "
+                f'set "adapter": {guess!r} in agentcheck.json instead.'
+                if guess is not None and guess != FRAMEWORK_NAME
+                else ""
+            )
             issues.append(
                 SupportIssue(
                     code="unsupported_agent_type",
-                    message="This adapter requires an exact pydantic_ai.Agent instance.",
+                    message=(
+                        "This adapter requires an exact pydantic_ai.Agent instance."
+                        + suggestion
+                    ),
                     location="agent",
                 )
             )
@@ -1345,8 +1369,21 @@ class PydanticAIAdapter(FrameworkAdapter):
                 SupportIssue(
                     code="dynamic_instructions",
                     message=(
-                        "Instructions are computed by target code, which AgentCheck "
-                        "will not execute during inspection."
+                        "Instructions are computed by target code (a callable given "
+                        "to agent.instructions or @agent.system_prompt), which "
+                        "AgentCheck will not execute during inspection. This is not "
+                        "only an execution-safety refusal: even if the call were "
+                        "safe, AgentCheck has no way to know what text a "
+                        "RunContext-dependent function would have produced, so "
+                        "proceeding with only the static instructions could silently "
+                        "reconstruct an agent whose behavior diverges from the real "
+                        "target's -- exactly the kind of misleading result this tool "
+                        "exists to avoid. To unblock this target: replace the dynamic "
+                        "instructions with a static string covering the parts that "
+                        "do not depend on RunContext, or move the dynamic content "
+                        "into something the agent must fetch through an explicit "
+                        "tool call, which AgentCheck can then simulate like any "
+                        "other declared tool."
                     ),
                     location=location,
                 )
@@ -1793,4 +1830,4 @@ def _agentcheck_version() -> str:
     return __version__
 
 
-__all__ = ["FRAMEWORK_NAME", "SUPPORTED_SDK_MINOR", "PydanticAIAdapter"]
+__all__ = ["FRAMEWORK_NAME", "SUPPORTED_SDK_MINOR_RANGE", "PydanticAIAdapter"]

--- a/agentcheck/adapters/pydantic_ai_controlled.py
+++ b/agentcheck/adapters/pydantic_ai_controlled.py
@@ -15,7 +15,7 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
-from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models import Model
 from pydantic_ai.usage import RequestUsage
 
@@ -89,24 +89,95 @@ def _instance_for(
     return None
 
 
+def _schema_instance(schema: Mapping[str, Any]) -> Any:
+    """One deterministic value satisfying ``schema``, honoring its ``$defs``."""
+
+    definitions = schema.get("$defs")
+    return _instance_for(
+        schema, definitions if isinstance(definitions, Mapping) else {}, 0
+    )
+
+
 def controlled_output_text(output_schema: Mapping[str, Any] | None) -> str:
-    """The single response body this model returns."""
+    """The single text response body this model returns.
+
+    Only reached when the framework will accept a plain text reply as the
+    final output. PydanticAI's non-string ``output_type``s (``bool``, a
+    dataclass, ...) instead require the reply to arrive as a call to a
+    framework-synthesized tool -- see ``_output_tool_call`` -- so this
+    function is never the right answer for those, and ``request`` below picks
+    between the two based on what the framework actually asked for, not by
+    guessing from the schema shape alone.
+    """
 
     if not output_schema:
         return _NEUTRAL_TEXT
-    definitions = output_schema.get("$defs")
-    instance = _instance_for(
-        output_schema, definitions if isinstance(definitions, Mapping) else {}, 0
-    )
+    instance = _schema_instance(output_schema)
     if instance is None:
         return _NEUTRAL_TEXT
     return json.dumps(instance, ensure_ascii=False, allow_nan=False, sort_keys=True)
+
+
+def _negotiated_schema(model_request_parameters: Any) -> Mapping[str, Any] | None:
+    """The schema this exact request actually needs to satisfy, or ``None``.
+
+    ``model_request_parameters.output_object.json_schema`` is what PydanticAI
+    negotiated for *this* request given the target's ``output_type`` -- and it
+    is not always the same shape as the raw type's own schema. A scalar or
+    non-object ``output_type`` (``bool``, ``int``, ...) is wrapped in a
+    single-key object (``{"response": ...}``, ``outer_typed_dict_key``) before
+    PydanticAI will accept it as either text or a tool-call argument; an
+    object ``output_type`` (a ``BaseModel``, a dataclass) is not. Building the
+    reply from a schema computed once at construction time and cached (the
+    previous design) got this wrong for the wrapped case: the raw schema for
+    ``bool`` is ``{"type": "boolean"}``, but the framework was actually
+    validating against ``{"type": "object", "properties": {"response": ...}}``,
+    so a bare ``"false"`` reply could never satisfy it no matter the retry
+    budget. Reading the schema fresh from what the framework passed into this
+    exact call is authoritative by construction: it is the framework's own
+    negotiated contract, not a guess reconstructed from the target's static
+    declaration.
+    """
+
+    output_object = getattr(model_request_parameters, "output_object", None)
+    schema = getattr(output_object, "json_schema", None) if output_object is not None else None
+    return schema if isinstance(schema, Mapping) else None
+
+
+def _output_tool_call(
+    model_request_parameters: Any, instance: Any
+) -> ToolCallPart | None:
+    """A call to the framework's own synthesized output tool, or ``None``.
+
+    PydanticAI represents a non-string ``output_type`` (``bool``, a
+    dataclass, ``TypedDict``, ...) as a required call to a tool it builds
+    itself -- ``final_result`` by default -- rather than as parseable text,
+    whenever ``model_request_parameters.allow_text_output`` is ``False``; a
+    ``TextPart`` reply can never satisfy that no matter its content or how
+    many retries remain. The instance was already derived from
+    ``_negotiated_schema`` (the same schema this tool's own
+    ``parameters_json_schema`` describes), so this only re-packages it as tool
+    arguments rather than as JSON text. The first output tool is used when
+    more than one is offered (a ``Union`` output type), which is an arbitrary
+    but deterministic and documented choice, not a guess at target behavior.
+    """
+
+    if getattr(model_request_parameters, "allow_text_output", True):
+        return None
+    output_tools = getattr(model_request_parameters, "output_tools", None)
+    if not output_tools or not isinstance(instance, Mapping):
+        return None
+    return ToolCallPart(tool_name=output_tools[0].name, args=dict(instance))
 
 
 class ControlledPydanticModel(Model):
     """Offline, deterministic stand-in for the target's provider."""
 
     def __init__(self, output_schema: Mapping[str, Any] | None = None) -> None:
+        # Retained as the reply for a request the framework gives no
+        # model_request_parameters.output_object to negotiate against (a
+        # plain-string output_type, most commonly) -- see request() below,
+        # which prefers the freshly negotiated schema whenever one exists.
         self._body = controlled_output_text(output_schema)
         self.calls = 0
 
@@ -124,10 +195,25 @@ class ControlledPydanticModel(Model):
         model_settings: Any,
         model_request_parameters: Any,
     ) -> ModelResponse:
-        del messages, model_settings, model_request_parameters
+        del messages, model_settings
         self.calls += 1
+        schema = _negotiated_schema(model_request_parameters)
+        instance = _schema_instance(schema) if schema is not None else None
+        tool_call = (
+            _output_tool_call(model_request_parameters, instance)
+            if instance is not None
+            else None
+        )
+        if tool_call is not None:
+            part: Any = tool_call
+        elif instance is not None:
+            part = TextPart(
+                json.dumps(instance, ensure_ascii=False, allow_nan=False, sort_keys=True)
+            )
+        else:
+            part = TextPart(self._body)
         return ModelResponse(
-            parts=[TextPart(self._body)],
+            parts=[part],
             usage=RequestUsage(input_tokens=0, output_tokens=0),
             model_name=CONTROLLED_MODEL_NAME,
         )

--- a/agentcheck/config.py
+++ b/agentcheck/config.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Literal, NamedTuple
+from typing import Any, Literal, NamedTuple, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -90,6 +90,16 @@ class AgentCheckConfig(BaseModel):
     schema_version: Literal["agentcheck.config.v1"] = "agentcheck.config.v1"
     adapter: Literal["openai_agents", "pydantic_ai", "custom"] = "openai_agents"
     entrypoint: str = DEFAULT_ENTRYPOINT
+    # A forward-compatible identifier for which bundled reference suite's
+    # scenario templates and behavioral policies apply -- the same kind of
+    # thing `schema_version` is, not a general suite selector a developer is
+    # expected to change. Exactly one ships today, so it is a Literal of one
+    # rather than a free string: a typo here is refused rather than silently
+    # accepted as a name that happens to match nothing. `suite_path` is the
+    # actual, real configuration surface for evaluating different scenario
+    # content (a custom frozen suite file); this field does not select among
+    # multiple built-in ones because there is currently only the one to
+    # select among.
     suite: Literal["account_support_v1"] = "account_support_v1"
     seed: int = Field(default=1729, ge=0, le=2**63 - 1)
     max_concurrency: int = Field(default=2, ge=1, le=16)
@@ -196,6 +206,30 @@ class AgentCheckConfig(BaseModel):
                 raise ValueError("tool_risk keys must be non-empty tool names")
         return value
 
+    @field_validator("suite", mode="before")
+    @classmethod
+    def validate_suite(cls, value: Any) -> Any:
+        """A clear, project-voiced refusal in place of a bare Literal mismatch.
+
+        Runs before the ``Literal`` type check itself, so a correct value is
+        untouched and a wrong one gets an explanation of what this field
+        actually is -- see the field's own comment -- rather than pydantic's
+        generic "Input should be 'account_support_v1'".
+        """
+
+        if isinstance(value, str) and value not in _KNOWN_SUITES:
+            raise ValueError(
+                f"suite {value!r} is not one of the suites AgentCheck ships: "
+                f"{', '.join(sorted(_KNOWN_SUITES))}. This field identifies "
+                "which bundled reference suite's scenario templates and "
+                "behavioral policies apply -- like schema_version, not a "
+                "general suite selector -- so a name that does not match one "
+                "of them is refused rather than silently accepted. To "
+                "evaluate different scenario content, set suite_path to your "
+                "own frozen suite file instead."
+            )
+        return value
+
     @field_validator("suite_path")
     @classmethod
     def validate_suite_path(cls, value: str | None) -> str | None:
@@ -256,6 +290,12 @@ class AgentCheckConfig(BaseModel):
         if any(part in {"", ".", ".."} for part in path.parts):
             raise ValueError("python_executable relative path must be a safe relative path")
         return path.as_posix()
+
+
+# Derived from the field's own Literal annotation, the same way
+# initialize.py's SUPPORTED_ADAPTERS is, so the validator's allowed set can
+# never drift from the type it is guarding.
+_KNOWN_SUITES: tuple[str, ...] = get_args(AgentCheckConfig.model_fields["suite"].annotation)
 
 
 def normalize_target(target: str | os.PathLike[str]) -> Path:

--- a/agentcheck/initialize.py
+++ b/agentcheck/initialize.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 from typing import Any, get_args
 
+from pydantic import ValidationError
+
 from .artifacts import create_private_file, replace_private_file
 from .config import (
     CONFIG_FILENAME,
@@ -47,19 +49,52 @@ def resolve_initialization_root(target: str | os.PathLike[str]) -> Path:
     return resolved
 
 
-def _validated_config(adapter: str, entrypoint: str) -> AgentCheckConfig:
+def _existing_document(destination: Path) -> dict[str, Any] | None:
+    """The current config's raw fields, or ``None`` if there is nothing to reuse.
+
+    ``init --force`` is documented as replacing the two fields ``init`` itself
+    controls (adapter, entrypoint) -- not as silently resetting every other
+    field a user may have hand-edited since, most importantly
+    ``environment_allowlist``, a security-relevant setting with no other CLI
+    knob to restore it. A destination that is itself a symlink is never read
+    through, matching ``replace_private_file``'s refusal to write through one:
+    a planted link should not be able to seed a trusted config from content
+    outside the target directory. Anything else unreadable or not a JSON
+    object (corrupt file, garbage content) is treated the same way a missing
+    file is: there is nothing safe to carry forward, so initialization falls
+    back to plain defaults exactly as it always has.
+    """
+
+    if destination.is_symlink() or not destination.is_file():
+        return None
+    try:
+        raw = json.loads(destination.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _validated_config(
+    adapter: str, entrypoint: str, *, base_document: dict[str, Any] | None = None
+) -> AgentCheckConfig:
     if adapter not in SUPPORTED_ADAPTERS:
         raise ConfigurationError(
             f"unsupported adapter: {adapter!r}; supported adapters: "
             f"{', '.join(SUPPORTED_ADAPTERS)}"
         )
-    document: dict[str, Any] = {"adapter": adapter, "entrypoint": entrypoint}
+    document: dict[str, Any] = dict(base_document or {})
+    document["adapter"] = adapter
+    document["entrypoint"] = entrypoint
     try:
         return AgentCheckConfig.model_validate(document)
-    except ValueError as exc:
-        raise ConfigurationError(
-            _ENTRYPOINT_FORM
-        ) from exc
+    except ValidationError as exc:
+        if base_document and any(error["loc"] != ("entrypoint",) for error in exc.errors()):
+            raise ConfigurationError(
+                f"the existing {CONFIG_FILENAME} being reused by --force has a field "
+                f"init cannot carry forward: {exc}. Fix that field directly in "
+                f"{CONFIG_FILENAME}, or remove the file and run init without --force."
+            ) from exc
+        raise ConfigurationError(_ENTRYPOINT_FORM) from exc
 
 
 def _encoded_config(config: AgentCheckConfig) -> bytes:
@@ -101,12 +136,19 @@ def write_initial_config(
     The document is serialized from a constructed :class:`AgentCheckConfig`, so an
     unwritable value fails before any file is created. The target agent is never
     imported and its entrypoint is not required to exist yet.
+
+    ``force`` replaces an existing file, but does not reset it: every field
+    besides ``adapter``/``entrypoint`` -- the two this function's own
+    parameters control -- is carried forward from the file being replaced, so
+    re-running init to fix one field (say, the adapter) cannot silently
+    discard another (say, ``environment_allowlist``).
     """
 
     resolved_root = resolve_initialization_root(root)
-    config = _validated_config(adapter, entrypoint)
-    entrypoint_location(resolved_root, config.entrypoint)
     destination = resolved_root / CONFIG_FILENAME
+    base_document = _existing_document(destination) if force else None
+    config = _validated_config(adapter, entrypoint, base_document=base_document)
+    entrypoint_location(resolved_root, config.entrypoint)
     _write_config_file(destination, _encoded_config(config), force=force)
     return destination
 

--- a/agentcheck/replay/fileset.py
+++ b/agentcheck/replay/fileset.py
@@ -163,15 +163,15 @@ def collect_source_file_set(root: Path) -> SourceFileSet:
                 "unable to inventory ignored source files for replay binding"
             )
         git_candidates = _unique_paths(tracked + ignored)
-        git_relevant = _select_relevant_paths(git_candidates)
+        git_relevant = _select_relevant_paths(git_candidates, root=resolved)
         if git_relevant:
             relevant = git_relevant
             mode: Literal["git_tracked", "local_files"] = "git_tracked"
         else:
-            relevant = _select_relevant_paths(_local_paths(resolved))
+            relevant = _select_relevant_paths(_local_paths(resolved), root=resolved)
             mode = "local_files"
     else:
-        relevant = _select_relevant_paths(_local_paths(resolved))
+        relevant = _select_relevant_paths(_local_paths(resolved), root=resolved)
         mode = "local_files"
     if not relevant:
         raise ConfigurationError(
@@ -223,7 +223,29 @@ def _normalize_relative(relative: str) -> str:
     return normalized
 
 
-def _excluded_by_location(relative: str) -> bool:
+def _is_virtualenv_root(directory: Path) -> bool:
+    """Whether ``directory`` is the root of a Python virtual environment.
+
+    ``pyvenv.cfg`` is the marker every standard tool that creates one
+    (``venv``, ``virtualenv``, ``uv venv``, ...) writes directly inside it --
+    the same signal Python's own ``sys.prefix`` machinery relies on. Detecting
+    a virtualenv this way, rather than by a fixed name list (``.venv``,
+    ``venv``), is what lets an arbitrarily-named one (``.test-venv``, and any
+    other name a project happens to use) be excluded correctly instead of
+    hitting the path-safety refusal below for a dot-prefixed directory that
+    was never the target's own source to begin with -- a virtualenv's
+    contents are installed third-party packages, the same category of thing
+    ``.venv``/``venv`` were already excluded by name for, not a new class of
+    exclusion this weakens the source-integrity guarantee by adding.
+    """
+
+    try:
+        return (directory / "pyvenv.cfg").is_file()
+    except OSError:
+        return False
+
+
+def _excluded_by_location(relative: str, *, root: Path) -> bool:
     """Exclude build, cache, and tool-reserved directories from source inventory.
 
     .github/, .vscode/, .idea/, .vs/ are reserved for GitHub and IDE tooling and
@@ -239,6 +261,11 @@ def _excluded_by_location(relative: str) -> bool:
     parts = relative.split("/")
     if any(part in _EXCLUDED_DIR_NAMES or part.endswith(".egg-info") for part in parts[:-1]):
         return True
+    accumulated = root
+    for part in parts[:-1]:
+        accumulated = accumulated / part
+        if _is_virtualenv_root(accumulated):
+            return True
     name = parts[-1] if parts else ""
     if name in _EXCLUDED_FILE_NAMES or name.startswith(".env"):
         return True
@@ -250,14 +277,16 @@ def _has_included_suffix(relative: str) -> bool:
     return any(name.endswith(suffix) for suffix in _INCLUDED_SUFFIXES)
 
 
-def _select_relevant_paths(paths: tuple[str, ...] | list[str]) -> list[str]:
+def _select_relevant_paths(
+    paths: tuple[str, ...] | list[str], *, root: Path
+) -> list[str]:
     selected: list[str] = []
     seen: set[str] = set()
     for raw in paths:
         relative = _normalize_relative(raw)
         if not relative or relative in seen:
             continue
-        if _excluded_by_location(relative) or not _has_included_suffix(relative):
+        if _excluded_by_location(relative, root=root) or not _has_included_suffix(relative):
             continue
         if not _is_safe_relative_path(relative):
             raise ConfigurationError(
@@ -357,6 +386,7 @@ def _local_paths(root: Path) -> tuple[str, ...]:
             if name not in _EXCLUDED_DIR_NAMES
             and not name.endswith(".egg-info")
             and not name.startswith(".")
+            and not _is_virtualenv_root(current / name)
         )
         for name in dirnames:
             child = current / name

--- a/agentcheck/runner/worker.py
+++ b/agentcheck/runner/worker.py
@@ -17,6 +17,7 @@ from agentcheck.adapters import (
     FrameworkAdapter,
     OpenAIAgentsAdapter,
     PydanticAIAdapter,
+    UnsupportedTargetError,
     encode_preflight_report,
 )
 from agentcheck.config import (
@@ -118,6 +119,19 @@ def _safe_error(exc: BaseException, *, phase: str) -> InfrastructureError:
             retryable=False,
             details=_safe_details({**exc.details, "error_type": type(exc).__name__}),
         )
+    if isinstance(exc, UnsupportedTargetError):
+        # Carries the same SupportIssue(s) preflight() would have reported --
+        # an adapter's own inspect() raising this (rather than a bare
+        # TypeError) keeps that detail (including any "did you mean the other
+        # adapter" guess) intact instead of it being discarded below.
+        code = exc.issues[0].code if exc.issues else "unsupported_target"
+        return InfrastructureError(
+            code=code,
+            message=(redact_log_text(str(exc))[:4_000] or "AgentCheck worker failed."),
+            phase=phase,
+            retryable=False,
+            details={"error_type": type(exc).__name__},
+        )
     if isinstance(exc, ValidationError):
         message = f"Contract validation failed with {exc.error_count()} error(s)."
         code = "worker_execution_failed"
@@ -127,13 +141,6 @@ def _safe_error(exc: BaseException, *, phase: str) -> InfrastructureError:
         except BaseException:  # pragma: no cover - defensive against hostile __str__
             message = "Exception text was unavailable."
         code = "worker_execution_failed"
-        if isinstance(exc, TypeError) and "exact agents.Agent" in message:
-            code = "unsupported_agent_shape"
-            message = (
-                "The configured entrypoint did not resolve to an exact agents.Agent. "
-                "Module-level Agent instances are supported; factory functions require "
-                "the explicit path.py:attribute() form."
-            )
     return InfrastructureError(
         code=code,
         message=(redact_log_text(message)[:4_000] or "AgentCheck worker failed."),

--- a/docs/pydantic-ai.md
+++ b/docs/pydantic-ai.md
@@ -258,7 +258,7 @@ does. Its run reports `Action paths exercised: 1/1`.
 OpenAI Agents SDK follows the same configuration idea: set
 `controlled_model` true to replace provider execution with AgentCheck's neutral
 offline model. Install the separate verified extra
-`agentcheck-ai[openai-agents]` (`openai-agents >=0.20,<0.21`). Custom agents are
+`agentcheck-ai[openai-agents]` (`openai-agents >=0.20,<0.23`). Custom agents are
 different: AgentCheck cannot see or replace model calls owned by custom
 orchestration, so `custom` plus `controlled_model` is explicitly rejected.
 

--- a/docs/pydantic-ai.md
+++ b/docs/pydantic-ai.md
@@ -14,12 +14,16 @@ Install the verified adapter extra from PyPI:
 python -m pip install "agentcheck-ai[pydantic-ai]"
 ```
 
-The extra installs `pydantic-ai-slim >=2.32,<2.33`. AgentCheck deliberately
-supports only PydanticAI 2.32.x because inspection reads framework-private
-attributes. A missing extra produces `framework_unavailable`; another minor
-version produces `unsupported_sdk_version` with the expected and detected
-versions. AgentCheck fails preflight instead of guessing at an unverified
-object shape.
+The extra installs `pydantic-ai-slim >=2.32,<2.36`. AgentCheck deliberately
+supports only PydanticAI 2.32.x through 2.35.x because inspection reads
+framework-private attributes with no stability guarantee across versions --
+each minor in that range was checked directly (the private-attribute surface
+this adapter reads, the framework-installed default-capability set, and the
+full adapter test suite) and found identical to 2.32 for everything this
+adapter touches. A missing extra produces `framework_unavailable`; a version
+outside the verified range produces `unsupported_sdk_version` with the
+expected range and the detected version. AgentCheck fails preflight instead
+of guessing at an unverified object shape.
 
 The distribution is `agentcheck-ai`, the Python import is `agentcheck`, and the
 command is `agentcheck`. Do not install the unrelated PyPI distribution named
@@ -63,6 +67,33 @@ The adapter requires:
 
 Those unsupported surfaces are executable target behavior that cannot be
 reconstructed safely. Preflight names each one and refuses the run.
+
+### Dynamic instructions
+
+`agent.instructions` and `@agent.system_prompt` accept a plain string or a
+callable that takes a `RunContext` and computes the text at run time -- the
+official PydanticAI examples use the callable form heavily (a bank-support
+agent embedding the caller's name and balance is a common shape). AgentCheck
+refuses a target whose instructions are computed this way
+(`dynamic_instructions`), and this is deliberately not just an
+execution-safety refusal that a future version could lift: even if calling
+the function were safe, AgentCheck has no way to know what text a
+`RunContext`-dependent function would have produced without a real run, and a
+reconstructed agent missing that text can make different tool-selection
+decisions than the real one -- silently producing a result that looks like it
+describes the real target but does not. AgentCheck would rather refuse than
+generate that kind of misleading evidence.
+
+To evaluate a target like this, either:
+
+- replace the dynamic instructions with a static string covering the parts
+  that do not depend on `RunContext` (drop the per-caller interpolation for
+  the copy exported to AgentCheck), or
+- move the dynamic content behind an explicit tool call the agent must make
+  (`get_customer_context`, for example) instead of injecting it into the
+  system prompt outside the agent's own decision loop -- AgentCheck can
+  simulate that tool call like any other declared tool, with the same
+  fixture-backed, fail-closed guarantee everything else in this adapter has.
 
 ### Dependency injection / `RunContext[Deps]`
 

--- a/examples/evaluation/pydantic_agent/README.md
+++ b/examples/evaluation/pydantic_agent/README.md
@@ -20,8 +20,8 @@ python -m pip install "agentcheck-ai[pydantic-ai]"
 ```
 
 This installs the verified PydanticAI range:
-`pydantic-ai-slim >=2.32,<2.33`. Other minor versions fail preflight with
-`unsupported_sdk_version` instead of being inspected approximately.
+`pydantic-ai-slim >=2.32,<2.36`. A version outside that range fails preflight
+with `unsupported_sdk_version` instead of being inspected approximately.
 
 ## Run the example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,14 +48,19 @@ dependencies = [
 [project.optional-dependencies]
 # Each adapter reads framework-private attributes to build an AgentSpec, so an
 # unverified version could produce a wrong spec rather than an obvious error.
-# Both gates are pinned to a single verified minor for that reason. They are
-# separate extras so evaluating one framework never installs the other.
+# Both gates are pinned to a verified minor range for that reason -- widening
+# either needs a direct check against the new minor, not just a bump here.
+# They are separate extras so evaluating one framework never installs the
+# other.
 openai-agents = [
     "openai-agents>=0.20,<0.21",
     "websockets>=15,<16",
 ]
 pydantic-ai = [
-    "pydantic-ai-slim>=2.32,<2.33",
+    # 2.32 through 2.35 verified: identical private-attribute surface and full
+    # pydantic_ai adapter test suite passing on every minor in range. See
+    # SUPPORTED_SDK_MINOR_RANGE in agentcheck/adapters/pydantic_ai.py.
+    "pydantic-ai-slim>=2.32,<2.36",
 ]
 all = [
     "agentcheck-ai[openai-agents]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,13 @@ all = [
 dev = [
     "agentcheck-ai[all]",
     "build>=1.3,<2",
+    # test_network_containment.py exercises network denial against every HTTP
+    # client library it can import, including httpx -- previously only
+    # present transitively through one exact openai-agents version, so
+    # widening that range (see SUPPORTED_SDK_MINOR_RANGE) could silently
+    # drop it depending on which minor a resolver picks. A test's own
+    # dependency must not be implicit.
+    "httpx>=0.27,<1",
     # Ruff's and mypy's default rule sets move between minors, so an unpinned
     # range means a lint failure lands on whoever installs next rather than on
     # the change that caused it. These are the versions the tree is actually

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,10 @@ dependencies = [
 # They are separate extras so evaluating one framework never installs the
 # other.
 openai-agents = [
-    "openai-agents>=0.20,<0.21",
+    # 0.20 through 0.22 verified: identical private-attribute surface and full
+    # openai_agents adapter test suite passing on every minor in range. See
+    # SUPPORTED_SDK_MINOR_RANGE in agentcheck/adapters/openai_agents.py.
+    "openai-agents>=0.20,<0.23",
     "websockets>=15,<16",
 ]
 pydantic-ai = [

--- a/tests/agentcheck/test_config.py
+++ b/tests/agentcheck/test_config.py
@@ -116,6 +116,40 @@ def test_suite_path_rejects_unsafe_locations() -> None:
         )
 
 
+def test_suite_accepts_only_the_one_bundled_reference_suite() -> None:
+    """``suite`` identifies which bundled reference suite applies -- the same
+    kind of forward-compatible identifier ``schema_version`` is -- not a
+    general suite selector, so a name that matches no bundled suite is
+    refused with an explanation, rather than pydantic's bare Literal-mismatch
+    text or (worse) being silently accepted."""
+
+    assert AgentCheckConfig().suite == "account_support_v1"
+    assert AgentCheckConfig(suite="account_support_v1").suite == "account_support_v1"
+    with pytest.raises(ValueError, match="is not one of the suites AgentCheck ships"):
+        AgentCheckConfig(suite="my_custom_suite")
+    with pytest.raises(ValueError, match="suite_path to your own frozen suite file"):
+        AgentCheckConfig(suite="my_custom_suite")
+
+
+def test_an_invalid_suite_in_agentcheck_json_names_the_field_clearly(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "agent.py").write_text("agent = object()\n", encoding="utf-8")
+    (tmp_path / "agentcheck.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.config.v1",
+                "entrypoint": "agent.py:agent",
+                "suite": "my_custom_suite",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigurationError, match="is not one of the suites AgentCheck ships"):
+        load_config(tmp_path)
+
+
 def test_store_path_rejects_unsafe_locations() -> None:
     with pytest.raises(ValueError, match="safe relative path"):
         AgentCheckConfig(store_path="../escape.sqlite")

--- a/tests/agentcheck/test_example_pydantic_agent.py
+++ b/tests/agentcheck/test_example_pydantic_agent.py
@@ -46,7 +46,7 @@ def test_example_contract_fixtures_and_docs_are_one_onboarding_path() -> None:
     example_docs = (EXAMPLE / "README.md").read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
     for text in (docs, example_docs):
-        assert "pydantic-ai-slim >=2.32,<2.33" in text
+        assert "pydantic-ai-slim >=2.32,<2.36" in text
         assert "agentcheck inspect" in text
         assert "agentcheck generate" in text
         assert "agentcheck test" in text
@@ -135,7 +135,7 @@ def test_example_cli_flow_exercises_a_simulated_tool_without_provider_or_handler
 def test_pydantic_guide_explains_controlled_model_limits_and_fail_closed_setup() -> None:
     docs = " ".join(PYDANTIC_DOC.read_text(encoding="utf-8").split())
 
-    assert "pydantic-ai-slim >=2.32,<2.33" in docs
+    assert "pydantic-ai-slim >=2.32,<2.36" in docs
     assert "unsupported_sdk_version" in docs
     assert "ControlledPydanticModel" in docs
     assert "never chooses a tool" in docs

--- a/tests/agentcheck/test_handoff_callbacks.py
+++ b/tests/agentcheck/test_handoff_callbacks.py
@@ -373,7 +373,22 @@ def test_static_handoffs_without_callback_remain_supported() -> None:
     assert "context_assignments" not in decoded["agents"][0]["handoffs"][0]
 
 
-def test_single_agent_spec_and_suite_fingerprints_remain_stable() -> None:
+def test_single_agent_spec_and_suite_fingerprints_remain_stable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinned against the fingerprinting algorithm, not the installed SDK.
+
+    ``spec_id`` deliberately bakes in ``framework_version`` (see
+    SUPPORTED_SDK_MINOR_RANGE's own docstring), so this pin is only
+    meaningful against one fixed version -- 0.20.0, whatever it was computed
+    against -- regardless of which minor within the adapter's verified range
+    (0.20-0.22) actually happens to be installed when the suite runs.
+    """
+
+    import agentcheck.adapters.openai_agents as openai_agents_adapter
+
+    monkeypatch.setattr(openai_agents_adapter, "_sdk_version", lambda: "0.20.0")
+
     @function_tool
     def get_weather(city: str) -> str:
         """Return weather."""

--- a/tests/agentcheck/test_handoffs.py
+++ b/tests/agentcheck/test_handoffs.py
@@ -544,7 +544,22 @@ def test_topology_is_described_for_handoff_targets_only() -> None:
         decode_topology({"framework": "openai_agents", "agents": [{"name": "x"}]})
 
 
-def test_single_agent_spec_id_is_byte_stable_after_handoff_support() -> None:
+def test_single_agent_spec_id_is_byte_stable_after_handoff_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinned against the fingerprinting algorithm, not the installed SDK.
+
+    ``spec_id`` deliberately bakes in ``framework_version`` (see
+    SUPPORTED_SDK_MINOR_RANGE's own docstring), so this pin is only
+    meaningful against one fixed version -- 0.20.0, whatever it was computed
+    against -- regardless of which minor within the adapter's verified range
+    (0.20-0.22) actually happens to be installed when the suite runs.
+    """
+
+    import agentcheck.adapters.openai_agents as openai_agents_adapter
+
+    monkeypatch.setattr(openai_agents_adapter, "_sdk_version", lambda: "0.20.0")
+
     @function_tool
     def get_weather(city: str) -> str:
         """Return weather."""

--- a/tests/agentcheck/test_init.py
+++ b/tests/agentcheck/test_init.py
@@ -160,6 +160,71 @@ def test_force_replaces_an_existing_config(tmp_path: Path) -> None:
         assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
 
 
+def test_force_preserves_a_previously_set_environment_allowlist(tmp_path: Path) -> None:
+    """Re-running init with --force must not silently drop a security setting.
+
+    ``init`` itself has no ``--environment-allowlist`` flag, so the only way a
+    developer ever gets this value into ``agentcheck.json`` is by hand-editing
+    the file after the first ``init``. A later ``--force`` re-run for an
+    unrelated reason (say, fixing the entrypoint) must carry it forward rather
+    than silently resetting it to the empty default.
+    """
+
+    root = _target(tmp_path)
+    write_initial_config(root)
+    config_path = root / CONFIG_FILENAME
+    document = json.loads(config_path.read_text(encoding="utf-8"))
+    document["environment_allowlist"] = ["BANK_SUPPORT_API_KEY"]
+    config_path.write_text(json.dumps(document) + "\n", encoding="utf-8")
+
+    write_initial_config(root, entrypoint="agent.py:agent", force=True)
+
+    _, loaded = load_config(root)
+    assert loaded.environment_allowlist == ("BANK_SUPPORT_API_KEY",)
+
+
+def test_force_preserves_fields_while_changing_only_the_adapter(tmp_path: Path) -> None:
+    root = _target(tmp_path)
+    write_initial_config(root)
+    config_path = root / CONFIG_FILENAME
+    document = json.loads(config_path.read_text(encoding="utf-8"))
+    document["environment_allowlist"] = ["SOME_KEY"]
+    document["seed"] = 4242
+    config_path.write_text(json.dumps(document) + "\n", encoding="utf-8")
+
+    write_initial_config(root, adapter="custom", force=True)
+
+    _, loaded = load_config(root)
+    assert loaded.adapter == "custom"
+    assert loaded.entrypoint == "agent.py:agent"
+    assert loaded.environment_allowlist == ("SOME_KEY",)
+    assert loaded.seed == 4242
+
+
+def test_force_reports_an_incompatible_preserved_field_clearly(tmp_path: Path) -> None:
+    """A stale field from an older config must not be blamed on the entrypoint."""
+
+    root = _target(tmp_path)
+    config_path = root / CONFIG_FILENAME
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.config.v1",
+                "adapter": "openai_agents",
+                "entrypoint": "agent.py:agent",
+                "suite": "a_suite_that_no_longer_exists",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        write_initial_config(root, force=True)
+
+    assert "entrypoint must use the form" not in str(excinfo.value)
+    assert CONFIG_FILENAME in str(excinfo.value)
+
+
 def test_repeated_initialization_is_deterministic(tmp_path: Path) -> None:
     first_root = _target(tmp_path)
     second_root = tmp_path / "second"

--- a/tests/agentcheck/test_interactive_scenarios.py
+++ b/tests/agentcheck/test_interactive_scenarios.py
@@ -853,7 +853,23 @@ def test_built_in_scenario_fingerprints_have_not_moved() -> None:
     } == BUILT_IN_FINGERPRINTS_SEED_7
 
 
-def test_a_generated_suite_with_no_followup_is_fingerprint_identical() -> None:
+def test_a_generated_suite_with_no_followup_is_fingerprint_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinned against the fingerprinting algorithm, not the installed SDK.
+
+    The suite's fingerprint is derived from the spec's, which deliberately
+    bakes in ``framework_version`` (see SUPPORTED_SDK_MINOR_RANGE's own
+    docstring), so this pin is only meaningful against one fixed version --
+    0.20.0, whatever it was computed against -- regardless of which minor
+    within the adapter's verified range (0.20-0.22) actually happens to be
+    installed when the suite runs.
+    """
+
+    import agentcheck.adapters.openai_agents as openai_agents_adapter
+
+    monkeypatch.setattr(openai_agents_adapter, "_sdk_version", lambda: "0.20.0")
+
     @function_tool
     def lookup_record(record_id: str) -> str:
         """Look up a stored record."""

--- a/tests/agentcheck/test_openai_adapter.py
+++ b/tests/agentcheck/test_openai_adapter.py
@@ -437,6 +437,27 @@ def test_unsupported_tool_fails_preflight_before_model_execution() -> None:
     assert model.calls == 0
 
 
+def test_an_unsupported_sdk_version_is_named() -> None:
+    """0.20-0.22 verified compatible; see SUPPORTED_SDK_MINOR_RANGE's docstring.
+
+    The range is a floor and a ceiling, not "0.20 or newer": each new minor
+    still needs the same empirical check (dir(Agent), the private-attribute
+    surface this adapter reads, and the full adapter test suite) before being
+    added, because inspection reads framework-private attributes with no
+    stability guarantee.
+    """
+
+    from agentcheck.adapters.openai_agents import _supported_sdk_version
+
+    assert _supported_sdk_version("0.20.0") is True
+    assert _supported_sdk_version("0.21.0") is True
+    assert _supported_sdk_version("0.22.0") is True
+    assert _supported_sdk_version("0.19.9") is False
+    assert _supported_sdk_version("0.23.0") is False
+    assert _supported_sdk_version("1.0.0") is False
+    assert _supported_sdk_version(None) is False
+
+
 def test_statically_typed_structured_output_passes_preflight_with_derived_schema() -> None:
     class StructuredAnswer(BaseModel):
         answer: str

--- a/tests/agentcheck/test_portable_identity.py
+++ b/tests/agentcheck/test_portable_identity.py
@@ -308,8 +308,22 @@ def test_identity_without_a_portable_locator_stays_location_bound() -> None:
     assert second.legacy_spec_id is None
 
 
-def test_the_pinned_location_bound_identity_is_reproduced_exactly() -> None:
-    """The legacy identity must be the old contract's bytes, not an approximation."""
+def test_the_pinned_location_bound_identity_is_reproduced_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy identity must be the old contract's bytes, not an approximation.
+
+    Pinned against the fingerprinting algorithm, not the installed SDK: the
+    identity deliberately bakes in ``framework_version`` (see
+    SUPPORTED_SDK_MINOR_RANGE's own docstring), so this pin is only
+    meaningful against one fixed version -- 0.20.0, whatever it was computed
+    against -- regardless of which minor within the adapter's verified range
+    (0.20-0.22) actually happens to be installed when the suite runs.
+    """
+
+    import agentcheck.adapters.openai_agents as openai_agents_adapter
+
+    monkeypatch.setattr(openai_agents_adapter, "_sdk_version", lambda: "0.20.0")
 
     agents = _agents_sdk()
     agent = _weather_agent(agents)

--- a/tests/agentcheck/test_preflight_diagnostics.py
+++ b/tests/agentcheck/test_preflight_diagnostics.py
@@ -224,6 +224,59 @@ def test_preflight_report_round_trips_and_rejects_unknown_fields() -> None:
         decode_preflight_report({**payload, "extra": True})
 
 
+def test_wrong_framework_target_names_the_likely_correct_adapter(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A target evaluated with the wrong --adapter gets an actionable hint.
+
+    Pure name-based duck-typing (module + class name of the already-imported
+    object) -- no cross-adapter import, so this works whichever adapter's
+    extra happens to be installed alongside the other in the dev environment.
+    """
+
+    root = tmp_path / "wrong_adapter"
+    root.mkdir()
+    (root / "agent.py").write_text(
+        "from agents import Agent\n\n"
+        'agent = Agent(name="Support", instructions="Help.", model="gpt-4.1-mini")\n',
+        encoding="utf-8",
+    )
+    write_initial_config(root, adapter="pydantic_ai")
+
+    assert main(["inspect", str(root)]) == 0
+    output = capsys.readouterr().out
+    assert "unsupported_agent_type" in output
+    assert 'set "adapter": \'openai_agents\' in agentcheck.json instead' in output
+
+
+def test_wrong_framework_target_names_the_likely_correct_adapter_the_other_way(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The openai_agents adapter refuses a wrong-type target outright.
+
+    Unlike pydantic_ai's tolerant, best-effort ``inspect()`` (which still
+    produces a spec and defers the whole "is this supported" decision to
+    preflight), openai_agents' ``inspect()`` refuses immediately -- so the CLI
+    command exits non-zero here rather than 0. What changed is only that the
+    refusal now carries the same actionable message preflight() would give,
+    instead of a bare, generic ``TypeError``.
+    """
+
+    root = tmp_path / "wrong_adapter_reverse"
+    root.mkdir()
+    (root / "agent.py").write_text(
+        "from pydantic_ai import Agent\n\n"
+        'agent = Agent("test", instructions="Help.", name="Support")\n',
+        encoding="utf-8",
+    )
+    write_initial_config(root, adapter="openai_agents")
+
+    assert main(["inspect", str(root)]) == 2
+    error = capsys.readouterr().err
+    assert "unsupported_agent_type" in error
+    assert 'set "adapter": \'pydantic_ai\' in agentcheck.json instead' in error
+
+
 def test_inspect_lists_dynamic_instructions_and_keeps_exit_zero(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/agentcheck/test_pydantic_ai_adapter.py
+++ b/tests/agentcheck/test_pydantic_ai_adapter.py
@@ -674,6 +674,49 @@ def test_the_controlled_model_answers_the_declared_schema_offline() -> None:
     assert run.tool_attempts == ()  # the controlled model calls no tools, by design
 
 
+def test_the_controlled_model_answers_a_scalar_output_type_offline() -> None:
+    """A non-object output_type (bool, int, ...) must not exhaust retries.
+
+    PydanticAI wraps a scalar output_type in a single-key object
+    (``{"response": ...}``) before it will accept it as a reply, whether as
+    text or as a tool-call argument -- a real gap this reproduces: the SDK's
+    own roulette_wheel example (``output_type=bool``) exhausted
+    ``retries=3`` and terminated as ``provider_error: Exceeded maximum
+    output retries`` under ``controlled_model=True`` before this fix,
+    because the controlled model's reply was built from the bare ``bool``
+    schema (``{"type": "boolean"}``) rather than the framework's actual
+    negotiated, wrapped one.
+    """
+
+    agent = Agent(_script(_text("unused")), instructions="Decide.", output_type=bool, name="B")
+    gateway = ToolGateway([], [])
+
+    run = _run(_prepare(agent, gateway, controlled_model=True), "decide")
+
+    assert run.termination == RunTermination.COMPLETED
+    assert run.final_output in ("true", "false")
+    assert run.tool_attempts == ()
+
+
+def test_the_controlled_model_preserves_the_targets_own_retry_budget() -> None:
+    """A rebuilt agent must not silently substitute pydantic_ai's default
+    retries=1 for whatever the target itself declared -- roulette_wheel's
+    own retries=3 is the real example that surfaced this."""
+
+    agent = Agent(
+        _script(_text("unused")),
+        instructions="Decide.",
+        output_type=Decision,
+        name="D",
+        retries=5,
+    )
+    gateway = ToolGateway([], [])
+
+    prepared = _prepare(agent, gateway, controlled_model=True)
+
+    assert prepared.runtime_agent._max_output_retries == 5
+
+
 # --- world state ------------------------------------------------------------
 
 

--- a/tests/agentcheck/test_pydantic_ai_adapter.py
+++ b/tests/agentcheck/test_pydantic_ai_adapter.py
@@ -277,8 +277,22 @@ def test_a_static_validation_context_value_is_not_rejected() -> None:
 
 
 def test_an_unsupported_sdk_version_is_named() -> None:
+    """2.32-2.35 verified compatible; see docs/pydantic-ai.md for the evidence.
+
+    The range is a floor and a ceiling, not "2.32 or newer": each new minor
+    still needs the same empirical check (dir(Agent), the private-attribute
+    surface this adapter reads, and the full pydantic_ai test suite) before
+    being added, because inspection reads framework-private attributes with
+    no stability guarantee.
+    """
+
+    assert _supported_sdk_version("2.32.0") is True
     assert _supported_sdk_version("2.32.1") is True
-    assert _supported_sdk_version("2.33.0") is False
+    assert _supported_sdk_version("2.33.0") is True
+    assert _supported_sdk_version("2.34.0") is True
+    assert _supported_sdk_version("2.35.0") is True
+    assert _supported_sdk_version("2.31.9") is False
+    assert _supported_sdk_version("2.36.0") is False
     assert _supported_sdk_version("1.0.0") is False
     assert _supported_sdk_version(None) is False
 

--- a/tests/agentcheck/test_pydantic_ai_controlled.py
+++ b/tests/agentcheck/test_pydantic_ai_controlled.py
@@ -1,0 +1,218 @@
+"""``ControlledPydanticModel``: the offline stand-in for a PydanticAI target's provider.
+
+The real bug this file pins down: PydanticAI wraps a non-object
+``output_type`` (``bool``, ``int``, ...) in a single-key object
+(``{"response": ...}``) before it will accept a reply for it, whether as text
+or as a tool-call argument -- the SDK's own ``roulette_wheel.py`` example
+(``output_type=bool``) exhausted its retry budget and terminated as
+``provider_error: Exceeded maximum output retries`` under
+``controlled_model=True`` because the earlier implementation built its reply
+from the *raw* declared schema (``{"type": "boolean"}``) computed once at
+construction time, instead of the framework's actual per-request negotiated
+one. These tests exercise the fix directly, at the level of what
+``model_request_parameters`` the real agent graph actually sends, rather than
+only through a full end-to-end run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.output import OutputObjectDefinition
+from pydantic_ai.tools import ToolDefinition
+
+from agentcheck.adapters.pydantic_ai_controlled import (
+    ControlledPydanticModel,
+    _negotiated_schema,
+    _output_tool_call,
+    _schema_instance,
+    controlled_output_text,
+)
+
+
+def _params(**overrides: Any) -> ModelRequestParameters:
+    return ModelRequestParameters(**overrides)
+
+
+# --- controlled_output_text / _schema_instance: unchanged, direct schema ----
+
+
+def test_controlled_output_text_is_deterministic_for_an_object_schema() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"approved": {"type": "boolean"}, "reason": {"type": "string"}},
+        "required": ["approved", "reason"],
+    }
+    first = controlled_output_text(schema)
+    second = controlled_output_text(schema)
+    assert first == second
+    assert json.loads(first) == {"approved": False, "reason": "agentcheck-controlled-value"}
+
+
+def test_controlled_output_text_is_neutral_without_a_schema() -> None:
+    assert "acknowledged" in controlled_output_text(None)
+    assert "acknowledged" in controlled_output_text({})
+
+
+# --- _negotiated_schema: the actual bug -------------------------------------
+
+
+def test_negotiated_schema_is_the_wrapped_object_for_a_scalar_output_type() -> None:
+    """This is the exact shape a real bool-output_type agent negotiates."""
+
+    params = _params(
+        output_object=OutputObjectDefinition(
+            json_schema={
+                "type": "object",
+                "properties": {"response": {"type": "boolean"}},
+                "required": ["response"],
+            },
+            name="bool",
+        ),
+        allow_text_output=True,
+    )
+
+    schema = _negotiated_schema(params)
+
+    assert schema is not None
+    assert schema["type"] == "object"
+    assert "response" in schema["properties"]
+
+
+def test_negotiated_schema_is_none_for_a_plain_string_output_type() -> None:
+    assert _negotiated_schema(_params()) is None
+
+
+# --- request(): the fix, exercised end-to-end at the Model level -----------
+
+
+def test_request_replies_with_the_negotiated_wrapped_shape_not_the_raw_one() -> None:
+    """Constructed with the *unwrapped* bool schema (what the old, buggy
+    design would have cached) -- request() must still reply in the wrapped
+    shape the framework actually asked for in model_request_parameters,
+    because that is what PydanticAI's own output validator checks against."""
+
+    model = ControlledPydanticModel({"type": "boolean"})
+    params = _params(
+        output_object=OutputObjectDefinition(
+            json_schema={
+                "type": "object",
+                "properties": {"response": {"type": "boolean"}},
+                "required": ["response"],
+            },
+            name="bool",
+        ),
+        allow_text_output=True,
+    )
+
+    response = asyncio.run(model.request([], None, params))
+
+    assert len(response.parts) == 1
+    body = json.loads(response.parts[0].content)
+    assert body == {"response": False}
+
+
+def test_request_falls_back_to_the_constructor_schema_without_a_negotiated_one() -> None:
+    """No output_object at all (a plain-string output_type): the neutral or
+    constructor-derived text is still exactly what it always was."""
+
+    model = ControlledPydanticModel({"type": "object", "properties": {"x": {"type": "string"}}})
+
+    response = asyncio.run(model.request([], None, _params()))
+
+    assert len(response.parts) == 1
+    assert json.loads(response.parts[0].content) == {"x": "agentcheck-controlled-value"}
+
+
+# --- _output_tool_call: the tool-based output mode --------------------------
+
+
+def test_output_tool_call_is_built_when_text_output_is_not_allowed() -> None:
+    instance = {"response": False}
+
+    call = _output_tool_call(
+        _params(
+            allow_text_output=False,
+            output_tools=[
+                ToolDefinition(
+                    name="final_result",
+                    parameters_json_schema={
+                        "type": "object",
+                        "properties": {"response": {"type": "boolean"}},
+                    },
+                )
+            ],
+        ),
+        instance,
+    )
+
+    assert call is not None
+    assert call.tool_name == "final_result"
+    assert call.args_as_dict() == instance
+
+
+def test_output_tool_call_is_none_when_text_output_is_allowed() -> None:
+    assert (
+        _output_tool_call(
+            _params(
+                allow_text_output=True,
+                output_tools=[ToolDefinition(name="final_result", parameters_json_schema={})],
+            ),
+            {"response": False},
+        )
+        is None
+    )
+
+
+def test_output_tool_call_is_none_without_an_instance() -> None:
+    assert (
+        _output_tool_call(
+            _params(allow_text_output=False, output_tools=[ToolDefinition(name="x", parameters_json_schema={})]),
+            None,
+        )
+        is None
+    )
+
+
+def test_request_calls_the_output_tool_when_text_output_is_disallowed() -> None:
+    model = ControlledPydanticModel(None)
+    params = _params(
+        output_object=OutputObjectDefinition(
+            json_schema={
+                "type": "object",
+                "properties": {"response": {"type": "boolean"}},
+                "required": ["response"],
+            },
+            name="bool",
+        ),
+        allow_text_output=False,
+        output_tools=[
+            ToolDefinition(
+                name="final_result",
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {"response": {"type": "boolean"}},
+                },
+            )
+        ],
+    )
+
+    response = asyncio.run(model.request([], None, params))
+
+    assert len(response.parts) == 1
+    assert response.parts[0].part_kind == "tool-call"
+    assert response.parts[0].args_as_dict() == {"response": False}
+
+
+def test_schema_instance_derives_a_value_matching_the_dollar_defs_case() -> None:
+    schema = {
+        "$defs": {"Choice": {"enum": ["yes", "no"]}},
+        "properties": {"pick": {"$ref": "#/$defs/Choice"}},
+        "required": ["pick"],
+        "type": "object",
+    }
+
+    assert _schema_instance(schema) == {"pick": "yes"}

--- a/tests/agentcheck/test_source_fileset.py
+++ b/tests/agentcheck/test_source_fileset.py
@@ -584,3 +584,81 @@ def test_hidden_relevant_python_file_fails_closed(tmp_path: Path) -> None:
     (target / ".hidden.py").write_text("VALUE = 2\n", encoding="utf-8")
     with pytest.raises(ConfigurationError, match="not a safe relative path"):
         collect_source_file_set(target)
+
+
+def _write_virtualenv(root: Path, name: str) -> None:
+    """A minimal but faithful virtualenv: the ``pyvenv.cfg`` marker every
+    real venv-creation tool (venv, virtualenv, uv venv) writes, plus an
+    installed-looking .py file the way a real site-packages tree would have
+    one -- exactly the shape reported blocking replay manifest generation."""
+
+    venv = root / name
+    (venv / "lib" / "python3.12" / "site-packages" / "somepkg").mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text("version = 3.12.3\n", encoding="utf-8")
+    (venv / "lib" / "python3.12" / "site-packages" / "somepkg" / "__init__.py").write_text(
+        "X = 1\n", encoding="utf-8"
+    )
+
+
+@pytest.mark.parametrize("venv_name", [".test-venv", "test-venv", "myenv"])
+def test_an_arbitrarily_named_virtualenv_is_excluded_in_local_mode(
+    tmp_path: Path, venv_name: str
+) -> None:
+    target = tmp_path / "local"
+    target.mkdir()
+    (target / "agent.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _write_virtualenv(target, venv_name)
+
+    inventory = collect_source_file_set(target)
+
+    assert inventory.mode == "local_files"
+    paths = {item.path for item in inventory.files}
+    assert paths == {"agent.py"}
+
+
+def test_an_arbitrarily_named_gitignored_virtualenv_is_excluded_in_git_mode(
+    tmp_path: Path,
+) -> None:
+    """Reproduces the reported failure exactly: a virtualenv gitignored under
+    a name other than .venv/venv (.test-venv here) used to be picked up by
+    `git ls-files --others --ignored` as an "ignored-but-present" candidate,
+    survive the fixed .venv/venv name-list exclusion, and then hit the
+    dot-prefixed path-safety refusal -- turning a harmless local virtualenv
+    into a hard replay-manifest failure instead of a silent, correct
+    exclusion of what was never the target's own source to begin with."""
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "agent.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git_init(target)
+    (target / ".gitignore").write_text(".test-venv/\n", encoding="utf-8")
+    _write_virtualenv(target, ".test-venv")
+    # Nothing is committed -- matching the reported scenario, where the
+    # virtualenv was gitignored but the rest of the target was never staged.
+
+    inventory = collect_source_file_set(target)
+
+    paths = {item.path for item in inventory.files}
+    assert "agent.py" in paths
+    assert not any(".test-venv" in path for path in paths)
+
+
+def test_a_dot_prefixed_directory_that_is_not_a_virtualenv_still_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """The fix is specific to genuine virtualenvs (pyvenv.cfg present) -- an
+    unrelated dot-prefixed, gitignored directory with no such marker must
+    still refuse rather than be silently excluded, preserving the existing
+    source-integrity guarantee for everything that is not a virtualenv."""
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "agent.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git_init(target)
+    (target / ".gitignore").write_text(".mystery/\n", encoding="utf-8")
+    nested = target / ".mystery" / "deeply" / "nested"
+    nested.mkdir(parents=True)
+    (nested / "thing.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="not a safe relative path"):
+        collect_source_file_set(target)

--- a/tests/agentcheck/test_target_loading.py
+++ b/tests/agentcheck/test_target_loading.py
@@ -348,6 +348,16 @@ def test_arbitrary_factory_functions_are_not_auto_executed(tmp_path: Path) -> No
 
 
 def test_factory_returning_non_agent_fails_closed(tmp_path: Path) -> None:
+    """A wrong-type target now fails through the same code as any other.
+
+    Previously this specific case (a bare ``TypeError`` raised by
+    ``OpenAIAgentsAdapter.inspect``) was pattern-matched into an
+    ``unsupported_agent_shape`` code by the worker's error mapping, distinct
+    from ``preflight()``'s own ``unsupported_agent_type`` for what is the same
+    underlying defect. ``inspect()`` now raises ``UnsupportedTargetError``
+    with ``preflight()``'s own issue directly, so both paths agree.
+    """
+
     root = _init(tmp_path / "target", "agent.py:create_agent()")
     (root / "agent.py").write_text(FACTORY_RETURNS_INT.lstrip(), encoding="utf-8")
     loaded, _source = load_target(root)
@@ -356,7 +366,7 @@ def test_factory_returning_non_agent_fails_closed(tmp_path: Path) -> None:
     result = inspect_in_subprocess(root, config)
     assert result.ok is False
     assert result.infrastructure_error is not None
-    assert result.infrastructure_error.code == "unsupported_agent_shape"
+    assert result.infrastructure_error.code == "unsupported_agent_type"
 
 
 def test_factory_exception_is_bounded_and_redacted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This bundles four validated fixes: three real-world findings from manual PydanticAI testing against the SDK's own `roulette_wheel.py` example, plus the two version-widening/init fixes from earlier in this session that were still local-only on `main`.

### 1. `controlled_model=True` + non-object `output_type` (bool, int, ...) exhausted retries every time

Reported symptom: every scenario terminated as `provider_error: Exceeded maximum output retries (1)`.

Two bugs compounded, both fixed, plus a third deeper one only visible once the first two stopped masking it:

- `_output_schema()` only derived a schema via `output_type.model_json_schema` (BaseModel-only) — a scalar `output_type` like `bool` silently produced *no* schema. Widened to fall back to `pydantic.TypeAdapter(output_type)`, the same category of safe static schema introspection `model_json_schema` already was.
- The rebuilt evaluation agent never propagated the target's own `retries=` setting, silently substituting pydantic_ai's default of `1`. Now read back from `_max_output_retries` and passed through.
- **The real root cause**: PydanticAI wraps a non-object `output_type` in a single-key object (`{"response": ...}`) before it will accept a reply, as either text or a tool-call argument. `ControlledPydanticModel` was building its reply from a schema computed once at construction time, which never reflected this wrapping — so even with a correct schema and a correct retry budget, every reply was shaped wrong and retries still exhausted. Fixed by deriving the reply from `model_request_parameters.output_object`/`output_tools`, read fresh on every request (the framework's own authoritative per-request contract), replying with a tool call instead of text when the framework requires one.

Reproduced against the SDK's own `roulette_wheel.py` (`output_type=bool`, `retries=3`) before and after each fix. 14 new regression tests (`test_pydantic_ai_adapter.py` + new `test_pydantic_ai_controlled.py`).

### 2. Replay manifest generation failed on an arbitrarily-named virtualenv

Reported symptom: a `.test-venv/` inside the target directory caused `AgentCheck warning: replay manifest failed: ... cannot be bound because its path is not a safe relative path`.

Root cause: git-mode source inventory only excluded `.venv`/`venv` by hardcoded name. A differently-named, gitignored virtualenv survived that exclusion as an "ignored-but-present" candidate and then hit the dot-prefix path-safety refusal as a hard failure, instead of being excluded.

Fixed by detecting a virtualenv by its `pyvenv.cfg` marker (the same signal every venv-creation tool writes, and Python's own `sys.prefix` machinery relies on) instead of a fixed name list, in both git and local-file inventory modes. This does not weaken the source-integrity guarantee — a virtualenv's contents were never the target's own authored source (same category `.venv`/`venv` were already excluded for), and a dot-prefixed directory that is *not* a genuine virtualenv still fails closed exactly as before (regression-tested). 6 new tests in `test_source_fileset.py`.

### 3. `agentcheck.json`'s `suite` field looked configurable but only accepted one value

Investigated and classified: not dead surface (it's read and enforced in `generate/suite.py`), not a behavioral bug (refusing other values is correct) — it's a forward-compatible identifier for which bundled reference suite applies, the same kind of thing `schema_version` already is, just without that field's self-evident name or any documentation saying so.

Smallest correct fix: a doc comment explaining what the field is, and a `mode="before"` validator producing a clear message pointing at `suite_path` (the actual knob for different scenario content) instead of pydantic's bare Literal-mismatch text. **Zero serialized-contract change** — the `Literal` type, default value, and field name are all untouched, so every existing `agentcheck.json` keeps validating exactly as before. 2 new tests in `test_config.py`.

### 4/5. Carried over from earlier this session (already validated, previously local-only)

- `init --force` no longer silently wipes `environment_allowlist` and other fields it doesn't control.
- pydantic-ai and openai-agents verified-version ranges widened (2.32→2.35, 0.20→0.22) with empirical evidence for each.

## Validation

- `ruff check agentcheck tests` / `mypy agentcheck` — clean
- Full suite: `1540 passed, 1 skipped`
- `python -m build` — clean sdist/wheel
- Zero paid provider calls throughout (fake placeholder API keys / the SDK's offline `TestModel` only)
- No target handler ever executed; fail-closed behavior preserved and, for finding 2, verified to still hold for anything that is not a genuine virtualenv

🤖 Generated with [Claude Code](https://claude.com/claude-code)