### PR TITLE
Fix write-family risk documentation drift (follow-up to #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ treated as authoritative anywhere a hard verdict depends on it.
 
 Inference is conservative in one direction only: a tool it cannot classify is
 left non-state-changing (`UNKNOWN`, not a confirmed safe) and receives **no
-fault family**. Verb-shaped names such as `delete_account` or `cancel_order`
-are read correctly; neutral ones such as `bash`, `write` or `execute_command`
-are not, and stay untested until declared. Coverage reports the gap as
+fault family**. Verb-shaped names such as `delete_account` or `cancel_order`,
+and persistence names such as `write` or `save_draft`, produce an inferred
+classification. Generic dispatch names such as `bash`, `execute_python`, or
+`execute_command` remain `UNKNOWN` and receive no risk-scoped fault family
+until declared. Inferred risk remains non-authoritative, so coverage reports
 `risk_metadata_not_authoritative` rather than implying the tool was checked.
 See [fault testing](docs/fault-testing.md) and, to declare your own
 contracts, [behavioral policies](docs/behavioral-policies.md). Multiple tool

--- a/docs/fault-testing.md
+++ b/docs/fault-testing.md
@@ -46,9 +46,14 @@ Name inference is wrong in both directions, and neither is hypothetical:
 
 - `find_user_id_by_email` in tau-bench is a pure lookup, and is read as
   state-changing because of the tokens in its name.
-- `bash`, `execute_python`, `write` and `execute_command` are read as read-only
-  (`UNKNOWN`, not a confirmed `False`), because nothing in those names says
-  otherwise. They receive no fault family at all unless declared.
+- Persistence names such as `write`, `save_draft`, `store_result`,
+  `persist_state`, and `append_log` are inferred state-changing but not
+  destructive. They receive the state-changing fault family, while coverage
+  remains `UNKNOWN` because inference is not authoritative.
+- Generic dispatch names such as `bash`, `execute_python`, and
+  `execute_command` remain read-only (`UNKNOWN`, not a confirmed `False`)
+  because their names do not reveal their effects. They receive no fault
+  family unless declared.
 
 Declaring one axis does not upgrade the other's authority: declaring only
 `destructive` on a tool leaves `state_changing` exactly as inferred (or


### PR DESCRIPTION
## Summary
- PR #53 changed `write`/`save`/`store`/`persist`/`append` name-token inference to the state-changing (not destructive) bucket, but `README.md` and `docs/fault-testing.md` still described those names as read-only/UNKNOWN.
- Updates both docs to match `agentcheck/inspect/capabilities.py`'s `_NAME_RULES` exactly: persistence-shaped names (including compound ones like `save_draft`, `store_result`, `persist_state`, `append_log`, which tokenize correctly) are documented as inferred state-changing/non-destructive; generic dispatch names (`bash`, `execute_python`, `execute_command`) remain documented as UNKNOWN since no rule covers them.
- Docs-only change; no behavior change.

## Test plan
- [x] Verified wording directly against `agentcheck/inspect/capabilities.py` (`_NAME_RULES`, `_tokens`, `_matched_rule`)
- [x] `pytest` documentation-consistency suite (6 tests) — passed locally
- [x] `ruff check agentcheck tests scripts` — clean
- [x] `scripts/check_no_secrets.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)