### PR TITLE
fix: "refund" fell into the weakest read-only risk-inference bucket

### DIFF
--- a/agentcheck/inspect/capabilities.py
+++ b/agentcheck/inspect/capabilities.py
@@ -74,9 +74,18 @@ _COMPOSITION_KEYWORDS = (
 # the project's own convention is to let a developer's explicit
 # `tool_risk` declaration escalate further rather than guess destructive from
 # a name alone.
+#
+# "refund" was added after a real, independently-maintained target's
+# request_refund tool -- a genuine financial state-changing action whose own
+# docstring reads "This action changes the order status and triggers a
+# refund process" -- fell through every rule to the same OTHER/read-
+# only/confidence 0.3 bucket. Grouped with cancel/terminate/close rather
+# than update/modify's non-destructive bucket: a refund reverses money
+# already collected, the same "undoes a completed state, real consequence"
+# shape as a cancellation, not a simple field edit.
 _NAME_RULES: tuple[tuple[frozenset[str], ActionKind, bool, bool], ...] = (
     (frozenset({"delete", "remove", "destroy", "erase", "purge"}), ActionKind.DELETE, True, True),
-    (frozenset({"cancel", "terminate", "close"}), ActionKind.MODIFY, True, True),
+    (frozenset({"cancel", "terminate", "close", "refund"}), ActionKind.MODIFY, True, True),
     (frozenset({"update", "modify", "change", "set", "edit"}), ActionKind.MODIFY, True, False),
     (
         frozenset(

--- a/tests/agentcheck/test_capabilities.py
+++ b/tests/agentcheck/test_capabilities.py
@@ -398,6 +398,7 @@ def test_absent_schema_yields_no_parameters_without_failing() -> None:
         ("delete_account", ActionKind.DELETE, True, True),
         ("purge_records", ActionKind.DELETE, True, True),
         ("cancel_subscription", ActionKind.MODIFY, True, True),
+        ("request_refund", ActionKind.MODIFY, True, True),
         ("update_email", ActionKind.MODIFY, True, False),
         ("create_ticket", ActionKind.CREATE, True, False),
         ("write", ActionKind.CREATE, True, False),
@@ -444,6 +445,32 @@ def test_a_bare_write_tool_is_not_silently_classified_read_only() -> None:
 
     assert capability.capability.state_changing is True
     assert capability.capability.action_kind is ActionKind.CREATE
+
+
+def test_a_refund_tool_is_not_silently_classified_read_only() -> None:
+    """Reproduces a real independent target's request_refund tool (an
+    e-commerce PydanticAI support agent): a genuine financial state-changing
+    action whose own docstring says it changes order status and triggers a
+    refund process. Before "refund" was added to the name vocabulary, this
+    fell through every rule to OTHER/read-only/confidence 0.3 -- the single
+    lowest-confidence, least-scrutinized classification -- for a tool that
+    reverses money already collected."""
+
+    capability = extract_capabilities(
+        [
+            _tool(
+                "request_refund",
+                description=(
+                    "Submit a refund request for an order. This action "
+                    "changes the order status and triggers a refund process."
+                ),
+            )
+        ]
+    )[0]
+
+    assert capability.capability.state_changing is True
+    assert capability.capability.destructive is True
+    assert capability.capability.action_kind is ActionKind.MODIFY
 
 
 def test_classification_matches_the_phase_one_name_vocabulary() -> None:


### PR DESCRIPTION
## Summary

Found running a fresh external-validation campaign against an independent PydanticAI e-commerce support agent (real repo, a `request_refund` tool with genuine order-eligibility logic and DB-backed reversal of a completed payment). `request_refund` inspected as `other, read-only (confidence 0.30)` — the single lowest-confidence, least-scrutinized bucket — for a tool whose own docstring says it changes order status and triggers a refund process. Exactly the same defect class as PR #53's `write` gap.

- Adds `"refund"` to the `cancel`/`terminate`/`close` name-token group (`ActionKind.MODIFY`, state-changing, destructive) rather than `update`/`modify`'s non-destructive bucket — a refund reverses money already collected, the same real, hard-to-undo consequence as a cancellation.

## Test plan

- [x] New regression test `test_a_refund_tool_is_not_silently_classified_read_only`, reproducing the real target's exact tool name and docstring. Confirmed to fail on pre-fix code (`state_changing=False`) and pass on the fix.
- [x] Revalidated against the original target: `inspect` now correctly shows `request_refund` as `(state-changing, destructive)`.
- [x] Full pipeline against the same target: `inspect` → `generate` → `fixtures init` → `test` completed, **31/31 PASS**, zero original handler executions, zero real mutations.
- [x] `ruff check agentcheck tests scripts` — clean
- [x] `mypy agentcheck` — clean (97 files)
- [x] Focused suite (`test_capabilities.py`, `test_tool_risk_authority.py`) — 79 passed
- Full exhaustive matrix left to this PR's own CI, not reproduced locally.

Provider spend: **$0**. The target's `Agent(...)` eagerly constructs its Anthropic provider at construction time, so a placeholder `ANTHROPIC_API_KEY` was needed to satisfy that constructor — it never reached the network (`allow_network: false`, `controlled_model: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)