### PR TITLE
feat: developer-declared MCP tool manifests for PydanticAI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## 0.5.0 (2026-08-28)
+
+**PydanticAI agents with external (MCP) toolsets are no longer refused
+outright.** Previously any non-function toolset on the agent — the shape a
+real MCP-backed agent has — tripped `unsupported_toolset` at `preflight`
+unconditionally. AgentCheck still never connects to a real MCP server
+anywhere in its pipeline: that would mean spawning a subprocess or making a
+network call against target-controlled code during `inspect`, `generate`, or
+`run`, which the no-target-execution and network-deny-by-default invariants
+rule out. Instead, a developer can now declare the external toolset's tool
+schemas by hand in `agentcheck-mcp-manifest.json` (same directory as
+`agentcheck.json`), authored once out of band by connecting to the real
+server with their own credentials. A declared tool is folded into the
+target's spec exactly like a function tool -- risk-resolved, fault-tested,
+and simulated through `ToolGateway` -- while the real external toolset is
+never queried or called. The manifest loader mirrors the fixtures loader's
+safety discipline exactly: contained-path resolution with `O_NOFOLLOW`, a
+byte-size cap, `extra="forbid"` schema validation, and every declared
+`input_schema` rejected if it references a non-local `$ref`/`$dynamicRef`.
+See [docs/mcp-manifest.md](docs/mcp-manifest.md). The OpenAI Agents SDK and
+Custom adapters accept the new parameter but do not yet act on it -- there is
+no external-toolset concept on those adapters today.
+
+**Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. Not
+breaking for any existing target: a target with no
+`agentcheck-mcp-manifest.json` behaves exactly as before, including agents
+with an external toolset, which are still refused at `preflight` exactly as
+before absent a manifest.
+
 ## 0.4.2 (2026-08-28)
 
 One fix, found running a broader external-validation campaign against

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/agentcheck/adapters/base.py
+++ b/agentcheck/adapters/base.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from agentcheck.domain.agent_spec import AgentSpec
     from agentcheck.domain.run import CanonicalRun
     from agentcheck.domain.scenario import ConversationTurn
+    from agentcheck.mcp_manifest import McpManifest
 
 
 class AdapterError(RuntimeError):
@@ -418,6 +419,7 @@ class FrameworkAdapter(ABC):
         source: str | None = None,
         identity_locator: str | None = None,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> "AgentSpec":
         """Extract an explicit, versioned specification without running the model.
 
@@ -434,11 +436,26 @@ class FrameworkAdapter(ABC):
         and ``destructive`` axes; an axis a declaration does not name still
         falls through to inference. Omitting it keeps prior behaviour exactly:
         every tool resolves through inference or ``UNKNOWN`` alone.
+
+        ``mcp_manifest`` is the developer's frozen snapshot of an external
+        (non-function) toolset's tool schemas -- see
+        ``agentcheck.mcp_manifest.McpManifest``. An adapter with no concept of
+        an external toolset ignores it. Omitting it keeps prior behaviour
+        exactly: a target with any such toolset stays unsupported.
         """
 
     @abstractmethod
