### PR TITLE
chore: prepare 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## 0.5.1 (2026-08-28)
+
+Three correctness fixes, found while reviewing and revalidating 0.5.0's
+new MCP-manifest support against a real Slack target.
+
+### Fixed
+
+- **An empty MCP manifest silently lifted the external-toolset refusal.**
+  A file containing `{}` declared no tools but still let `preflight` proceed,
+  creating apparent coverage for a surface AgentCheck could not see. Empty
+  manifests are now rejected by the loader, and both direct adapter surfaces
+  reject a programmatically constructed empty `McpManifest` too.
+- **A manifest could add phantom tools to an agent with no external
+  toolset.** A stale manifest survived even after its external toolset was
+  removed and inserted tools the agent could not actually call, so AgentCheck
+  could generate scenarios against a fictional surface. Inspection and
+  preflight now reject a manifest unless the PydanticAI agent actually has an
+  external toolset for it to describe.
+- **`"post"` fell into the weakest read-only risk-inference bucket.** A real
+  Slack agent's manifest-declared `post_message` tool inspected as `other,
+  read-only (confidence 0.30)`, but `post` is also a common noun in the same
+  domain. The resolver now treats a leading or standalone `post` as part of
+  the `send`/`email`/`notify`/`publish` group, while a clearer recognized
+  action before it wins. Names such as `get_post`, `fetch_post`, and
+  `summarize_post` remain non-mutating rather than acquiring impossible
+  duplicate-side-effect policies; `post_summary` remains a SEND action.
+
+**Compatibility:** this patch is intentionally breaking for two invalid
+manifest configurations that 0.5.0 silently accepted: an empty manifest now
+fails to load, and a manifest attached to an agent with no external toolset
+now fails inspection. Remove the stale file when no external toolset exists;
+otherwise declare the external toolset's actual schemas. Valid, non-empty
+manifests attached to agents with external toolsets are unaffected.
+
+**Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. The manifest
+corrections refuse invalid configurations rather than changing valid suite
+generation. The `post` correction changes action metadata for matching tool
+names and can also change inferred risk. When it changes a tool's resolved
+`state_changing` boolean, the target gets a new `spec_id` and must regenerate an
+older frozen suite. A declared or authoritative value that keeps the resolved
+risk booleans stable also keeps `spec_id` stable, although a newly generated
+bounded suite can still record SEND rather than OTHER action metadata. Names
+with a leading recognized non-mutating action or no matching `post` token are
+unaffected.
+
 ## 0.5.0 (2026-08-28)
 
 **PydanticAI agents with external (MCP) toolsets are no longer refused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ identity**.
 
 ## 0.5.1 (2026-08-28)
 
-Three correctness fixes, found while reviewing and revalidating 0.5.0's
+Three product correctness fixes, found while reviewing and revalidating 0.5.0's
 new MCP-manifest support against a real Slack target.
 
 ### Fixed
@@ -38,6 +38,12 @@ new MCP-manifest support against a real Slack target.
   action before it wins. Names such as `get_post`, `fetch_post`, and
   `summarize_post` remain non-mutating rather than acquiring impossible
   duplicate-side-effect policies; `post_summary` remains a SEND action.
+
+### Packaging
+
+- **Release artifacts now carry the project's `NOTICE` alongside `LICENSE`.**
+  The artifact audit positively requires both files in the wheel and source
+  distribution, so a future packaging omission fails before publication.
 
 **Compatibility:** this patch is intentionally breaking for two invalid
 manifest configurations that 0.5.0 silently accepted: an empty manifest now

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
+include NOTICE
 include README.md
 include CHANGELOG.md
 include CONTRIBUTING.md

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = "0.5.1"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"
-license-files = ["LICENSE"]
+license-files = ["LICENSE", "NOTICE"]
 authors = [{ name = "Waseem Ghanem" }]
 requires-python = ">=3.10"
 keywords = ["ai-agents", "evaluation", "testing", "safety", "llm", "agents"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.5.0"
+version = "0.5.1"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -38,6 +38,10 @@ FORBIDDEN = (
 # underscores. Matching that shape rather than a literal keeps this check honest
 # if either name changes again.
 WHEEL_ALLOWED = re.compile(r"^(agentcheck/|[A-Za-z0-9_.]+-[^/]*\.dist-info/)")
+WHEEL_LICENSE_PATH = re.compile(
+    r"^[A-Za-z0-9_.]+-[^/]*\.dist-info/licenses/(?P<filename>[^/]+)$"
+)
+REQUIRED_DISTRIBUTION_FILES = ("LICENSE", "NOTICE")
 
 # An sdist legitimately carries contributor material as well as the package,
 # but a new top-level directory must be reviewed. This generic allowlist catches
@@ -51,6 +55,7 @@ SDIST_ALLOWED_ROOTS = frozenset(
         "CONTRIBUTING.md",
         "LICENSE",
         "MANIFEST.in",
+        "NOTICE",
         "PKG-INFO",
         "README.md",
         "SECURITY.md",
@@ -103,8 +108,23 @@ def main() -> int:
                         f"{artifact.name}: {name} (unexpected sdist top-level path)"
                     )
 
+        required_counts = dict.fromkeys(REQUIRED_DISTRIBUTION_FILES, 0)
+        if artifact.suffix == ".whl":
+            for name in names:
+                match = WHEEL_LICENSE_PATH.fullmatch(name)
+                if match is not None and match.group("filename") in required_counts:
+                    required_counts[match.group("filename")] += 1
+        else:
+            for filename in required_counts:
+                required_counts[filename] = names.count(filename)
+        for filename, count in required_counts.items():
+            if count != 1:
+                failures.append(
+                    f"{artifact.name}: expected exactly one packaged {filename}, found {count}"
+                )
+
     if failures:
-        print("\nFAIL: distributions contain files that must not ship:")
+        print("\nFAIL: distribution audit failed:")
         for failure in failures:
             print(f"- {failure}")
         return 1


### PR DESCRIPTION
## Summary

- bump agentcheck-ai and the runtime version to 0.5.1
- document all three correctness fixes merged in PR #62: empty manifests, phantom manifest tools, and post action inference
- state the intentionally breaking invalid-manifest corrections and the precise suite-identity impact

## Validation

- 11 focused version-decoupling tests passed
- wheel and sdist built as 0.5.1 in a disposable directory
- repository distribution audit passed for both artifacts
- Twine 7.0.0 strict metadata checks passed
- fresh wheel install and CLI both reported 0.5.1
- PR #62 CI and post-merge main CI are green

## Safety and cost

- release-only metadata and documentation change; generator compatibility remains 1
- no provider credentials used, no live provider calls, and no paid requests
- cost: 0 dollars