### PR TITLE
fix: worker-python probe required both framework SDKs regardless of adapter

### DIFF
--- a/agentcheck/runner/orchestrator.py
+++ b/agentcheck/runner/orchestrator.py
@@ -140,21 +140,36 @@ def _read_response(path: Path) -> dict[str, Any] | None:
     return raw if isinstance(raw, dict) else None
 
 
-def _probe_worker_python(executable: Path) -> None:
-    """Fail closed if the selected interpreter cannot host an AgentCheck worker."""
+_ADAPTER_PROBE_MODULES: dict[str, tuple[str, ...]] = {
+    "openai_agents": ("agents",),
+    "pydantic_ai": ("pydantic_ai",),
+    "custom": (),
+}
+
+
+def _probe_worker_python(executable: Path, config: AgentCheckConfig) -> None:
+    """Fail closed if the selected interpreter cannot host an AgentCheck worker.
+
+    Only requires the framework package the *configured* adapter actually
+    needs. A worker interpreter is commonly a target-local, framework-isolated
+    venv (the CLI's own ``--python`` help text suggests exactly this) -- one
+    that deliberately has only ``pydantic-ai`` installed, say, with no
+    ``openai-agents`` at all. Probing for every framework unconditionally
+    would fail closed on that legitimate, recommended setup for a reason
+    unrelated to whether the worker can actually run this target.
+    """
 
     probe_config = AgentCheckConfig()
     environment = child_environment(probe_config)
     environment["PYTHONPATH"] = str(_PACKAGE_ROOT)
+    required_modules = ("agentcheck", "pydantic", *_ADAPTER_PROBE_MODULES[config.adapter])
+    import_line = "import sys, " + ", ".join(required_modules)
     try:
         completed = subprocess.run(
             [
                 str(executable),
                 "-c",
-                (
-                    "import sys, agentcheck, pydantic, agents\n"
-                    "print('%d.%d.%d' % sys.version_info[:3])"
-                ),
+                (f"{import_line}\nprint('%d.%d.%d' % sys.version_info[:3])"),
             ],
             env=environment,
             stdin=subprocess.DEVNULL,
@@ -177,11 +192,11 @@ def _probe_worker_python(executable: Path) -> None:
         )
         raise ConfigurationError(
             "The selected python_executable could not import AgentCheck and its "
-            "runtime dependencies (pydantic, openai-agents). Install AgentCheck "
-            "into that environment (`python -m pip install -e '.[agentcheck]'`) "
-            "or run AgentCheck from an environment that already contains the "
-            "target's dependencies. AgentCheck does not install packages "
-            "automatically. "
+            f"runtime dependencies ({', '.join(required_modules[1:])}). Install "
+            "AgentCheck into that environment (`python -m pip install -e "
+            "'.[agentcheck]'`) or run AgentCheck from an environment that already "
+            "contains the target's dependencies. AgentCheck does not install "
+            "packages automatically. "
             f"{stderr}".strip()
         )
     version_text = completed.stdout.decode("utf-8", errors="replace").strip().splitlines()
@@ -224,7 +239,7 @@ def _worker_command(root: Path, config: AgentCheckConfig) -> list[str]:
     # Compare the invoked wrapper paths, not symlink targets. Two venvs may
     # share a base interpreter binary but have different site-packages.
     if os.path.normpath(str(executable)) != os.path.normpath(sys.executable):