-    def preflight(self, target: Any) -> PreflightReport:
-        """Decide whether every executable surface can be intercepted safely."""
+    def preflight(
+        self, target: Any, *, mcp_manifest: "McpManifest | None" = None
+    ) -> PreflightReport:
+        """Decide whether every executable surface can be intercepted safely.
+
+        ``mcp_manifest`` has the same meaning as in ``inspect``: when given, it
+        is the developer taking explicit responsibility for an external
+        toolset's schemas, which is what allows that toolset to stop being an
+        unconditional ``unsupported_toolset`` finding for adapters that
+        support one.
+        """
 
     @abstractmethod
     def prepare(
@@ -452,6 +469,7 @@ class FrameworkAdapter(ABC):
         identity_locator: str | None = None,
         controlled_model: bool = False,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> PreparedTarget:
         """Return a sanitized runtime target or fail before model execution.
 
@@ -462,6 +480,9 @@ class FrameworkAdapter(ABC):
         to the prepared target, and the risk markers used to build the actual
         runtime invokers, resolve through the same developer declarations
         rather than disagreeing with each other.
+
+        ``mcp_manifest`` is forwarded to ``inspect`` and ``preflight`` for the
+        same reason: one declaration, read consistently everywhere it matters.
         """
 
     def describe_topology(

--- a/agentcheck/adapters/custom.py
+++ b/agentcheck/adapters/custom.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from agentcheck.config import ToolRiskDeclaration
+    from agentcheck.mcp_manifest import McpManifest
 
 from jsonschema.exceptions import SchemaError  # type: ignore[import-untyped]
 
@@ -822,6 +823,7 @@ class CustomAgentAdapter(FrameworkAdapter):
         source: str | None = None,
         identity_locator: str | None = None,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> AgentSpec:
         """Describe the declared surface. Nothing on the target is executed.
 
@@ -832,6 +834,7 @@ class CustomAgentAdapter(FrameworkAdapter):
         of the target access.
         """
 
+        del mcp_manifest  # No external-toolset concept on this adapter yet.
         locator = source or f"{type(target).__module__}.{type(target).__name__}"
         tool_risk_assertions: dict[str, ToolRiskAssertion] = {}
         definitions: list[ToolDefinition] = []
@@ -1080,7 +1083,9 @@ class CustomAgentAdapter(FrameworkAdapter):
 
     # -- support decision ---------------------------------------------------
 
-    def preflight(self, target: Any) -> PreflightReport:
+    def preflight(
+        self, target: Any, *, mcp_manifest: "McpManifest | None" = None
+    ) -> PreflightReport:
         """Refuse a target that cannot be driven safely, before it is driven.
 
         Every check is structural. Nothing here calls ``start``, ``resume`` or
@@ -1088,6 +1093,7 @@ class CustomAgentAdapter(FrameworkAdapter):
         declaration that has to be executed to be read is not a declaration.
         """
 
+        del mcp_manifest  # No external-toolset concept on this adapter yet.
         if not self._implements_any_of_the_contract(target):
             # One diagnosis, not three symptoms. An object with none of the
             # contract on it is almost always the wrong object -- a config
@@ -1282,6 +1288,7 @@ class CustomAgentAdapter(FrameworkAdapter):
         identity_locator: str | None = None,
         controlled_model: bool = False,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> PreparedTarget:
         """Bind the declared agent to a gateway, or refuse before it runs.
 
@@ -1292,6 +1299,7 @@ class CustomAgentAdapter(FrameworkAdapter):
         constructed here.
         """
 
+        del mcp_manifest  # No external-toolset concept on this adapter yet.
         if controlled_model:
             # Refused, not recorded as a caveat. AgentCheck substitutes a
             # deterministic model by rebuilding the target around one, and a

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -66,6 +66,7 @@ from agentcheck.inspect.risk_authority import declared_risk_for, resolve_tool_ri
 
 if TYPE_CHECKING:
     from agentcheck.config import ToolRiskDeclaration
+    from agentcheck.mcp_manifest import McpManifest
 from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
 from agentcheck.runner.budgets import BudgetExceeded
 from agentcheck.runner.launch_barrier import LaunchBarrier
@@ -2019,7 +2020,9 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
         source: str | None = None,
         identity_locator: str | None = None,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> AgentSpec:
+        del mcp_manifest  # No external-toolset concept on this adapter yet.
         _require_sdk()
         source = source or "runtime:agent"
         if type(target) is not Agent:
@@ -2467,7 +2470,10 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
             ),
         )
 
-    def preflight(self, target: Any) -> PreflightReport:
+    def preflight(
+        self, target: Any, *, mcp_manifest: "McpManifest | None" = None
+    ) -> PreflightReport:
+        del mcp_manifest  # No external-toolset concept on this adapter yet.
         _require_sdk()
         issues: list[SupportIssue] = []
         version = _sdk_version()
@@ -2711,7 +2717,9 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
         identity_locator: str | None = None,
         controlled_model: bool = False,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> PreparedTarget:
