### PR TITLE
fix: "post" fell into the weakest read-only risk-inference bucket

### DIFF
--- a/agentcheck/inspect/capabilities.py
+++ b/agentcheck/inspect/capabilities.py
@@ -83,6 +83,14 @@ _COMPOSITION_KEYWORDS = (
 # than update/modify's non-destructive bucket: a refund reverses money
 # already collected, the same "undoes a completed state, real consequence"
 # shape as a cancellation, not a simple field edit.
+#
+# "post" was added after validating the new MCP-manifest feature against a
+# real target: a Slack agent's documented external tool set includes a
+# "post a message" action, the same verb Slack's own API uses
+# (`chat.postMessage`), which fell through to the same OTHER/read-
+# only/confidence 0.3 bucket "send" already covers. Grouped with
+# send/email/notify/publish, not created as its own bucket, since posting a
+# message is the same real-world action as sending one.
 _NAME_RULES: tuple[tuple[frozenset[str], ActionKind, bool, bool], ...] = (
     (frozenset({"delete", "remove", "destroy", "erase", "purge"}), ActionKind.DELETE, True, True),
     (frozenset({"cancel", "terminate", "close", "refund"}), ActionKind.MODIFY, True, True),
@@ -95,7 +103,7 @@ _NAME_RULES: tuple[tuple[frozenset[str], ActionKind, bool, bool], ...] = (
         True,
         False,
     ),
-    (frozenset({"send", "email", "notify", "publish"}), ActionKind.SEND, True, False),
+    (frozenset({"send", "email", "notify", "publish", "post"}), ActionKind.SEND, True, False),
     (frozenset({"schedule", "book", "reserve"}), ActionKind.SCHEDULE, True, False),
     (frozenset({"lookup", "find", "search", "get", "read"}), ActionKind.LOOKUP, False, False),
     (frozenset({"retrieve", "fetch"}), ActionKind.RETRIEVE, False, False),

--- a/tests/agentcheck/test_capabilities.py
+++ b/tests/agentcheck/test_capabilities.py
@@ -404,6 +404,7 @@ def test_absent_schema_yields_no_parameters_without_failing() -> None:
         ("write", ActionKind.CREATE, True, False),
         ("save_draft", ActionKind.CREATE, True, False),
         ("send_receipt", ActionKind.SEND, True, False),
+        ("post_message", ActionKind.SEND, True, False),
         ("schedule_visit", ActionKind.SCHEDULE, True, False),
         ("lookup_account", ActionKind.LOOKUP, False, False),
         ("retrieve_invoice", ActionKind.RETRIEVE, False, False),
@@ -471,6 +472,28 @@ def test_a_refund_tool_is_not_silently_classified_read_only() -> None:
     assert capability.capability.state_changing is True
     assert capability.capability.destructive is True
     assert capability.capability.action_kind is ActionKind.MODIFY
+
+
+def test_a_post_message_tool_is_not_silently_classified_read_only() -> None:
+    """Reproduces a real MCP toolset's documented tool surface (a Slack
+    agent's external tools, validated via the new MCP-manifest feature):
+    "post a message" is the same real-world action "send" already covers,
+    and is the verb Slack's own API uses (chat.postMessage). Before "post"
+    was added to the name vocabulary, this fell through every rule to
+    OTHER/read-only/confidence 0.3 for a tool that sends a real message to
+    a channel."""
+
+    capability = extract_capabilities(
+        [
+            _tool(
+                "post_message",
+                description="Send a message to a Slack channel or thread.",
+            )
+        ]
+    )[0]
+
+    assert capability.capability.state_changing is True
+    assert capability.capability.action_kind is ActionKind.SEND
 
 
 def test_classification_matches_the_phase_one_name_vocabulary() -> None:


### PR DESCRIPTION
## Summary
- Found revalidating 0.5.0's new MCP-manifest feature against a real target: hand-authoring `agentcheck-mcp-manifest.json` for the Slack bolt-python-starter-agent (`slack-samples/bolt-python-starter-agent` @ `620efde`, already used earlier in the campaign) surfaced `post_message` -- the verb Slack's own API uses (`chat.postMessage`) -- inspecting as `other, read-only (confidence 0.30)`, the same defect class `write` (0.3.0) and `refund` (0.4.2) fell into.
- `"post"` now joins the `send`/`email`/`notify`/`publish` name-token group: state-changing, not destructive, matching "send" exactly since posting and sending a message are the same real-world action.
- Same narrow `spec_id`-movement exception as the `write`/`refund` fixes.

## Test plan
- [x] Regression test proven to fail pre-fix / pass post-fix (`test_a_post_message_tool_is_not_silently_classified_read_only`, plus a new parametrize row)
- [x] `pytest tests/agentcheck/test_capabilities.py` -- 61/61 passing
- [x] `ruff check` / `mypy` clean
- [x] Revalidated against the real target end to end via a hand-authored MCP manifest + harness factory: `inspect` now shows `post_message: send, state-changing (confidence 0.70)`; full pipeline (`inspect` → `generate` → `fixtures init` → `test`) completed, 24/24 PASS, zero real network calls, zero real toolset touches
- [ ] CI full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)