### PR TITLE
Release prep: 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## 0.4.2 (2026-08-28)
+
+One fix, found running a broader external-validation campaign against
+independent, real-world OpenAI Agents SDK and PydanticAI repositories.
+
+**"refund" fell into the weakest read-only risk-inference bucket.** A
+real, independently-maintained PydanticAI e-commerce support agent's
+`request_refund` tool -- genuine order-eligibility logic reversing a
+completed payment -- inspected as `other, read-only (confidence 0.30)`,
+the same defect class 0.3.0's `write` gap was. `"refund"` now joins the
+`cancel`/`terminate`/`close` name-token group (state-changing,
+destructive): a refund reverses money already collected, the same
+real, hard-to-undo consequence as a cancellation.
+
+**Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. **Breaking
+for any target with a matching, undeclared tool name:** same category of
+break as the `write` fix in 0.4.0 -- a target with an undeclared tool named
+`refund` (or a compound name containing that token, e.g. `process_refund`)
+gets a new `spec_id`, and any frozen suite generated before this fix is
+rejected as stale until regenerated. A target that declares `tool_risk`
+explicitly for that tool, or has no matching tool name at all, is
+unaffected.
+
 ## 0.4.1 (2026-08-28)
 
 One fix, found validating an independent PydanticAI target

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.4.1"
+version = "0.4.2"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release-readiness prep for **0.4.2** (PATCH). Version-metadata and CHANGELOG only; the fix itself already merged in #58.

- Bumps `pyproject.toml` `version` and `agentcheck.__version__` to `0.4.2`.
- Adds the CHANGELOG entry for #58: `"refund"` fell into the weakest read-only risk-inference bucket, found running a broader external-validation campaign against `linardsb/GERBONI`, an independent PydanticAI e-commerce support agent.

**Why PATCH, not MINOR:** correctness fix only, no new capability.

**Compatibility:** `GENERATOR_COMPATIBILITY_VERSION` unchanged. One narrow exception noted explicitly: a target with an undeclared tool named `refund` (or a compound name containing that token) gets a new `spec_id` — same category as 0.4.0's `write`-fix precedent.

## Test plan

Local focused validation — the full suite already ran on #58's own PR CI and post-merge run:

- [x] `tests/agentcheck/test_version_decoupling.py` (11/11)
- [x] `ruff check` / `mypy` — clean
- [x] `scripts/check_no_secrets.py` — clean
- [x] `python -m build` + `scripts/check_distribution.py` — clean, artifacts labeled `0.4.2`
- [x] Wheel-install and base-install smokes — both report `0.4.2`
- [x] `scripts/check_workflow_safety.py` — clean

Provider spend: **$0**.

## Not in this PR

No GitHub Release, tag, or PyPI publish — executed as a separate step after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)