### PR TITLE
Release prep: 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## 0.4.1 (2026-08-28)
+
+One fix, found validating an independent PydanticAI target
+(`slack-samples/bolt-python-starter-agent`) with a dedicated,
+framework-isolated `--python` interpreter -- exactly the setup the CLI's
+own `--python` help text recommends.
+
+**Worker-python probe required both framework SDKs regardless of
+adapter.** `_probe_worker_python()` unconditionally imported `agents`
+(the OpenAI Agents SDK) in the candidate worker interpreter, so a
+`pydantic_ai`- or `custom`-adapter target using an isolated interpreter
+that only had `pydantic-ai` installed (or neither framework, for
+`custom`) failed closed with a misleading "could not import AgentCheck
+and its runtime dependencies (pydantic, openai-agents)" error -- even
+though that adapter needs no such package. This directly contradicted the
+project's own separate-extras guarantee ("evaluating one framework never
+installs the other"). Fixed: the probe now imports only the framework
+package the *configured* adapter actually needs.
+
+**Suite identity:** unaffected. `GENERATOR_COMPATIBILITY_VERSION` stays
+`1`; this fix changes worker-interpreter diagnostics only, not inspection,
+generation, or evaluation semantics. No target's `spec_id` moves.
+
 ## 0.4.0 (2026-08-27)
 
 One new capability, four fixes found by hands-on reliability sweeps and real

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.4.0"
+version = "0.4.1"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release-readiness prep for **0.4.1** (PATCH). Version-metadata and
CHANGELOG only; the fix itself already merged in #56.

- Bumps `pyproject.toml` `version` and `agentcheck.__version__` to `0.4.1`.
- Adds the CHANGELOG entry for #56: the worker-python probe required both
  framework SDKs regardless of the configured adapter, breaking a
  legitimate pydantic-ai-only or `custom`-adapter worker interpreter — the
  exact isolated-interpreter pattern the CLI's own `--python` help text
  recommends.

**Why PATCH, not MINOR:** correctness fix only, no new capability, no
serialized-contract change. `GENERATOR_COMPATIBILITY_VERSION` unchanged; no
target's `spec_id` moves.

## Test plan

Local focused validation — the full suite already ran on #56's own PR CI
and on its post-merge run, so it is not reproduced again here:

- [x] `tests/agentcheck/test_version_decoupling.py` (11/11)
- [x] `ruff check agentcheck tests scripts` — clean
- [x] `mypy agentcheck` — clean (97 files)
- [x] `scripts/check_no_secrets.py` — clean
- [x] `python -m build` — both artifacts built, correctly labeled `0.4.1`
- [x] `scripts/check_distribution.py` — clean
- [x] Wheel-install and base-install smokes — both report `0.4.1`, base
      stays framework-independent
- [x] `openai-agents` extra — 21/21; `pydantic-ai` extra — 44/44
- [x] `scripts/check_workflow_safety.py` — clean

Provider spend: **$0**.

## Not in this PR

No GitHub Release, tag, or PyPI publish — prepared and executed as a
separate step after this merges, per the established release policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)