### PR TITLE
docs: correct 0.5.1 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
-## 0.5.1 (2026-08-28)
+## 0.5.1 (2026-08-29)
 
 Three product correctness fixes, found while reviewing and revalidating 0.5.0's
 new MCP-manifest support against a real Slack target.


### PR DESCRIPTION
Summary:
- Correct the 0.5.1 changelog date to the actual publication date, 2026-08-29.
- Keep the release record consistent with the changelog contract that dates are release dates.

Validation:
- secret scan passed
- documentation consistency: 6 passed
- release-version alignment: 1 passed
- staged diff check passed

Scope: one documentation line; no product, workflow, package, or containment changes.