### PR TITLE
Fix gate false PASS for inconclusive baseline runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@ identity**.
 - **A trusted baseline could turn an inconclusive gate run into `PASS`.** The
   baseline comparator correctly treats missing evidence as a non-regression,
   but the one-command release gate accidentally reused that result as its own
-  decision. `agentcheck gate` now blocks with exit code 3 whenever the current
-  suite contains `INCONCLUSIVE`, including when the baseline comparison found
-  no new authoritative failure. A baseline can accept known failures; it can
-  never supply evidence the current run did not observe.
+  decision. When the baseline comparison finds no new authoritative failure
+  but the current suite remains `INCONCLUSIVE`, `agentcheck gate` now blocks
+  with exit code 3. A baseline can accept known failures; it can never supply
+  evidence the current run did not observe.
 
 **Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. This correction
 changes only the gate's aggregate CI decision; it does not change generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,26 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## Unreleased
+
+### Fixed
+
+- **A trusted baseline could turn an inconclusive gate run into `PASS`.** The
+  baseline comparator correctly treats missing evidence as a non-regression,
+  but the one-command release gate accidentally reused that result as its own
+  decision. `agentcheck gate` now blocks with exit code 3 whenever the current
+  suite contains `INCONCLUSIVE`, including when the baseline comparison found
+  no new authoritative failure. A baseline can accept known failures; it can
+  never supply evidence the current run did not observe.
+
+**Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. This correction
+changes only the gate's aggregate CI decision; it does not change generated
+scenarios, stored run evidence, or serialized artifact identity.
+
 ## 0.5.1 (2026-08-29)
 
-Four product correctness fixes, found while reviewing and revalidating 0.5.0's
-new MCP-manifest support and its documented CI gate contract.
+Three product correctness fixes, found while reviewing and revalidating 0.5.0's
+new MCP-manifest support against a real Slack target.
 
 ### Fixed
 
@@ -38,13 +54,6 @@ new MCP-manifest support and its documented CI gate contract.
   action before it wins. Names such as `get_post`, `fetch_post`, and
   `summarize_post` remain non-mutating rather than acquiring impossible
   duplicate-side-effect policies; `post_summary` remains a SEND action.
-- **A trusted baseline could turn an inconclusive gate run into `PASS`.** The
-  baseline comparator correctly treats missing evidence as a non-regression,
-  but the one-command release gate accidentally reused that result as its own
-  decision. `agentcheck gate` now blocks with exit code 3 whenever the current
-  suite contains `INCONCLUSIVE`, including when the baseline comparison found
-  no new authoritative failure. A baseline can accept known failures; it can
-  never supply evidence the current run did not observe.
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ identity**.
 
 ## 0.5.1 (2026-08-29)
 
-Three product correctness fixes, found while reviewing and revalidating 0.5.0's
-new MCP-manifest support against a real Slack target.
+Four product correctness fixes, found while reviewing and revalidating 0.5.0's
+new MCP-manifest support and its documented CI gate contract.
 
 ### Fixed
 
@@ -38,6 +38,13 @@ new MCP-manifest support against a real Slack target.
   action before it wins. Names such as `get_post`, `fetch_post`, and
   `summarize_post` remain non-mutating rather than acquiring impossible
   duplicate-side-effect policies; `post_summary` remains a SEND action.
+- **A trusted baseline could turn an inconclusive gate run into `PASS`.** The
+  baseline comparator correctly treats missing evidence as a non-regression,
+  but the one-command release gate accidentally reused that result as its own
+  decision. `agentcheck gate` now blocks with exit code 3 whenever the current
+  suite contains `INCONCLUSIVE`, including when the baseline comparison found
+  no new authoritative failure. A baseline can accept known failures; it can
+  never supply evidence the current run did not observe.
 
 ### Packaging
 

--- a/agentcheck/gate.py
+++ b/agentcheck/gate.py
@@ -259,6 +259,28 @@ def run_gate(
     checked = check_baseline(
         root, baseline_path=relative, run_id=execution.run_id, latest=False
     )
+    if checked.exit_code == EXIT_PASS and counts.get("inconclusive"):
+        # ``baseline check`` asks only whether an authoritative failure is new,
+        # so INCONCLUSIVE is deliberately non-blocking there.  The one-command
+        # release gate has a stronger contract: missing evidence can never be
+        # upgraded to PASS merely because a baseline had nothing to compare.
+        return GateResult(
+            decision=GateDecision.BLOCK,
+            exit_code=EXIT_INCONCLUSIVE,
+            reason="the suite could not decide, which is not a pass",
+            detail=(
+                f"{counts['inconclusive']} inconclusive case(s)",
+                "the baseline found no new authoritative failure, but it cannot "
+                "supply evidence the current run did not observe",
+            ),
+            summary_block=checked.summary,
+            counts=counts,
+            run_id=execution.run_id,
+            suite_fingerprint=suite_fingerprint,
+            baseline_path=relative,
+            baseline_compared=True,
+            report_path=report,
+        )
     if checked.exit_code == EXIT_PASS:
         return GateResult(
             decision=GateDecision.PASS,

--- a/tests/agentcheck/test_gate.py
+++ b/tests/agentcheck/test_gate.py
@@ -144,6 +144,30 @@ def test_no_new_failure_against_the_baseline_passes(
     assert result.baseline_compared is True
 
 
+def test_inconclusive_run_with_a_baseline_is_never_reported_as_pass(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> None:
+    """A regression baseline cannot certify evidence the current run lacks."""
+
+    _baseline(target)
+    calls = _patch(
+        monkeypatch,
+        counts={Verdict.PASS: 39, Verdict.INCONCLUSIVE: 1},
+        root=target,
+        checked=_FakeChecked(EXIT_PASS),
+    )
+
+    result = run_gate(target)
+
+    assert result.decision == GateDecision.BLOCK
+    assert result.exit_code == EXIT_INCONCLUSIVE
+    assert result.baseline_compared is True
+    assert "not a pass" in result.reason
+    assert any("cannot supply evidence" in item for item in result.detail)
+    assert result.summary_block == "summary\n"
+    assert calls["check_baseline"] == 1
+
+
 def test_a_new_failure_against_the_baseline_blocks(
     monkeypatch: pytest.MonkeyPatch, target: Path
 ) -> None:


### PR DESCRIPTION
## Problem

With a trusted baseline present, a current run containing INCONCLUSIVE could inherit baseline check's non-regression exit 0 and be reported as PASS. That contradicts the gate contract: a baseline can accept known failures, but cannot supply missing evidence.

## Fix

- preserve baseline comparison semantics
- make the release gate block with exit 3 when the comparison finds no new failure but the current run remains inconclusive
- retain the baseline summary and explain why it cannot certify missing evidence
- add a regression test that fails on the previous behavior
- record the fix under Unreleased because v0.5.1 was tagged without it

## Validation

- 18 focused gate tests passed
- 11 version-decoupling tests passed after correcting the changelog release boundary
- Ruff passed on changed Python files
- Mypy passed on agentcheck/gate.py
- git diff --check passed

No provider calls, credentials, network-enabled target execution, or containment changes.