-        _probe_worker_python(executable)
+        _probe_worker_python(executable, config)
     return [
         str(executable),
         "-c",

--- a/tests/agentcheck/test_target_loading.py
+++ b/tests/agentcheck/test_target_loading.py
@@ -286,6 +286,74 @@ def test_prepared_venv_with_extra_package_is_used(tmp_path: Path) -> None:
     assert result.require_value().identity.name.value == "PreparedExtra"
 
 
+CUSTOM_AGENT = """
+from agentcheck import ToolRuntime, TurnResult
+
+
+class MinimalCustomAgent:
+    name = "Minimal"
+    instructions = "Do nothing."
+    tools = ()
+
+    def start(self, message: str, tools: ToolRuntime) -> TurnResult:
+        return TurnResult(output="ok")
+
+
+agent = MinimalCustomAgent()
+"""
+
+
+@POSIX_ONLY
+def test_worker_python_probe_does_not_require_unrelated_framework_sdks(
+    tmp_path: Path,
+) -> None:
+    """A worker interpreter for one adapter must not need another adapter's SDK.
+
+    Reproduces a real bug found validating an independent PydanticAI target
+    (a Slack bolt starter agent) with a dedicated, framework-isolated
+    ``--python`` interpreter -- exactly the setup the CLI's own ``--python``
+    help text recommends. The probe used to hardcode ``import ... agents``
+    unconditionally, so a legitimate pydantic-ai-only (or, as tested here,
+    framework-free ``custom``-adapter) worker venv failed closed with a
+    misleading "could not import ... openai-agents" error even though that
+    adapter needs no such package. A bare venv with only the base AgentCheck
+    package installed -- no framework extra at all -- is the sharpest
+    reproduction: it must work for a ``custom``-adapter target, which needs
+    neither SDK.
+    """
+    root = _init(tmp_path / "target", "agent.py:agent")
+    (root / "agent.py").write_text(CUSTOM_AGENT.lstrip(), encoding="utf-8")
+
+    venv_dir = tmp_path / "bare-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_dir)],
+        check=True,
+        capture_output=True,
+    )
+    venv_python = venv_dir / "bin" / "python"
+    package_root = Path(__file__).resolve().parents[2]
+    subprocess.run(
+        [str(venv_python), "-m", "pip", "install", "-q", str(package_root)],
+        check=True,
+        capture_output=True,
+        timeout=180,
+    )
+    # Confirm the bare venv genuinely lacks both framework SDKs -- otherwise
+    # this test would pass for the wrong reason.
+    missing = subprocess.run(
+        [str(venv_python), "-c", "import agents"],
+        capture_output=True,
+    )
+    assert missing.returncode != 0, "bare venv unexpectedly has openai-agents installed"
+
+    _, config = load_config(root)
+    config = config.model_copy(update={"adapter": "custom"})
+    config = apply_python_executable(config, str(venv_python))
+    result = inspect_in_subprocess(root, config)
+    assert result.ok, result.infrastructure_error
+    assert result.require_value().identity.name.value == "Minimal"
+
+
 def test_child_environment_still_omits_credentials_with_explicit_python(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Found validating an independent PydanticAI target
(`slack-samples/bolt-python-starter-agent` @ `620efde`, an official Slack
sample with real `deps_type` dependency injection and a genuine
state-changing tool, `add_emoji_reaction`) using a dedicated `--python`
interpreter pointing at a pydantic-ai-only venv — exactly the isolated-
interpreter pattern the CLI's own `--python` help text recommends.

`_probe_worker_python()` unconditionally ran `import ... agentcheck,
pydantic, agents`, so any worker interpreter without `openai-agents`
installed failed closed with a misleading "could not import AgentCheck and
its runtime dependencies (pydantic, openai-agents)" error — even for a
`pydantic_ai` or `custom` adapter target that needs neither `agents` nor,
for `custom`, either framework SDK. This directly contradicts this
project's own separate-extras guarantee ("evaluating one framework never
installs the other").

- Adds `_ADAPTER_PROBE_MODULES`, mapping each adapter to the framework
  package(s) its worker interpreter actually needs (`agents` for
  `openai_agents`, `pydantic_ai` for `pydantic_ai`, none extra for
  `custom`).
- `_probe_worker_python` now takes the real `AgentCheckConfig` and only
  probes for the modules that adapter needs.
- Error message lists the actual required modules for that adapter instead
  of always naming both frameworks.

## Test plan

- [x] New regression test
      `test_worker_python_probe_does_not_require_unrelated_framework_sdks`:
      builds a real bare venv (base AgentCheck install, no framework extra)
      and confirms a `custom`-adapter target inspects successfully through
      it. Confirmed this fails on pre-fix code (`ModuleNotFoundError: No
      module named 'agents'`) and passes on the fix.
- [x] Revalidated against the original real-world target: `agentcheck
      inspect` now succeeds with a pydantic-ai-only worker interpreter,
      correctly detecting `add_emoji_reaction` as state-changing.
- [x] `ruff check agentcheck tests scripts` — clean
- [x] `mypy agentcheck` — clean (97 files)
- [x] Focused suite: `test_target_loading.py`, `test_worker_process.py`,
      `test_custom_agent_adapter.py` — 108 passed
- Full exhaustive matrix left to this PR's own CI, not reproduced locally.

Provider spend: **$0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)