+        del mcp_manifest  # No external-toolset concept on this adapter yet.
         report = self.preflight(target)
         report.require_supported()
         spec = self.inspect(

--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -55,6 +55,7 @@ from agentcheck.domain.run import (
     UsageMetrics,
 )
 from agentcheck.domain.scenario import ConversationRole, ConversationTurn
+from agentcheck.errors import ConfigurationError
 from agentcheck.inspect.capabilities import extract_capabilities
 from agentcheck.inspect.risk_authority import declared_risk_for, resolve_tool_risk
 from agentcheck.runner.launch_barrier import LaunchBarrier
@@ -64,6 +65,7 @@ from jsonschema.exceptions import SchemaError  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from agentcheck.config import ToolRiskDeclaration
+    from agentcheck.mcp_manifest import McpManifest
 
 from .base import (
     guess_other_adapter,
@@ -361,6 +363,40 @@ def _tool_definition(
         name=name,
         description=resolved,
         input_schema=dict(schema) if isinstance(schema, Mapping) else {},
+        output_schema=None,
+        state_changing=state_changing,
+        destructive=destructive,
+        replaceable=True,
+    )
+    return definition, assertion
+
+
+def _manifest_tool_definition(
+    name: str,
+    declared: "Any",
+    *,
+    declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+) -> tuple[ToolDefinition, ToolRiskAssertion]:
+    """The manifest equivalent of ``_tool_definition``.
+
+    Same resolution path (risk goes through the identical ``tool_risk``
+    declaration/inference precedence every other tool uses), the only
+    difference is where the raw name/description/schema come from: a
+    developer's frozen ``DeclaredMcpTool`` entry instead of a live PydanticAI
+    ``Tool`` object, because there is no live object here -- see
+    ``agentcheck/mcp_manifest/pack.py`` for why.
+    """
+
+    description = declared.description
+    resolved = description if isinstance(description, str) and description else None
+    risk_declared = declared_risk_for(name, declared_tool_risk)
+    state_changing, destructive, assertion = resolve_tool_risk(
+        name, resolved, declared=risk_declared
+    )
+    definition = ToolDefinition(
+        name=name,
+        description=resolved,
+        input_schema=dict(declared.input_schema),
         output_schema=None,
         state_changing=state_changing,
         destructive=destructive,
@@ -1097,6 +1133,7 @@ class PydanticAIAdapter(FrameworkAdapter):
         source: str | None = None,
         identity_locator: str | None = None,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> AgentSpec:
         _require_sdk()
         locator = source or f"{type(target).__module__}.{type(target).__name__}"
@@ -1110,6 +1147,7 @@ class PydanticAIAdapter(FrameworkAdapter):
         tool_properties: list[AgentProperty[Any]] = []
         tool_risk_assertions: dict[str, ToolRiskAssertion] = {}
         fingerprint_tools: list[Any] = []
+        function_tool_names = set(_agent_tools(target).keys())
         for index, (name, tool) in enumerate(sorted(_agent_tools(target).items())):
             definition, risk_assertion = _tool_definition(
                 name, tool, declared_tool_risk=declared_tool_risk
@@ -1128,6 +1166,37 @@ class PydanticAIAdapter(FrameworkAdapter):
                     authoritative=False,
                 )
             )
+
+        if mcp_manifest is not None:
+            offset = len(fingerprint_tools)
+            for index, (name, declared) in enumerate(sorted(mcp_manifest.tools.items())):
+                if name in function_tool_names:
+                    raise ConfigurationError(
+                        f"agentcheck-mcp-manifest.json declares {name!r}, which is "
+                        "also a real function tool on this agent -- a manifest may "
+                        "only name tools that come from an external toolset."
+                    )
+                definition, risk_assertion = _manifest_tool_definition(
+                    name, declared, declared_tool_risk=declared_tool_risk
+                )
+                definitions.append(definition)
+                tool_risk_assertions[name] = risk_assertion
+                fingerprint_tools.append(definition.model_dump(mode="json"))
+                tool_properties.append(
+                    _property(
+                        definition,
+                        locator=f"{locator}.mcp_manifest.tools[{offset + index}]",
+                        summary=(
+                            "Tool name, description, and JSON Schema from the "
+                            "developer-declared MCP manifest, not read from a live "
+                            "server."
+                        ),
+                        kind=SourceKind.TOOL_SCHEMA,
+                        confidence=0.9,
+                        inferred=True,
+                        authoritative=False,
+                    )
+                )
 
         capabilities = [
             _property(
@@ -1332,7 +1401,9 @@ class PydanticAIAdapter(FrameworkAdapter):
             ),
         )
 
-    def preflight(self, target: Any) -> PreflightReport:
+    def preflight(
+        self, target: Any, *, mcp_manifest: "McpManifest | None" = None
+    ) -> PreflightReport:
         """Decide, before any model call, whether every surface can be replaced."""
 
         if _SDK_IMPORT_ERROR is not None:
@@ -1475,13 +1546,15 @@ class PydanticAIAdapter(FrameworkAdapter):
         toolsets = list(getattr(target, "toolsets", ()) or ())
         own = _agent_toolset(target)
         extra = [t for t in toolsets if t is not own]
-        if extra:
+        if extra and mcp_manifest is None:
             issues.append(
                 SupportIssue(
                     code="unsupported_toolset",
                     message=(
                         "Only the agent's own function toolset is supported; external "
-                        "toolsets are not replaced."
+                        "toolsets are not replaced. To evaluate one anyway, declare "
+                        "its tool schemas in agentcheck-mcp-manifest.json -- see "
+                        "docs/mcp-manifest.md."
                     ),
                     location="agent.toolsets",
                 )
@@ -1531,15 +1604,17 @@ class PydanticAIAdapter(FrameworkAdapter):
         identity_locator: str | None = None,
         controlled_model: bool = False,
         declared_tool_risk: "Mapping[str, ToolRiskDeclaration] | None" = None,
+        mcp_manifest: "McpManifest | None" = None,
     ) -> PreparedTarget:
         _require_sdk()
-        report = self.preflight(target)
+        report = self.preflight(target, mcp_manifest=mcp_manifest)
         report.require_supported()
         spec = self.inspect(
             target,
             source=source,
             identity_locator=identity_locator,
             declared_tool_risk=declared_tool_risk,
+            mcp_manifest=mcp_manifest,
         )
         require_known_tool_risk_names(spec, declared_tool_risk)
 

--- a/agentcheck/mcp_manifest/__init__.py
+++ b/agentcheck/mcp_manifest/__init__.py
@@ -1,0 +1,17 @@
+"""Developer-declared schemas for a target's external (MCP) toolsets."""
+
+from .loader import load_mcp_manifest
+from .pack import (
+    DEFAULT_MCP_MANIFEST_FILENAME,
+    MCP_MANIFEST_CONTRACT_VERSION,
+    DeclaredMcpTool,
+    McpManifest,
+)
+
+__all__ = [
+    "DEFAULT_MCP_MANIFEST_FILENAME",
+    "MCP_MANIFEST_CONTRACT_VERSION",
+    "DeclaredMcpTool",
+    "McpManifest",
+    "load_mcp_manifest",
+]

--- a/agentcheck/mcp_manifest/loader.py
+++ b/agentcheck/mcp_manifest/loader.py
@@ -1,0 +1,76 @@
+"""Load and validate a developer-declared external-toolset manifest.
+
+Mirrors ``agentcheck/fixtures/loader.py`` deliberately: contained path, no
+symlink following, bounded size, versioned contract, offline-only schema
+validation, and a ``ConfigurationError`` on anything malformed. A manifest
+that cannot be trusted is refused rather than partially applied -- the same
+reasoning as fixtures: a silently ignored or partially-read declaration would
+look like coverage the target does not actually have.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from agentcheck.config import contained_path
+from agentcheck.errors import ConfigurationError
+from agentcheck.schema_safety import UnsafeSchemaReference, offline_validator
+
+from .pack import DEFAULT_MCP_MANIFEST_FILENAME, McpManifest
+
+
+_MAX_MANIFEST_BYTES = 256 * 1024
+
+
+def load_mcp_manifest(root: Path, *, filename: str | None = None) -> McpManifest | None:
+    """Read the target's MCP manifest file, or ``None`` when it declares none.
+
+    Absence is the normal case, not an error: a target with no external
+    toolset needs no manifest, and one that has one but declares no manifest
+    keeps failing closed exactly as before this existed.
+    """
+
+    name = filename or DEFAULT_MCP_MANIFEST_FILENAME
+    path = contained_path(root, name)
+    if not path.exists():
+        return None
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ConfigurationError(f"unable to read {name}: {exc}") from exc
+    try:
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            raw = handle.read(_MAX_MANIFEST_BYTES + 1)
+    except OSError as exc:
+        raise ConfigurationError(f"unable to read {name}: {exc}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if len(raw) > _MAX_MANIFEST_BYTES:
+        raise ConfigurationError(
+            f"{name} exceeds the {_MAX_MANIFEST_BYTES} byte manifest limit"
+        )
+    try:
+        manifest = McpManifest.model_validate_json(raw)
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ConfigurationError(f"invalid {name}: {exc}") from exc
+    for tool_name, declared in manifest.tools.items():
+        try:
+            offline_validator(declared.input_schema)
+        except UnsafeSchemaReference as exc:
+            raise ConfigurationError(
+                f"{name}: tool {tool_name!r} input_schema {exc}"
+            ) from exc
+        except Exception as exc:  # jsonschema's own schema-validity errors
+            raise ConfigurationError(
+                f"{name}: tool {tool_name!r} input_schema is not a valid JSON Schema: {exc}"
+            ) from exc
+    return manifest
+
+
+__all__ = ["load_mcp_manifest"]

--- a/agentcheck/mcp_manifest/pack.py
+++ b/agentcheck/mcp_manifest/pack.py
@@ -1,0 +1,76 @@
+"""Developer-declared schemas for an external (non-function) toolset.
+
+PydanticAI agents that get their tools from an MCP server (``MCPToolset`` and
+its predecessors ``MCPServerStdio``/``MCPServerSSE``/etc.) do not carry a
+static tool list the way a plain ``@agent.tool``-decorated function toolset
+does: the schemas only exist once something actually connects to that real
+server and asks it. AgentCheck never does that -- connecting would mean
+either spawning the target's declared subprocess or reaching a real network
+endpoint during ``inspect``, both of which are the exact things this
+project's network-deny-by-default and no-target-code-execution invariants
+exist to prevent (see ``../../projects/agentcheck/architecture/
+safety-invariants.md`` invariants 1, 2, and 8 in the Company Brain).
+
+This is the developer's answer, in the same spirit as
+``agentcheck-fixtures.json``: a frozen, committed snapshot of what the real
+MCP server was observed to expose, authored by the developer running their
+own introspection against their own server, with their own credentials,
+entirely outside AgentCheck. AgentCheck reads only this static file and never
+connects to the real server itself.
+
+This is explicitly a snapshot, not a live mirror. It can drift out of sync
+with the real server exactly the way a stale fixture can, and AgentCheck has
+no way to detect that -- the same limitation this project already accepts for
+fixtures, stated here for the same reason.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from agentcheck.domain import ContractModel, JsonObject
+
+
+MCP_MANIFEST_CONTRACT_VERSION: Literal["agentcheck.mcp_manifest.v1"] = (
+    "agentcheck.mcp_manifest.v1"
+)
+
+DEFAULT_MCP_MANIFEST_FILENAME = "agentcheck-mcp-manifest.json"
+
+
+class DeclaredMcpTool(ContractModel):
+    """One tool the developer observed the real MCP server exposing.
+
+    Shape mirrors ``ToolDefinition`` deliberately narrow: only what a
+    developer can read off the server's own ``tools/list`` response. Risk
+    (``state_changing``/``destructive``) is not declared here -- it goes
+    through the same ``tool_risk`` block in ``agentcheck.json`` every other
+    tool uses, so one declaration mechanism covers both tool sources rather
+    than a second, competing one.
+    """
+
+    description: str | None = Field(default=None, max_length=8_000)
+    input_schema: JsonObject = Field(default_factory=dict)
+
+
+class McpManifest(ContractModel):
+    """Frozen, developer-declared schemas for one target's external toolsets.
+
+    Unknown fields are rejected, matching every other committed AgentCheck
+    contract file.
+    """
+
+    schema_version: Literal["agentcheck.mcp_manifest.v1"] = (
+        MCP_MANIFEST_CONTRACT_VERSION
+    )
+    tools: dict[str, DeclaredMcpTool] = Field(default_factory=dict)
+
+
+__all__ = [
+    "DEFAULT_MCP_MANIFEST_FILENAME",
+    "MCP_MANIFEST_CONTRACT_VERSION",
+    "DeclaredMcpTool",
+    "McpManifest",
+]

--- a/agentcheck/runner/worker.py
+++ b/agentcheck/runner/worker.py
@@ -34,6 +34,7 @@ from agentcheck.domain import (
     ToolFixture,
 )
 from agentcheck.inspect import TargetLoadError, enable_contained_target_imports, load_target
+from agentcheck.mcp_manifest import load_mcp_manifest
 from agentcheck.privacy import redact_log_text
 
 from .network_guard import install_network_guard
@@ -248,6 +249,7 @@ def _inspect(
 ) -> tuple[Any, dict[str, Any], dict[str, Any] | None]:
     target, source = _load_agent(root, config)
     adapter = _adapter_for(config)
+    mcp_manifest = load_mcp_manifest(root)
     # A canonical target-relative locator for the same module `source` points
     # at, carrying no checkout location and no spelling of the same path.
     spec = adapter.inspect(
@@ -255,8 +257,9 @@ def _inspect(
         source=source,
         identity_locator=portable_entrypoint(root, config.entrypoint),
         declared_tool_risk=config.tool_risk,
+        mcp_manifest=mcp_manifest,
     )
-    preflight = encode_preflight_report(adapter.preflight(target))
+    preflight = encode_preflight_report(adapter.preflight(target, mcp_manifest=mcp_manifest))
     topology = adapter.describe_topology(target, source=source)
     return spec, preflight, topology
 
@@ -264,11 +267,13 @@ def _inspect(
 def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) -> Any:
     target, source = _load_agent(root, config)
     adapter = _adapter_for(config)
+    mcp_manifest = load_mcp_manifest(root)
     spec = adapter.inspect(
         target,
         source=source,
         identity_locator=portable_entrypoint(root, config.entrypoint),
         declared_tool_risk=config.tool_risk,
+        mcp_manifest=mcp_manifest,
     )
     tools = tuple(item.value for item in spec.tools.items)
     world = WorldSimulator(scenario.initial_world_state)
@@ -287,6 +292,7 @@ def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) 
         identity_locator=portable_entrypoint(root, config.entrypoint),
         controlled_model=config.controlled_model,
         declared_tool_risk=config.tool_risk,
+        mcp_manifest=mcp_manifest,
     )
     return asyncio.run(
         adapter.run(

--- a/docs/mcp-manifest.md
+++ b/docs/mcp-manifest.md
@@ -1,0 +1,76 @@
+# MCP tool manifests
+
+An agent whose tools come from an external toolset — the shape a real
+MCP-backed agent has — is refused at `preflight` with `unsupported_toolset`.
+AgentCheck only replaces tools it can fully own: the agent's own function
+toolset, whose schemas are static and known at inspect time. An MCP toolset's
+tools are discovered by connecting to a live server, and AgentCheck will not
+do that during `inspect`, `generate`, or `run` — that would mean either
+spawning a subprocess (stdio MCP) or making a network call (remote MCP)
+against target-controlled code, which is exactly what the no-target-execution
+and network-deny-by-default invariants exist to rule out.
+
+A developer-declared manifest is the only thing that lifts the refusal.
+
+## What it is
+
+`agentcheck-mcp-manifest.json` in the target root, alongside
+`agentcheck.json`:
+
+```json
+{
+  "schema_version": "agentcheck.mcp_manifest.v1",
+  "tools": {
+    "send_message": {
+      "description": "Send a message to a Slack channel.",
+      "input_schema": {
+        "type": "object",
+        "properties": { "channel": { "type": "string" }, "text": { "type": "string" } },
+        "required": ["channel", "text"]
+      }
+    }
+  }
+}
+```
+
+You write this by hand, once, out of band — by connecting to the real MCP
+server yourself, with your own credentials, and copying down the tool names,
+descriptions, and JSON Schemas it reports. AgentCheck never reads it back
+from a live server; it only ever reads this frozen file.
+
+Each declared tool is folded into the target's spec exactly like a function
+tool: it gets a `ToolDefinition`, participates in risk resolution (name +
+description inference, or an explicit override in `agentcheck.json`'s
+`tool_risk` block — see [fault-testing.md](fault-testing.md)), and is
+simulated through `ToolGateway` from fixtures like every other tool. The
+agent's real external toolset is never queried and never called; only the
+name has to match for AgentCheck to intercept the call.
+
+A name in the manifest that collides with a real function tool on the agent
+is a configuration error (`ConfigurationError`), not a silent override — the
+manifest may only name tools that come from an external toolset.
+
+## What it is not
+
+Not a live mirror. The manifest is a snapshot, with the same staleness risk
+as a fixtures file: if the real MCP server's schema changes, AgentCheck keeps
+testing against what you declared until you update the manifest by hand.
+
+Not validated against the real server by AgentCheck. Getting the schema
+wrong just means the simulated tool doesn't match reality — the same failure
+mode as a hand-written fixture that doesn't match a real tool's behavior.
+
+Not a way to test the MCP server itself, or the transport, or authentication
+to it. AgentCheck tests how the agent behaves given tool calls and results
+shaped the way you declared — the same behavioral surface it always tests,
+now extended to toolsets it previously couldn't see into at all.
+
+## Safety
+
+The manifest file goes through the same loader discipline as
+`agentcheck-fixtures.json`: contained-path resolution with `O_NOFOLLOW` (a
+symlink escaping the target directory is refused), a byte-size cap, strict
+schema validation (`extra="forbid"`), and `input_schema` for every declared
+tool is run through the same `offline_validator` that rejects non-local
+`$ref`/`$dynamicRef` — a manifest cannot smuggle in a remote schema fetch any
+more than a fixture can.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.4.2"
+version = "0.5.0"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/agentcheck/test_mcp_manifest.py
+++ b/tests/agentcheck/test_mcp_manifest.py
@@ -1,0 +1,323 @@
+"""Developer-declared MCP tool manifests: loader safety and adapter wiring.
+
+The core claim under test: a PydanticAI agent whose tools come from an
+external (non-function) toolset -- the shape a real MCP-backed agent has --
+is refused today, and a developer-declared, frozen manifest is the only
+thing that lifts that refusal. AgentCheck never connects to a real MCP
+server anywhere in this file; the fake external toolset below raises
+immediately if either of its methods is ever called, so a passing test here
+is itself proof that path was never touched.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.toolsets import AbstractToolset
+
+from agentcheck.adapters import PydanticAIAdapter
+from agentcheck.domain import (
+    ConversationRole,
+    ConversationTurn,
+    ResourceBudgets,
+    SimulatedToolOutcome,
+    SimulatedToolStatus,
+    ToolFixture,
+    ToolOutcomeStatus,
+)
+from agentcheck.errors import ConfigurationError
+from agentcheck.mcp_manifest import DeclaredMcpTool, McpManifest, load_mcp_manifest
+from agentcheck.runner import ToolGateway
+from agentcheck.runner.budgets import BudgetTracker
+
+
+class _NeverCalledExternalToolset(AbstractToolset[Any]):
+    """Stands in for a real MCP toolset without ever touching a real server.
+
+    Every method raises on entry. AgentCheck must never call any of them --
+    that is the entire safety property a manifest exists to preserve, and a
+    test that let this run for real would prove nothing about it.
+    """
+
+    @property
+    def id(self) -> str | None:
+        return "fake-mcp"
+
+    async def get_tools(self, ctx: RunContext[Any]) -> dict[str, Any]:
+        raise AssertionError("a real MCP connection must never be attempted")
+
+    async def call_tool(
+        self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: Any
+    ) -> Any:
+        raise AssertionError("the original external tool must never execute")
+
+
+def _agent_with_external_toolset(*, extra_function_tool: bool = False) -> Agent:
+    tools = []
+    if extra_function_tool:
+
+        def existing_tool(x: int) -> int:
+            raise AssertionError("real function tool handler must never run")
+
+        tools.append(existing_tool)
+    return Agent(
+        "test",
+        tools=tools,
+        toolsets=[_NeverCalledExternalToolset()],
+    )
+
+
+# --- preflight: refused without a manifest, supported with one -------------
+
+
+def test_external_toolset_without_manifest_is_still_refused() -> None:
+    agent = _agent_with_external_toolset()
+    report = PydanticAIAdapter().preflight(agent)
+    assert any(issue.code == "unsupported_toolset" for issue in report.issues)
+
+
+def test_external_toolset_with_manifest_is_supported() -> None:
+    agent = _agent_with_external_toolset()
+    manifest = McpManifest(
+        tools={
+            "send_message": DeclaredMcpTool(
+                description="Send a message.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            )
+        }
+    )
+    report = PydanticAIAdapter().preflight(agent, mcp_manifest=manifest)
+    assert not any(issue.code == "unsupported_toolset" for issue in report.issues)
+
+
+# --- inspect: manifest tools become real, risk-resolved ToolDefinitions ----
+
+
+def test_manifest_tool_is_added_to_the_spec_and_risk_resolved() -> None:
+    agent = _agent_with_external_toolset()
+    manifest = McpManifest(
+        tools={
+            "delete_reminder": DeclaredMcpTool(
+                description="Delete a reminder by id.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"reminder_id": {"type": "string"}},
+                    "required": ["reminder_id"],
+                },
+            )
+        }
+    )
+    spec = PydanticAIAdapter().inspect(agent, mcp_manifest=manifest)
+    names = {item.value.name for item in spec.tools.items}
+    assert "delete_reminder" in names
+    definition = next(
+        item.value for item in spec.tools.items if item.value.name == "delete_reminder"
+    )
+    # "delete" matches the existing name-token vocabulary -- proves the
+    # manifest path shares the same risk resolver as function tools, not a
+    # second, weaker one.
+    assert definition.state_changing is True
+    assert definition.destructive is True
+
+
+def test_manifest_name_colliding_with_a_real_tool_is_rejected() -> None:
+    agent = _agent_with_external_toolset(extra_function_tool=True)
+    manifest = McpManifest(
+        tools={"existing_tool": DeclaredMcpTool(description="Collides.", input_schema={})}
+    )
+    with pytest.raises(ConfigurationError, match="existing_tool"):
+        PydanticAIAdapter().inspect(agent, mcp_manifest=manifest)
+
+
+# --- prepare/run: the manifest tool reaches ToolGateway, never the real one -
+
+
+@dataclass
+class _Deps:
+    pass
+
+
+def test_manifest_declared_tool_is_simulated_through_the_gateway() -> None:
+    """End-to-end: the model calls the manifest tool, AgentCheck answers it
+    from a fixture, and the real external toolset is never touched."""
+
+    manifest = McpManifest(
+        tools={
+            "send_message": DeclaredMcpTool(
+                description="Send a message.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            )
+        }
+    )
+
+    def scripted(messages: list[Any], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="send_message", args={"text": "hi"})]
+            )
+        return ModelResponse(parts=[TextPart("done")])
+
+    agent_with_model = Agent(
+        FunctionModel(scripted),
+        tools=[],
+        toolsets=[_NeverCalledExternalToolset()],
+    )
+
+    adapter = PydanticAIAdapter()
+    spec = adapter.inspect(agent_with_model, mcp_manifest=manifest)
+    tools = tuple(item.value for item in spec.tools.items)
+    gateway = ToolGateway(
+        tools,
+        (
+            ToolFixture(
+                fixture_id="fixture:send_message",
+                tool_name="send_message",
+                outcome=SimulatedToolOutcome(
+                    status=SimulatedToolStatus.SUCCESS, result={"ok": True}
+                ),
+            ),
+        ),
+        budgets=BudgetTracker(ResourceBudgets()),
+        run_id="test-run",
+    )
+    prepared = adapter.prepare(
+        agent_with_model,
+        gateway,
+        world_state=gateway.world,
+        controlled_model=False,
+        mcp_manifest=manifest,
+    )
+    import asyncio
+
+    result = asyncio.run(
+        adapter.run(
+            prepared,
+            (
+                ConversationTurn(
+                    turn_id="turn-1", role=ConversationRole.USER, content="please send hi"
+                ),
+            ),
+            run_id="test-run",
+            max_turns=5,
+            scenario_id="test-scenario",
+            target_id=spec.spec_id,
+        )
+    )
+    tool_events = [
+        event
+        for event in result.events
+        if event.event_type.value in {"tool_attempt", "tool_result"}
+    ]
+    assert len(tool_events) == 2
+    outcome_events = [e for e in tool_events if e.event_type.value == "tool_result"]
+    assert outcome_events[0].payload["status"] == ToolOutcomeStatus.SUCCESS.value
+
+
+# --- loader: same safety discipline as fixtures ----------------------------
+
+
+def test_load_mcp_manifest_absent_file_returns_none(tmp_path: Path) -> None:
+    assert load_mcp_manifest(tmp_path) is None
+
+
+def test_load_mcp_manifest_valid_file(tmp_path: Path) -> None:
+    (tmp_path / "agentcheck-mcp-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.mcp_manifest.v1",
+                "tools": {
+                    "search": {
+                        "description": "Search things.",
+                        "input_schema": {"type": "object"},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = load_mcp_manifest(tmp_path)
+    assert manifest is not None
+    assert "search" in manifest.tools
+
+
+def test_load_mcp_manifest_rejects_malformed_json(tmp_path: Path) -> None:
+    (tmp_path / "agentcheck-mcp-manifest.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(ConfigurationError):
+        load_mcp_manifest(tmp_path)
+
+
+def test_load_mcp_manifest_rejects_unknown_fields(tmp_path: Path) -> None:
+    (tmp_path / "agentcheck-mcp-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.mcp_manifest.v1",
+                "tools": {},
+                "unexpected_field": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigurationError):
+        load_mcp_manifest(tmp_path)
+
+
+def test_load_mcp_manifest_rejects_remote_schema_reference(tmp_path: Path) -> None:
+    (tmp_path / "agentcheck-mcp-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.mcp_manifest.v1",
+                "tools": {
+                    "search": {
+                        "description": "Search.",
+                        "input_schema": {"$ref": "https://example.com/schema.json"},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigurationError, match="local fragment"):
+        load_mcp_manifest(tmp_path)
+
+
+def test_load_mcp_manifest_rejects_oversized_file(tmp_path: Path) -> None:
+    huge_description = "x" * (256 * 1024 + 1)
+    (tmp_path / "agentcheck-mcp-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.mcp_manifest.v1",
+                "tools": {"a": {"description": huge_description, "input_schema": {}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigurationError, match="byte manifest limit"):
+        load_mcp_manifest(tmp_path)
+
+
+def test_load_mcp_manifest_refuses_a_symlink_escaping_the_target(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-mcp-manifest.json"
+    outside.write_text(
+        json.dumps({"schema_version": "agentcheck.mcp_manifest.v1", "tools": {}}),
+        encoding="utf-8",
+    )
+    link = tmp_path / "agentcheck-mcp-manifest.json"
+    link.symlink_to(outside)
+    with pytest.raises(ConfigurationError):
+        load_mcp_manifest(tmp_path)
+    outside.unlink()


### PR DESCRIPTION
## Summary
- PydanticAI agents with an external (MCP) toolset are no longer refused outright at preflight -- a developer can declare the toolset's tool schemas in `agentcheck-mcp-manifest.json`, and AgentCheck folds each declared tool into the target's spec (risk-resolved, fault-tested, simulated through `ToolGateway`) exactly like a real function tool.
- AgentCheck still never connects to a real MCP server anywhere in the pipeline -- no subprocess spawn, no network call during inspect/generate/run. The manifest is a frozen, developer-authored snapshot, loaded with the same safety discipline as `agentcheck-fixtures.json` (contained-path + `O_NOFOLLOW`, byte cap, `extra="forbid"`, `offline_validator` on every schema).
- OpenAI Agents SDK and Custom adapters accept the new parameter but ignore it -- no external-toolset concept there yet.
- 0.5.0 (new capability). Suite identity unaffected; a target with no manifest behaves exactly as before.

See `docs/mcp-manifest.md` for the full design and rationale.

## Test plan
- [x] `pytest tests/agentcheck/test_mcp_manifest.py` -- 12/12 passing (loader safety, preflight refusal/acceptance, spec/risk resolution, name-collision rejection, full end-to-end simulate-through-gateway with a fake external toolset that raises if ever touched)
- [x] `pytest tests/agentcheck/test_pydantic_ai_adapter.py tests/agentcheck/test_pydantic_ai_controlled.py tests/agentcheck/test_version_decoupling.py` -- 78/78 passing, no regressions from the adapter/ABC signature changes
- [x] `ruff check` / `mypy` clean
- [ ] CI full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)