### PR TITLE
Two real defects found testing independent external agent repos

### DIFF
--- a/agentcheck/inspect/capabilities.py
+++ b/agentcheck/inspect/capabilities.py
@@ -61,11 +61,31 @@ _COMPOSITION_KEYWORDS = (
 # Reproduces the Phase 1 name-token vocabulary exactly.  Order is significant:
 # the first matching rule wins, so a tool named ``delete_and_update`` stays a
 # deletion.  These are weak lexical hints, never authoritative classifications.
+#
+# "write"/"save"/"store"/"persist"/"append" were added after a real,
+# independently-maintained target's file-write tool -- named exactly "write",
+# its own docstring reading "Writes a file... will overwrite the existing
+# file" -- fell through every rule and landed at OTHER/read-only/confidence
+# 0.3: the single lowest-confidence, least-scrutinized bucket, for a tool that
+# unconditionally overwrites local files. Grouped with create/add/open/register
+# (state-changing, not assumed destructive) rather than delete/remove's
+# destructive bucket: a bare "write" name does not by itself distinguish
+# "create new" from "overwrite existing" the way "delete" is unambiguous, and
+# the project's own convention is to let a developer's explicit
+# `tool_risk` declaration escalate further rather than guess destructive from
+# a name alone.
 _NAME_RULES: tuple[tuple[frozenset[str], ActionKind, bool, bool], ...] = (
     (frozenset({"delete", "remove", "destroy", "erase", "purge"}), ActionKind.DELETE, True, True),
     (frozenset({"cancel", "terminate", "close"}), ActionKind.MODIFY, True, True),
     (frozenset({"update", "modify", "change", "set", "edit"}), ActionKind.MODIFY, True, False),
-    (frozenset({"create", "add", "open", "register"}), ActionKind.CREATE, True, False),
+    (
+        frozenset(
+            {"create", "add", "open", "register", "write", "writes", "save", "saves", "store", "stores", "persist", "append"}
+        ),
+        ActionKind.CREATE,
+        True,
+        False,
+    ),
     (frozenset({"send", "email", "notify", "publish"}), ActionKind.SEND, True, False),
     (frozenset({"schedule", "book", "reserve"}), ActionKind.SCHEDULE, True, False),
     (frozenset({"lookup", "find", "search", "get", "read"}), ActionKind.LOOKUP, False, False),

--- a/agentcheck/replay/fileset.py
+++ b/agentcheck/replay/fileset.py
@@ -54,6 +54,7 @@ _EXCLUDED_DIR_NAMES = frozenset(
         ".venv",
         "venv",
         ".tox",
+        ".claude",
         ".mypy_cache",
         ".ruff_cache",
         ".pytest_cache",
@@ -248,8 +249,13 @@ def _is_virtualenv_root(directory: Path) -> bool:
 def _excluded_by_location(relative: str, *, root: Path) -> bool:
     """Exclude build, cache, and tool-reserved directories from source inventory.
 
-    .github/, .vscode/, .idea/, .vs/ are reserved for GitHub and IDE tooling and
-    are not read by target agent runtime code, so they are excluded outright.
+    .github/, .vscode/, .idea/, .vs/, .claude/ are reserved for GitHub, IDE, and
+    coding-assistant tooling (Claude Code's own project settings and subagent
+    definitions, for itself, not for the target) and are not read by target
+    agent runtime code, so they are excluded outright. Found via a real,
+    independently-maintained target repo whose committed `.claude/settings.json`
+    otherwise hit the path-safety refusal below exactly like an unrecognized
+    virtualenv name would.
 
     ``.agents/`` is deliberately NOT excluded here: it is the OpenAI Agents SDK's
     default sandbox skills_path (see ``agents.sandbox.capabilities.skills.Skills``),

--- a/tests/agentcheck/test_capabilities.py
+++ b/tests/agentcheck/test_capabilities.py
@@ -400,6 +400,8 @@ def test_absent_schema_yields_no_parameters_without_failing() -> None:
         ("cancel_subscription", ActionKind.MODIFY, True, True),
         ("update_email", ActionKind.MODIFY, True, False),
         ("create_ticket", ActionKind.CREATE, True, False),
+        ("write", ActionKind.CREATE, True, False),
+        ("save_draft", ActionKind.CREATE, True, False),
         ("send_receipt", ActionKind.SEND, True, False),
         ("schedule_visit", ActionKind.SCHEDULE, True, False),
         ("lookup_account", ActionKind.LOOKUP, False, False),
@@ -417,6 +419,31 @@ def test_each_action_kind_and_risk_classification_is_reachable(
     assert capability.state_changing is state_changing
     assert capability.destructive is destructive
     assert classify_tool(name) == (action_kind, state_changing, destructive)
+
+
+def test_a_bare_write_tool_is_not_silently_classified_read_only() -> None:
+    """Reproduces a real independent target's file-write tool: named exactly
+    "write", with a docstring stating it overwrites existing files. Before
+    "write" was added to the name vocabulary, this fell through every rule to
+    OTHER/read-only/confidence 0.3 -- the single lowest-confidence,
+    least-scrutinized classification -- for a tool that unconditionally
+    mutates local files."""
+
+    capability = extract_capabilities(
+        [
+            _tool(
+                "write",
+                description=(
+                    "Writes a file to the local filesystem. This tool will "
+                    "overwrite the existing file if there is one at the "
+                    "provided path."
+                ),
+            )
+        ]
+    )[0]
+
+    assert capability.capability.state_changing is True
+    assert capability.capability.action_kind is ActionKind.CREATE
 
 
 def test_classification_matches_the_phase_one_name_vocabulary() -> None:

--- a/tests/agentcheck/test_source_fileset.py
+++ b/tests/agentcheck/test_source_fileset.py
@@ -568,6 +568,31 @@ def test_vscode_directory_excluded_from_git_tracked_inventory(tmp_path: Path) ->
     )
 
 
+def test_claude_directory_excluded_from_git_tracked_inventory(tmp_path: Path) -> None:
+    """.claude/ is Claude Code's own project settings and subagent definitions
+    (for itself, not for the target), not read by target runtime code -- found
+    against a real independent repo whose committed .claude/settings.json hit
+    the path-safety refusal exactly like an unrecognized virtualenv name would.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "agent.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git_init(target)
+    claude_dir = target / ".claude" / "agents"
+    claude_dir.mkdir(parents=True)
+    (target / ".claude" / "settings.json").write_text("{}\n", encoding="utf-8")
+    (claude_dir / "reviewer.md").write_text("# reviewer\n", encoding="utf-8")
+    _git_track(target, "agent.py", ".claude/settings.json", ".claude/agents/reviewer.md")
+
+    fileset = collect_source_file_set(target)
+    paths = {item.path for item in fileset.files}
+
+    assert "agent.py" in paths
+    assert not any(".claude" in path for path in paths), (
+        f".claude/ should be excluded, but found: {[p for p in paths if '.claude' in p]}"
+    )
+
+
 def test_unsafe_relevant_filename_fails_closed(tmp_path: Path) -> None:
     target = tmp_path / "local"
     target.mkdir()


### PR DESCRIPTION
## Summary

Part of a bounded real-world validation campaign against 3 independently-maintained public agent repositories, pinned to exact commit SHAs, none of them official framework examples:

- `kingabzpro/Multi-Agent-Research-Assistant` @ `50b0ee3` (OpenAI Agents SDK)
- `nickjlamb/inbox-triage` @ `3211ca0` (PydanticAI, two agents)
- `serialx/vibecore` @ `8de60c7` (OpenAI Agents SDK, factory entrypoint)

Everything else in the campaign either worked correctly end-to-end or was correctly refused by existing, already-tested logic (agent-as-tool composition, dynamic instructions, output validators — see session findings, not part of this PR). Both fixes here were found testing `serialx/vibecore`, a real terminal coding agent with 14 tools.

### 1. `.claude/` not in the source-inventory exclusion list

A real repo's committed `.claude/settings.json` (Claude Code's own project settings — for the coding assistant, not the target) hit the dot-prefix path-safety refusal and broke replay manifest generation — the same failure mode PR #52 fixed for an unrecognized virtualenv name, for an unrelated reason. Added to the same exclusion list `.github`/`.vscode`/`.idea`/`.vs` already use, for the same reason: tool-reserved, never read by target runtime code.

A second, distinct dot-directory in the same repo (`.hooks/`, a Claude Code hook script referenced from `.claude/settings.json`) was deliberately **not** added: unlike `.claude/`, "hooks" isn't a widely-standardized tooling convention and could plausibly be real target source in an unrelated project. That target still correctly fails closed on it — intentional exclusion-list conservatism, not a second bug.

### 2. Tool-risk inference vocabulary missing "write"

Every other basic persistence verb (create, update, delete, send) was in the name/description vocabulary that infers `state_changing`/`destructive` from a bare tool name — "write" (and save/store/persist/append) was not. A real tool literally named `write`, whose own docstring reads *"Writes a file... will overwrite the existing file"*, fell through every rule to `OTHER`/read-only/confidence 0.3 — the single lowest-confidence, least-scrutinized classification available — for a tool that unconditionally mutates local files.

Added to the same bucket as `create`/`add`/`open`/`register` (state-changing, not assumed destructive): a bare "write" name doesn't distinguish "create new" from "overwrite existing" the way "delete" is unambiguous, and the project's existing convention is to let a developer's own `tool_risk` declaration escalate further rather than guess destructive from a name alone.

Deliberately **not** "fixed": the same repo's `bash` tool (arbitrary shell execution) stays `OTHER`/read-only by name alone. A tool named after what it dispatches through, not what it does, is a fundamentally different and harder problem than a missing common verb — this project does not guess semantic risk from a name it structurally cannot support.

## Validation

- `ruff check agentcheck tests` / `mypy agentcheck` — clean
- Full suite: `1544 passed, 1 skipped` (up from 1540, the 4 new regression tests)
- `python -m build` — clean sdist/wheel
- Reproduced against the real `vibecore` repo before and after each fix; regenerating the frozen suite after the capability-inference fix correctly refused to run against the now-stale `spec_id` until regenerated — itself confirmation the identity/staleness check works as designed
- Zero paid provider calls throughout the campaign (fake placeholder credentials only, `controlled_model`/local models only)
- Zero original target handler executions during simulated evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)