### PR TITLE
CI: treat root-level NOTICE as docs-only for scope classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             expensive=false
             while IFS= read -r -d '' path; do
               case "$path" in
-                *.md|docs/assets/*) ;;
+                *.md|docs/assets/*|NOTICE) ;;
                 *) expensive=true; break ;;
               esac
             done < <(


### PR DESCRIPTION
## Summary
- The change-scope classifier in `.github/workflows/ci.yml` skips the full test matrix and most `checks` steps when every changed file matches `*.md` or `docs/assets/*`.
- A root-level `NOTICE` file (no extension) doesn't match either pattern, so a NOTICE-only change (like #63) still triggers the full matrix.
- Adds `NOTICE` to the allowed docs-only patterns.

## Test plan
- [ ] Confirm this PR's own "Classify change scope" job reports `expensive=false`
- [ ] Confirm the `tests` job is skipped and `checks` runs only its docs-only steps

https://claude.ai/code/session_019Ymv8q8tdttik328p3jpYR