### PR TITLE
fix: close MCP manifest false-assurance gaps

### DIFF
--- a/agentcheck/adapters/pydantic_ai.py
+++ b/agentcheck/adapters/pydantic_ai.py
@@ -256,6 +256,44 @@ def _agent_tools(target: Any) -> dict[str, Any]:
     return dict(toolset.tools)
 
 
+def _external_toolsets(target: Any) -> list[Any]:
+    """Toolsets AgentCheck cannot read for itself -- MCP and anything like it."""
+
+    toolsets = list(getattr(target, "toolsets", ()) or ())
+    own = _agent_toolset(target)
+    return [toolset for toolset in toolsets if toolset is not own]
+
+
+def _mcp_manifest_issue(
+    target: Any, mcp_manifest: "McpManifest | None"
+) -> SupportIssue | None:
+    """Return a manifest/target issue shared by every adapter surface."""
+
+    if mcp_manifest is None:
+        return None
+    if not mcp_manifest.tools:
+        return SupportIssue(
+            code="invalid_mcp_manifest",
+            message=(
+                "agentcheck-mcp-manifest.json declares no tools. An empty manifest "
+                "cannot describe an external toolset or lift its refusal."
+            ),
+            location="agentcheck-mcp-manifest.json",
+        )
+    if not _external_toolsets(target):
+        return SupportIssue(
+            code="mcp_manifest_without_external_toolset",
+            message=(
+                "agentcheck-mcp-manifest.json is present, but this agent has no "
+                "external toolset for it to describe. A manifest only declares "
+                "tools AgentCheck cannot read for itself; applying one here would "
+                "add tools the agent cannot actually call."
+            ),
+            location="agent.toolsets",
+        )
+    return None
+
+
 def _static_instruction_parts(target: Any) -> tuple[list[str], list[str]]:
     """Return (static parts, reasons the instructions are not fully static).
 
@@ -1143,6 +1181,10 @@ class PydanticAIAdapter(FrameworkAdapter):
         instructions = "\n\n".join(static) if static else None
         output_schema = _output_schema(target)
 
+        manifest_issue = _mcp_manifest_issue(target, mcp_manifest)
+        if manifest_issue is not None:
+            raise ConfigurationError(manifest_issue.message)
+
         definitions: list[ToolDefinition] = []
         tool_properties: list[AgentProperty[Any]] = []
         tool_risk_assertions: dict[str, ToolRiskAssertion] = {}
@@ -1543,10 +1585,10 @@ class PydanticAIAdapter(FrameworkAdapter):
                     location="agent.event_stream_handler",
                 )
             )
-        toolsets = list(getattr(target, "toolsets", ()) or ())
-        own = _agent_toolset(target)
-        extra = [t for t in toolsets if t is not own]
-        if extra and mcp_manifest is None:
+        manifest_issue = _mcp_manifest_issue(target, mcp_manifest)
+        if manifest_issue is not None:
+            issues.append(manifest_issue)
+        elif _external_toolsets(target) and mcp_manifest is None:
             issues.append(
                 SupportIssue(
                     code="unsupported_toolset",

--- a/agentcheck/inspect/capabilities.py
+++ b/agentcheck/inspect/capabilities.py
@@ -91,6 +91,14 @@ _COMPOSITION_KEYWORDS = (
 # only/confidence 0.3 bucket "send" already covers. Grouped with
 # send/email/notify/publish, not created as its own bucket, since posting a
 # message is the same real-world action as sending one.
+#
+# "post" introduced a noun collision in exactly the domain that motivated
+# this token ("a post" on Slack/Reddit/WordPress versus "post a message").
+# Because SEND is matched before later rules, a plain token match would read
+# get_post/read_post/summarize_post as state-changing sends and generate
+# duplicate-side-effect policies for non-mutating tools. It is therefore
+# listed in _AMBIGUOUS_TOKENS below; token order distinguishes a leading read
+# action from a leading `post` action when both appear.
 _NAME_RULES: tuple[tuple[frozenset[str], ActionKind, bool, bool], ...] = (
     (frozenset({"delete", "remove", "destroy", "erase", "purge"}), ActionKind.DELETE, True, True),
     (frozenset({"cancel", "terminate", "close", "refund"}), ActionKind.MODIFY, True, True),
@@ -108,6 +116,19 @@ _NAME_RULES: tuple[tuple[frozenset[str], ActionKind, bool, bool], ...] = (
     (frozenset({"lookup", "find", "search", "get", "read"}), ActionKind.LOOKUP, False, False),
     (frozenset({"retrieve", "fetch"}), ActionKind.RETRIEVE, False, False),
     (frozenset({"summarize", "summary"}), ActionKind.SUMMARIZE, False, False),
+)
+
+# Tokens that name an action in one reading and an object in another. They
+# match their rule unless a different recognized action token precedes them,
+# so `post_message` and `post_summary` stay sends while `get_post` and
+# `summarize_post` reach their own rules.
+_AMBIGUOUS_TOKENS = frozenset({"post"})
+
+_UNAMBIGUOUS_ACTION_TOKENS = frozenset(
+    token
+    for rule_tokens, _, _, _ in _NAME_RULES
+    for token in rule_tokens
+    if token not in _AMBIGUOUS_TOKENS
 )
 
 _NAME_TOKEN_CONFIDENCE = 0.6
@@ -277,19 +298,31 @@ class CapabilityExtractor(Protocol):
     ) -> tuple[ExtractedCapability, ...]: ...
 
 
-def _tokens(value: str) -> set[str]:
+def _tokens(value: str) -> tuple[str, ...]:
     normalized = "".join(
         character if character.isalnum() else " " for character in value.casefold()
     )
-    return set(normalized.split())
+    return tuple(normalized.split())
 
 
 def _matched_rule(
-    tokens: set[str],
+    tokens: Sequence[str],
 ) -> tuple[frozenset[str], ActionKind, bool, bool] | None:
+    token_set = set(tokens)
+    first_ambiguous = next(
+        (index for index, token in enumerate(tokens) if token in _AMBIGUOUS_TOKENS),
+        None,
+    )
+    clearer_intent_precedes = first_ambiguous is not None and any(
+        token in _UNAMBIGUOUS_ACTION_TOKENS for token in tokens[:first_ambiguous]
+    )
     for rule in _NAME_RULES:
-        if tokens & rule[0]:
-            return rule
+        matched = token_set & rule[0]
+        if not matched:
+            continue
+        if clearer_intent_precedes and matched <= _AMBIGUOUS_TOKENS:
+            continue
+        return rule
     return None
 
 
@@ -579,7 +612,7 @@ def _classification_signals(
         )
 
     vocabulary, action_kind, state_changing, destructive = rule
-    matched = sorted(name_tokens & vocabulary)
+    matched = sorted(set(name_tokens) & vocabulary)
     signals.append(
         CapabilitySignal(
             kind=CapabilitySignalKind.NAME_TOKEN,
@@ -597,7 +630,7 @@ def _classification_signals(
     corroborated = False
     if definition.description:
         description_locator = f"tool:{definition.name}.description"
-        shared = sorted(_tokens(definition.description) & vocabulary)
+        shared = sorted(set(_tokens(definition.description)) & vocabulary)
         if shared:
             corroborated = True
             confidence = _CORROBORATED_CONFIDENCE

--- a/agentcheck/mcp_manifest/loader.py
+++ b/agentcheck/mcp_manifest/loader.py
@@ -24,7 +24,7 @@ _MAX_MANIFEST_BYTES = 256 * 1024
 
 
 def load_mcp_manifest(root: Path, *, filename: str | None = None) -> McpManifest | None:
-    """Read the target's MCP manifest file, or ``None`` when it declares none.
+    """Read the target's MCP manifest file, or ``None`` when the file is absent.
 
     Absence is the normal case, not an error: a target with no external
     toolset needs no manifest, and one that has one but declares no manifest
@@ -59,6 +59,14 @@ def load_mcp_manifest(root: Path, *, filename: str | None = None) -> McpManifest
         manifest = McpManifest.model_validate_json(raw)
     except (ValueError, UnicodeDecodeError) as exc:
         raise ConfigurationError(f"invalid {name}: {exc}") from exc
+    # Refused rather than treated as absent: a file that declares nothing
+    # would otherwise clear the external-toolset refusal while describing no
+    # tools at all, which reads as coverage the target never had.
+    if not manifest.tools:
+        raise ConfigurationError(
+            f"{name} declares no tools. Remove the file if the target has no "
+            "external toolset, or declare the toolset's tool schemas in it."
+        )
     for tool_name, declared in manifest.tools.items():
         try:
             offline_validator(declared.input_schema)

--- a/tests/agentcheck/test_capabilities.py
+++ b/tests/agentcheck/test_capabilities.py
@@ -496,6 +496,45 @@ def test_a_post_message_tool_is_not_silently_classified_read_only() -> None:
     assert capability.capability.action_kind is ActionKind.SEND
 
 
+@pytest.mark.parametrize(
+    ("name", "expected_kind"),
+    [
+        ("get_post", ActionKind.LOOKUP),
+        ("fetch_post", ActionKind.RETRIEVE),
+        ("read_post", ActionKind.LOOKUP),
+        ("find_post_by_id", ActionKind.LOOKUP),
+        ("get_post_comments", ActionKind.LOOKUP),
+        ("summarize_post", ActionKind.SUMMARIZE),
+        ("summary_post", ActionKind.SUMMARIZE),
+    ],
+)
+def test_an_ambiguous_post_yields_to_a_clearer_action(
+    name: str, expected_kind: ActionKind
+) -> None:
+    """The token "post" is a noun as often as a verb in its target domain.
+    Its SEND rule must not override a different recognized action and derive
+    a duplicate-side-effect policy for a non-mutating tool -- a FAIL the
+    target could never legitimately avoid."""
+
+    action_kind, state_changing, destructive = classify_tool(name)
+
+    assert state_changing is False
+    assert destructive is False
+    assert action_kind is expected_kind
+
+
+@pytest.mark.parametrize(
+    "name", ["post_message", "slack_post_message", "send_post", "post_summary"]
+)
+def test_an_ambiguous_post_stays_send_when_it_leads_or_stands_alone(
+    name: str,
+) -> None:
+    """The narrowing must not cost the case it was added for, including the
+    server-prefixed names MCP toolsets commonly use."""
+
+    assert classify_tool(name) == (ActionKind.SEND, True, False)
+
+
 def test_classification_matches_the_phase_one_name_vocabulary() -> None:
     """The gateway marks ambiguous state from these flags, so they must not drift."""
 

--- a/tests/agentcheck/test_mcp_manifest.py
+++ b/tests/agentcheck/test_mcp_manifest.py
@@ -131,6 +131,51 @@ def test_manifest_tool_is_added_to_the_spec_and_risk_resolved() -> None:
     assert definition.destructive is True
 
 
+def test_preflight_rejects_an_empty_manifest() -> None:
+    """A manifest declaring nothing cannot describe the external toolset, so
+    it must not clear the refusal. Substituting silence for a declaration is
+    how a target reports coverage it never had."""
+
+    agent = _agent_with_external_toolset()
+    report = PydanticAIAdapter().preflight(agent, mcp_manifest=McpManifest())
+    assert any(issue.code == "invalid_mcp_manifest" for issue in report.issues)
+
+
+def test_inspect_rejects_an_empty_manifest() -> None:
+    agent = _agent_with_external_toolset()
+    with pytest.raises(ConfigurationError, match="declares no tools"):
+        PydanticAIAdapter().inspect(agent, mcp_manifest=McpManifest())
+
+
+def test_a_manifest_without_an_external_toolset_is_rejected() -> None:
+    """A manifest only declares tools AgentCheck cannot read for itself.
+    Applying one to an agent with no external toolset -- a stale file left
+    behind by a refactor -- would add tools the agent cannot call and then
+    generate scenarios against them."""
+
+    def real_tool(x: int) -> int:
+        raise AssertionError("real function tool handler must never run")
+
+    agent = Agent("test", tools=[real_tool])
+    manifest = McpManifest(
+        tools={"phantom": DeclaredMcpTool(description="Phantom.", input_schema={})}
+    )
+    with pytest.raises(ConfigurationError, match="no external toolset"):
+        PydanticAIAdapter().inspect(agent, mcp_manifest=manifest)
+
+
+def test_preflight_rejects_a_manifest_without_an_external_toolset() -> None:
+    agent = Agent("test")
+    manifest = McpManifest(
+        tools={"phantom": DeclaredMcpTool(description="Phantom.", input_schema={})}
+    )
+    report = PydanticAIAdapter().preflight(agent, mcp_manifest=manifest)
+    assert any(
+        issue.code == "mcp_manifest_without_external_toolset"
+        for issue in report.issues
+    )
+
+
 def test_manifest_name_colliding_with_a_real_tool_is_rejected() -> None:
     agent = _agent_with_external_toolset(extra_function_tool=True)
     manifest = McpManifest(
@@ -253,6 +298,12 @@ def test_load_mcp_manifest_valid_file(tmp_path: Path) -> None:
     manifest = load_mcp_manifest(tmp_path)
     assert manifest is not None
     assert "search" in manifest.tools
+
+
+def test_load_mcp_manifest_rejects_a_file_declaring_no_tools(tmp_path: Path) -> None:
+    (tmp_path / "agentcheck-mcp-manifest.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="declares no tools"):
+        load_mcp_manifest(tmp_path)
 
 
 def test_load_mcp_manifest_rejects_malformed_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## What and why

The 0.5.0 MCP-manifest path had two false-assurance cases: an empty manifest
could lift the external-toolset refusal while declaring nothing, and a stale
manifest could add phantom tools to an agent with no external toolset. The
first `post` risk-inference fix also treated noun uses such as `get_post` as
state-changing.

This follow-up makes the smallest fail-closed correction:

- one shared validation rule rejects empty manifests and manifest/target
  mismatches consistently in both `inspect()` and `preflight()`;
- the on-disk loader rejects manifests that declare no tools;
- ordered token handling keeps `post_message` and `post_summary` as SEND while
  letting clearer leading actions such as `get_post` and `summarize_post` win.

The 0.5.1 version and changelog changes remain outside this fix PR for the
project's separate release-prep PR.

## Safety and compatibility

- [x] Original declared tool handlers still never execute during simulated evaluation.
- [x] Unknown tools still fail closed; no plausible result is synthesized.
- [x] Worker isolation, network denial, source integrity, and verdict semantics are unchanged or explicitly reviewed.
- [x] No safety or wall-clock budget was widened.
- [x] Fingerprint, schema, protocol, and stored-artifact compatibility impact is stated.
- [x] Replay is not described as deterministic provider-output replay.

Compatibility: valid non-empty manifests attached to agents with external
toolsets are unchanged. Empty manifests and manifests attached to agents with
no external toolset now fail closed. Inferred tool-risk classifications that
change because `post` is recognized as SEND move the target `spec_id`; explicit
`tool_risk` remains authoritative.

## Validation

- 155 focused capability, manifest, PydanticAI adapter/controlled-model, and version-decoupling tests passed.
- 139 downstream derived-policy, boundary, risk-authority, generation, policy-pack, and PydanticAI risk-parity tests passed.
- `ruff check agentcheck tests scripts` passed.
- `mypy agentcheck` passed across 100 source files.
- `git diff --check` passed.
- Independent static review: no remaining findings.
- Provider requests: 0
- API spend: $0
