### PR TITLE
Fail closed on unmeasured action-path evidence

### DIFF
--- a/agentcheck/cli.py
+++ b/agentcheck/cli.py
@@ -41,7 +41,7 @@ from agentcheck.domain import (
     Scenario,
     Severity,
     Verdict,
-    action_path_exercise,
+    measured_action_path_exercise,
 )
 from agentcheck.errors import ConfigurationError, ScenarioValidationError
 from agentcheck.generate.boundaries import (
@@ -790,7 +790,7 @@ def _fixtures_init_command(
 
 
 def _print_action_path_exercise(execution: Any) -> None:
-    """Say whether a tool was actually called, not just whether a case existed.
+    """Say whether the intended tool was attempted, not merely generated.
 
     A pass on an action-path case means two very different things depending on
     this: the agent called the tool and behaved correctly, or the agent never
@@ -798,18 +798,30 @@ def _print_action_path_exercise(execution: Any) -> None:
     reader cannot tell them apart.
     """
 
-    exercise = action_path_exercise(getattr(execution, "runs", ()) or ())
+    exercise = measured_action_path_exercise(
+        getattr(execution, "scenarios", ()) or (),
+        getattr(execution, "runs", ()) or (),
+        getattr(execution, "evaluations", ()) or (),
+    )
     if exercise.total == 0:
         return
     print()
     print(
         f"Action paths exercised: {len(exercise.exercised)}/{exercise.total} "
-        "(a tool was actually called)"
+        "(an intended action-tool attempt was observed)"
     )
     for scenario_id in exercise.not_exercised:
         print(
-            f"  not exercised: {scenario_id} - the agent did not call the tool, "
-            "so trajectory checks held vacuously"
+            f"  not exercised: {scenario_id} - the agent did not call the "
+            "intended action tool; prerequisite or unrelated calls do not "
+            "exercise this path, so this run supplies no behavioral execution "
+            "evidence for it"
+        )
+    for scenario_id in exercise.unmeasured:
+        print(
+            f"  unmeasured: {scenario_id} - no single non-infrastructure run "
+            "and evaluation were bound to one unambiguous focal action, so "
+            "there is no behavioral execution evidence"
         )
     authored = {
         scenario.scenario_id

--- a/agentcheck/domain/__init__.py
+++ b/agentcheck/domain/__init__.py
@@ -57,6 +57,7 @@ from .run import (
     CanonicalEvent,
     CanonicalEventType,
     CanonicalRun,
+    MeasuredActionPathExercise,
     RunTermination,
     StateTransition,
     StateTransitionOperation,
@@ -66,6 +67,7 @@ from .run import (
     ToolOutcomeStatus,
     UsageMetrics,
     action_path_exercise,
+    measured_action_path_exercise,
 )
 from .scenario import (
     ACTION_SCENARIO_PREFIX,
@@ -145,6 +147,8 @@ __all__ = [
     "ACTION_SCENARIO_PREFIX",
     "ActionPathExercise",
     "action_path_exercise",
+    "MeasuredActionPathExercise",
+    "measured_action_path_exercise",
     "Scenario",
     "Severity",
     "SimulatedToolOutcome",

--- a/agentcheck/domain/run.py
+++ b/agentcheck/domain/run.py
@@ -8,7 +8,9 @@ from typing import Literal, NamedTuple, Sequence
 from pydantic import Field, model_validator
 
 from .base import ContractModel, JsonObject, JsonValue, UtcDatetime
-from .scenario import ACTION_SCENARIO_PREFIX
+from .evaluation import CaseEvaluation
+from .scenario import ACTION_SCENARIO_PREFIX, Scenario
+from .verdict import Verdict
 
 
 CANONICAL_EVENT_CONTRACT_VERSION: Literal["agentcheck.canonical_event.v1"] = (
@@ -229,13 +231,13 @@ class CanonicalRun(ContractModel):
 
 
 class ActionPathExercise(NamedTuple):
-    """Whether the agent actually called the tool on each action-path case.
+    """Legacy run-only split retained for public API compatibility.
 
     A pass on an action-path case means one of two very different things: the
-    agent called the tool and behaved correctly, or it never called the tool
-    and every trajectory check held vacuously. Both the CLI summary and the
-    HTML report have to draw that distinction, so the classification lives
-    here rather than being recomputed, and worded differently, in each.
+    agent called a tool and behaved correctly, or it never called one and every
+    trajectory check held vacuously. This type predates complete scenario and
+    evaluation binding. Evidence-facing summaries use
+    :func:`measured_action_path_exercise` instead.
     """
 
     exercised: tuple[str, ...]
@@ -247,7 +249,12 @@ class ActionPathExercise(NamedTuple):
 
 
 def action_path_exercise(runs: Sequence[CanonicalRun]) -> ActionPathExercise:
-    """Split action-path runs by whether a tool call was actually attempted."""
+    """Split observed action-path runs by whether any tool was attempted.
+
+    This compatibility helper cannot know about missing runs, infrastructure
+    evaluations, or the scenario's focal tool. Do not use it for a complete
+    evidence metric; use :func:`measured_action_path_exercise` instead.
+    """
 
     exercised: list[str] = []
     not_exercised: list[str] = []
@@ -259,3 +266,94 @@ def action_path_exercise(runs: Sequence[CanonicalRun]) -> ActionPathExercise:
         else:
             not_exercised.append(run.scenario_id)
     return ActionPathExercise(tuple(exercised), tuple(not_exercised))
+
+
+class MeasuredActionPathExercise(NamedTuple):
+    """Evidence-safe action-path classification over the complete denominator."""
+
+    exercised: tuple[str, ...]
+    not_exercised: tuple[str, ...]
+    unmeasured: tuple[str, ...]
+
+    @property
+    def total(self) -> int:
+        return len(self.exercised) + len(self.not_exercised) + len(self.unmeasured)
+
+
+def _focal_action_tool(scenario: Scenario) -> str | None:
+    if "path:action" not in scenario.dimension_tags:
+        return None
+    tagged = {
+        tag.split(":", 1)[1]
+        for tag in scenario.dimension_tags
+        if tag.startswith("tool:") and tag != "tool:"
+    }
+    declared = {
+        item.tool_name
+        for item in (
+            *scenario.required_tool_behavior,
+            *scenario.allowed_tool_behavior,
+        )
+    }
+    focal = tagged.intersection(declared)
+    if len(focal) != 1:
+        return None
+    return next(iter(focal))
+
+
+def measured_action_path_exercise(
+    scenarios: Sequence[Scenario],
+    runs: Sequence[CanonicalRun],
+    evaluations: Sequence[CaseEvaluation],
+) -> MeasuredActionPathExercise:
+    """Classify every action path from bound run and evaluation evidence.
+
+    The scenario set owns the denominator. Deriving it from ``runs`` would make
+    an infrastructure-failed case disappear. A path is exercised only when its
+    single focal tool has an observed attempt in the single canonical run bound
+    to a non-infrastructure evaluation. Missing, duplicate, ambiguous, or
+    infrastructure evidence remains unmeasured.
+    """
+
+    exercised: list[str] = []
+    not_exercised: list[str] = []
+    unmeasured: list[str] = []
+    runs_by_scenario: dict[str, list[CanonicalRun]] = {}
+    for run in runs:
+        runs_by_scenario.setdefault(run.scenario_id, []).append(run)
+    evaluations_by_scenario: dict[str, list[CaseEvaluation]] = {}
+    for evaluation in evaluations:
+        evaluations_by_scenario.setdefault(evaluation.scenario_id, []).append(
+            evaluation
+        )
+
+    for scenario in scenarios:
+        if not str(scenario.scenario_id).startswith(ACTION_SCENARIO_PREFIX):
+            continue
+        matching_runs = runs_by_scenario.get(scenario.scenario_id, [])
+        matching_evaluations = evaluations_by_scenario.get(scenario.scenario_id, [])
+        focal_tool = _focal_action_tool(scenario)
+        if (
+            len(matching_runs) != 1
+            or len(matching_evaluations) != 1
+            or focal_tool is None
+        ):
+            unmeasured.append(scenario.scenario_id)
+            continue
+        run = matching_runs[0]
+        evaluation = matching_evaluations[0]
+        if (
+            evaluation.verdict is Verdict.INFRA_ERROR
+            or evaluation.run_id != run.run_id
+        ):
+            unmeasured.append(scenario.scenario_id)
+            continue
+        if any(
+            attempt.tool_name == focal_tool for attempt in run.tool_attempts
+        ):
+            exercised.append(scenario.scenario_id)
+        else:
+            not_exercised.append(scenario.scenario_id)
+    return MeasuredActionPathExercise(
+        tuple(exercised), tuple(not_exercised), tuple(unmeasured)
+    )

--- a/agentcheck/report/render.py
+++ b/agentcheck/report/render.py
@@ -19,7 +19,7 @@ from agentcheck.domain import (
     Finding,
     Scenario,
     Verdict,
-    action_path_exercise,
+    measured_action_path_exercise,
 )
 from agentcheck.generate.selection import SelectionPlan
 from agentcheck.generate.suite import FrozenSuite
@@ -466,19 +466,30 @@ def render_report(
     # caveat the terminal prints. Without it a reader sees a pass rate and no
     # sign that the agent never called the tool, which is the difference
     # between "behaved correctly" and "was never asked to act".
-    exercise = action_path_exercise(runs)
+    exercise = measured_action_path_exercise(scenarios, runs, evaluations)
     exercise_html = ""
     if exercise.total:
         not_exercised_html = "".join(
             f"<li><span class=\"mono\">{_escape(scenario_id)}</span> — the agent did "
-            "not call the tool, so this case's trajectory checks held vacuously and "
-            "its pass is not evidence of correct action behaviour.</li>"
+            "not call the intended action tool. Prerequisite or unrelated calls do "
+            "not exercise this path, so this run supplies no behavioral execution "
+            "evidence for it.</li>"
             for scenario_id in exercise.not_exercised
+        )
+        unmeasured_html = "".join(
+            f"<li><span class=\"mono\">{_escape(scenario_id)}</span> — no single "
+            "non-infrastructure run and evaluation were bound to one unambiguous "
+            "focal action, so this path has no behavioral execution evidence.</li>"
+            for scenario_id in exercise.unmeasured
         )
         exercise_html = (
             f"<p>Action paths exercised: {len(exercise.exercised)}/{exercise.total} "
-            "(a tool was actually called)</p>"
-            + (f"<ul>{not_exercised_html}</ul>" if not_exercised_html else "")
+            "(an intended action-tool attempt was observed)</p>"
+            + (
+                f"<ul>{not_exercised_html}{unmeasured_html}</ul>"
+                if not_exercised_html or unmeasured_html
+                else ""
+            )
         )
     selection_html = ""
     if plan is not None:

--- a/examples/evaluation/pydantic_agent/README.md
+++ b/examples/evaluation/pydantic_agent/README.md
@@ -38,7 +38,7 @@ Expected highlights are `Preflight: supported`, four generated schema/action
 cases, and:
 
 ```text
-Action paths exercised: 1/1 (a tool was actually called)
+Action paths exercised: 1/1 (an intended action-tool attempt was observed)
 Passed:        4
 Infra errors:  0
 ```

--- a/tests/agentcheck/test_domain.py
+++ b/tests/agentcheck/test_domain.py
@@ -7,8 +7,8 @@ import pytest
 from pydantic import ValidationError
 
 from agentcheck.domain import (
-    action_path_exercise,
     ActionKind,
+    ActionPathExercise,
     AgentProperty,
     AgentSpec,
     AssertionResult,
@@ -62,6 +62,8 @@ from agentcheck.domain import (
     UsageMetrics,
     Verdict,
     WorkflowsSpec,
+    action_path_exercise,
+    measured_action_path_exercise,
 )
 
 
@@ -558,23 +560,22 @@ def test_critical_findings_require_deterministic_or_human_confirmation() -> None
 
 
 def test_action_path_exercise_separates_real_calls_from_vacuous_passes() -> None:
-    """A pass on an action case is only behavioural evidence if a tool ran."""
+    """The legacy run-only API remains source and tuple compatible."""
 
-    now = NOW
     called_event = CanonicalEvent(
         event_id="event-called",
         run_id="run-called",
         sequence=0,
         event_type=CanonicalEventType.TOOL_ATTEMPT,
-        timestamp=now,
+        timestamp=NOW,
         payload={"tool_name": "send_report"},
     )
     called = CanonicalRun(
         run_id="run-called",
         scenario_id="action-send-report",
         target_id="spec",
-        started_at=now,
-        ended_at=now,
+        started_at=NOW,
+        ended_at=NOW,
         termination=RunTermination.COMPLETED,
         events=(called_event,),
         tool_attempts=(
@@ -584,7 +585,7 @@ def test_action_path_exercise_separates_real_calls_from_vacuous_passes() -> None
                 tool_name="send_report",
                 arguments={},
                 sequence=0,
-                timestamp=now,
+                timestamp=NOW,
             ),
         ),
     )
@@ -592,17 +593,16 @@ def test_action_path_exercise_separates_real_calls_from_vacuous_passes() -> None
         run_id="run-declined",
         scenario_id="action-archive-report",
         target_id="spec",
-        started_at=now,
-        ended_at=now,
+        started_at=NOW,
+        ended_at=NOW,
         termination=RunTermination.COMPLETED,
     )
-    # A boundary case is not an action path, so it must not be counted either way.
     boundary = CanonicalRun(
         run_id="run-boundary",
         scenario_id="boundary-send-report-missing-required",
         target_id="spec",
-        started_at=now,
-        ended_at=now,
+        started_at=NOW,
+        ended_at=NOW,
         termination=RunTermination.COMPLETED,
     )
 
@@ -610,8 +610,209 @@ def test_action_path_exercise_separates_real_calls_from_vacuous_passes() -> None
 
     assert exercise.exercised == ("action-send-report",)
     assert exercise.not_exercised == ("action-archive-report",)
+    assert tuple(exercise) == (
+        ("action-send-report",),
+        ("action-archive-report",),
+    )
+    assert ActionPathExercise(*exercise) == exercise
     assert exercise.total == 2
 
 
 def test_action_path_exercise_is_empty_without_action_cases() -> None:
     assert action_path_exercise(()).total == 0
+
+
+def test_measured_action_paths_fail_closed_on_incomplete_or_ambiguous_evidence() -> None:
+    """Only the intended action attempt with a usable binding is exercised."""
+
+    from agentcheck.evaluate import evaluate_run
+
+    def action_scenario(
+        scenario_id: str,
+        tool_name: str,
+        *,
+        helper_tool: str | None = None,
+        tag_helper: bool = False,
+    ) -> Scenario:
+        tags = ["path:action", f"tool:{tool_name}"]
+        constraints = [
+            ToolBehaviorConstraint(
+                criterion_id=f"allow-{tool_name}",
+                tool_name=tool_name,
+                min_calls=0,
+                max_calls=1,
+                oracle_ids=("oracle-delete-contract",),
+            )
+        ]
+        if helper_tool is not None:
+            constraints.append(
+                ToolBehaviorConstraint(
+                    criterion_id=f"allow-{helper_tool}",
+                    tool_name=helper_tool,
+                    min_calls=0,
+                    max_calls=1,
+                    oracle_ids=("oracle-delete-contract",),
+                )
+            )
+            if tag_helper:
+                tags.append(f"tool:{helper_tool}")
+        payload = _scenario(
+            scenario_id=scenario_id,
+            tags=tuple(tags),
+        ).model_dump(mode="python")
+        payload["forbidden_tool_behavior"] = ()
+        payload["allowed_tool_behavior"] = tuple(constraints)
+        payload["fingerprint"] = ""
+        return Scenario.model_validate(payload)
+
+    def run_with_attempt(
+        scenario_id: str,
+        tool_name: str,
+        *,
+        suffix: str,
+        termination: RunTermination = RunTermination.COMPLETED,
+    ) -> CanonicalRun:
+        run_id = f"run-{suffix}"
+        event = CanonicalEvent(
+            event_id=f"event-{suffix}",
+            run_id=run_id,
+            sequence=0,
+            event_type=CanonicalEventType.TOOL_ATTEMPT,
+            timestamp=NOW,
+            payload={"tool_name": tool_name},
+        )
+        return CanonicalRun(
+            run_id=run_id,
+            scenario_id=scenario_id,
+            target_id="spec",
+            started_at=NOW,
+            ended_at=NOW,
+            termination=termination,
+            termination_reason=(
+                "The worker failed after recording the attempt."
+                if termination is not RunTermination.COMPLETED
+                else None
+            ),
+            events=(event,),
+            tool_attempts=(
+                ToolAttempt(
+                    attempt_id=f"attempt-{suffix}",
+                    event_id=event.event_id,
+                    tool_name=tool_name,
+                    arguments={},
+                    sequence=0,
+                    timestamp=NOW,
+                ),
+            ),
+        )
+
+    def passing_evaluation(run: CanonicalRun, *, suffix: str) -> CaseEvaluation:
+        assertion = AssertionResult(
+            assertion_id=f"assert-{suffix}",
+            criterion="The observed action path met its deterministic contract.",
+            result=Verdict.PASS,
+            oracle_ids=("oracle-delete-contract",),
+            rationale="The deterministic action-path assertion passed.",
+        )
+        return CaseEvaluation(
+            evaluation_id=f"evaluation-{suffix}",
+            scenario_id=run.scenario_id,
+            run_id=run.run_id,
+            verdict=Verdict.PASS,
+            assertions=(assertion,),
+            started_at=NOW,
+            completed_at=NOW,
+            summary="The action-path evaluation completed.",
+        )
+
+    called_scenario = action_scenario("action-send-report", "send_report")
+    prerequisite_scenario = action_scenario(
+        "action-cancel-order", "cancel_order", helper_tool="lookup_order"
+    )
+    declined_scenario = action_scenario("action-archive-report", "archive_report")
+    missing_scenario = action_scenario("action-delete-report", "delete_report")
+    duplicate_scenario = action_scenario("action-publish-report", "publish_report")
+    infra_scenario = action_scenario("action-refund-order", "refund_order")
+    ambiguous_scenario = action_scenario(
+        "action-transfer-order",
+        "transfer_order",
+        helper_tool="lookup_order",
+        tag_helper=True,
+    )
+    boundary_scenario = _scenario(scenario_id="boundary-send-report-missing-required")
+
+    called = run_with_attempt(called_scenario.scenario_id, "send_report", suffix="called")
+    prerequisite_only = run_with_attempt(
+        prerequisite_scenario.scenario_id,
+        "lookup_order",
+        suffix="prerequisite",
+    )
+    declined = CanonicalRun(
+        run_id="run-declined",
+        scenario_id=declined_scenario.scenario_id,
+        target_id="spec",
+        started_at=NOW,
+        ended_at=NOW,
+        termination=RunTermination.COMPLETED,
+    )
+    duplicate_1 = run_with_attempt(
+        duplicate_scenario.scenario_id, "publish_report", suffix="duplicate-1"
+    )
+    duplicate_2 = run_with_attempt(
+        duplicate_scenario.scenario_id, "publish_report", suffix="duplicate-2"
+    )
+    infra_run = run_with_attempt(
+        infra_scenario.scenario_id,
+        "refund_order",
+        suffix="infra",
+        termination=RunTermination.WORKER_ERROR,
+    )
+    ambiguous_run = run_with_attempt(
+        ambiguous_scenario.scenario_id, "transfer_order", suffix="ambiguous"
+    )
+    infra_evaluation = evaluate_run(infra_scenario, infra_run)
+
+    assert infra_evaluation.verdict is Verdict.INFRA_ERROR
+
+    exercise = measured_action_path_exercise(
+        (
+            called_scenario,
+            prerequisite_scenario,
+            declined_scenario,
+            missing_scenario,
+            duplicate_scenario,
+            infra_scenario,
+            ambiguous_scenario,
+            boundary_scenario,
+        ),
+        (
+            called,
+            prerequisite_only,
+            declined,
+            duplicate_1,
+            duplicate_2,
+            infra_run,
+            ambiguous_run,
+        ),
+        (
+            passing_evaluation(called, suffix="called"),
+            passing_evaluation(prerequisite_only, suffix="prerequisite"),
+            passing_evaluation(declined, suffix="declined"),
+            passing_evaluation(duplicate_1, suffix="duplicate"),
+            infra_evaluation,
+            passing_evaluation(ambiguous_run, suffix="ambiguous"),
+        ),
+    )
+
+    assert exercise.exercised == ("action-send-report",)
+    assert exercise.not_exercised == (
+        "action-cancel-order",
+        "action-archive-report",
+    )
+    assert exercise.unmeasured == (
+        "action-delete-report",
+        "action-publish-report",
+        "action-refund-order",
+        "action-transfer-order",
+    )
+    assert exercise.total == 7

--- a/tests/agentcheck/test_positive_path_cases.py
+++ b/tests/agentcheck/test_positive_path_cases.py
@@ -323,9 +323,20 @@ def _exercise_output(scenario, run, capsys) -> str:
     from types import SimpleNamespace
 
     from agentcheck.cli import _print_action_path_exercise
+    from agentcheck.domain import Verdict
 
     _print_action_path_exercise(
-        SimpleNamespace(runs=(run,), scenarios=(scenario,))
+        SimpleNamespace(
+            runs=(run,),
+            scenarios=(scenario,),
+            evaluations=(
+                SimpleNamespace(
+                    scenario_id=scenario.scenario_id,
+                    run_id=run.run_id,
+                    verdict=Verdict.PASS,
+                ),
+            ),
+        )
     )
     return capsys.readouterr().out
 
@@ -372,3 +383,23 @@ def test_unexercised_authored_case_does_not_repeat_the_suggestion(capsys) -> Non
     assert "Action paths exercised: 0/1" in output
     assert '"user_request"' not in output
     assert "already carry an authored request" in output
+
+
+def test_action_path_without_a_canonical_run_stays_in_the_denominator(
+    capsys,
+) -> None:
+    """An infrastructure-failed case must not vanish from the path metric."""
+
+    from types import SimpleNamespace
+
+    from agentcheck.cli import _print_action_path_exercise
+
+    (case,) = build_positive_path_cases(_spec(update_seat), seed=1729)
+    _print_action_path_exercise(
+        SimpleNamespace(runs=(), scenarios=(case.scenario,), evaluations=())
+    )
+
+    output = capsys.readouterr().out
+    assert "Action paths exercised: 0/1" in output
+    assert f"unmeasured: {case.scenario.scenario_id}" in output
+    assert "no behavioral execution evidence" in output

--- a/tests/agentcheck/test_report.py
+++ b/tests/agentcheck/test_report.py
@@ -22,19 +22,25 @@ from agentcheck.domain import (
     CapabilitiesSpec,
     CanonicalRun,
     CaseEvaluation,
+    ConversationRole,
+    ConversationTurn,
     IdentitySpec,
     InspectionProvenance,
     InstructionsSpec,
     InterfaceSpec,
     ObservabilitySpec,
+    OracleProvenance,
+    OracleStrength,
     Policy,
     PoliciesSpec,
     RunTermination,
     RuntimeSpec,
+    Scenario,
     SourceKind,
     SourceReference,
     SpecEvidence,
     ToolsSpec,
+    ToolBehaviorConstraint,
     UsageMetrics,
     Verdict,
     utc_now,
@@ -1009,22 +1015,83 @@ def test_report_states_when_an_action_path_was_never_exercised() -> None:
         ended_at=now,
         termination=RunTermination.COMPLETED,
     )
+    oracle = OracleProvenance(
+        oracle_id="action-oracle",
+        strength=OracleStrength.TOOL_CONTRACT,
+        source="declared tool contract",
+        confidence=1.0,
+        evidence_ids=("declared-tool",),
+        supports_hard_failure=True,
+    )
+
+    def action_scenario(scenario_id: str, tool_name: str) -> Scenario:
+        return Scenario(
+            scenario_id=scenario_id,
+            title=f"Exercise {tool_name}",
+            conversation_turns=(
+                ConversationTurn(
+                    turn_id=f"turn-{scenario_id}",
+                    role=ConversationRole.USER,
+                    content=f"Please perform {tool_name}.",
+                ),
+            ),
+            allowed_tool_behavior=(
+                ToolBehaviorConstraint(
+                    criterion_id=f"allow-{tool_name}",
+                    tool_name=tool_name,
+                    min_calls=0,
+                    max_calls=1,
+                    oracle_ids=(oracle.oracle_id,),
+                ),
+            ),
+            dimension_tags=("path:action", f"tool:{tool_name}"),
+            oracle_provenance=(oracle,),
+            generation_seed=SEED,
+        )
+
+    declined_scenario = action_scenario(
+        "action-send-flagged-notification", "send_flagged_notification"
+    )
+    unexecuted_scenario = action_scenario(
+        "action-archive-flagged-notification", "archive_flagged_notification"
+    )
+    declined_evaluation = CaseEvaluation(
+        evaluation_id="evaluation-declined-action",
+        scenario_id=declined.scenario_id,
+        run_id=declined.run_id,
+        verdict=Verdict.PASS,
+        assertions=(
+            AssertionResult(
+                assertion_id="assert-declined-action",
+                criterion="The declined action path met its deterministic contract.",
+                result=Verdict.PASS,
+                oracle_ids=(oracle.oracle_id,),
+                rationale="No prohibited action behavior was observed.",
+            ),
+        ),
+        started_at=now,
+        completed_at=now,
+        summary="The declined action-path evaluation completed.",
+    )
 
     report = render_report(
         run_id="run",
         target="target",
         git_revision=None,
         spec=_spec("agent"),
-        scenarios=(),
+        scenarios=(declined_scenario, unexecuted_scenario),
         runs=(declined,),
-        evaluations=(),
+        evaluations=(declined_evaluation,),
         findings=(),
     )
 
-    assert "Action paths exercised: 0/1" in report
+    assert "Action paths exercised: 0/2" in report
     assert "action-send-flagged-notification" in report
-    assert "held vacuously" in report
-    assert "not evidence of correct action behaviour" in report
+    assert "did not call the intended action tool" in report
+    assert "Prerequisite or unrelated calls do not exercise this path" in report
+    assert "action-archive-flagged-notification" in report
+    assert "no single non-infrastructure run and evaluation" in report
+    assert "no behavioral execution evidence" in report
 
 
 def test_report_case_origins_account_for_every_case() -> None:


### PR DESCRIPTION
## Summary
- preserve the legacy run-only action-path helper while adding an evidence-facing classifier with a scenario-owned denominator
- count a path as exercised only when one bound non-infrastructure evaluation has a canonical attempt for the uniquely declared focal tool
- label missing, duplicate, ambiguous, and infrastructure evidence as unmeasured in CLI and HTML reports
- add regressions for prerequisite-only calls, missing and duplicate runs, ambiguous focal tools, and a target attempt followed by infrastructure failure

## Evidence-integrity impact
This prevents generated-but-unexecuted action cases, unrelated prerequisite calls, or infrastructure-failed cases from producing an inflated Action paths exercised numerator or disappearing from its denominator. The wording intentionally claims an observed attempt, not successful tool execution.

## Offline validation
- 70 passed: test_domain.py, test_positive_path_cases.py, test_report.py
- 9 passed after rebase: focused classifier, CLI/report, compatibility, and documentation regressions
- Ruff passed on all changed Python files
- mypy passed on 4 changed source files
- git diff --check passed

No provider-backed tests or paid integrations were used.