### PR TITLE
Reject unresolved fixture template placeholders

### DIFF
--- a/agentcheck/fixtures/loader.py
+++ b/agentcheck/fixtures/loader.py
@@ -117,8 +117,7 @@ def validate_fixture_pack(pack: FixturePack, spec: AgentSpec) -> dict[str, JsonO
                 raise ConfigurationError(
                     f"{tool_name}.{parameter} still contains the generated "
                     f"{_GENERATED_PLACEHOLDER} placeholder; replace it with a "
-                    "representative synthetic test value before generating or "
-                    "testing the suite"
+                    "representative synthetic test value, then regenerate the suite"
                 )
             if isinstance(value, str) and redact_log_text(value) != value:
                 raise ConfigurationError(

--- a/agentcheck/fixtures/loader.py
+++ b/agentcheck/fixtures/loader.py
@@ -24,6 +24,7 @@ from .pack import DEFAULT_FIXTURES_FILENAME, FixturePack
 
 _MAX_FIXTURE_BYTES = 64 * 1024
 _ENV_KEY = "$env"
+_GENERATED_PLACEHOLDER = "REPLACE_ME"
 
 
 def load_fixture_pack(root: Path, *, filename: str | None = None) -> FixturePack | None:
@@ -111,6 +112,13 @@ def validate_fixture_pack(pack: FixturePack, spec: AgentSpec) -> dict[str, JsonO
                     f"fixture for {tool_name} names unknown parameter "
                     f"{parameter!r}; the tool declares: {known}. The tool schema "
                     "may have changed since the fixture was written."
+                )
+            if value == _GENERATED_PLACEHOLDER:
+                raise ConfigurationError(
+                    f"{tool_name}.{parameter} still contains the generated "
+                    f"{_GENERATED_PLACEHOLDER} placeholder; replace it with a "
+                    "representative synthetic test value before generating or "
+                    "testing the suite"
                 )
             if isinstance(value, str) and redact_log_text(value) != value:
                 raise ConfigurationError(

--- a/tests/agentcheck/test_generate.py
+++ b/tests/agentcheck/test_generate.py
@@ -45,6 +45,7 @@ from agentcheck.domain import (
 )
 from agentcheck.errors import ConfigurationError, ScenarioValidationError
 from agentcheck.evaluate import evaluate_run
+from agentcheck.fixtures import DEFAULT_FIXTURES_FILENAME
 from agentcheck.generate import (
     DEFAULT_SUITE_FILENAME,
     FROZEN_SUITE_CONTRACT_VERSION,
@@ -356,6 +357,34 @@ def test_generate_then_test_preserves_builtin_verdicts(tmp_path: Path) -> None:
         for case in generation.suite.cases
         if case.lineage.origin is CaseOrigin.SCHEMA_BOUNDARY
     )
+
+
+def test_generate_refuses_an_unedited_fixture_template(tmp_path: Path) -> None:
+    target = _copy_example(tmp_path)
+    (target / DEFAULT_FIXTURES_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": "agentcheck.fixtures.v1",
+                "tools": {
+                    "delete_account": {
+                        "arguments": {"account_id": "REPLACE_ME"}
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ConfigurationError,
+        match=(
+            r"delete_account\.account_id still contains the generated REPLACE_ME "
+            r"placeholder; replace it with a representative synthetic test value"
+        ),
+    ):
+        application.generate_suite(target, seed=SEED)
+
+    assert not (target / DEFAULT_SUITE_FILENAME).exists()
 
 
 def test_execute_suite_without_a_frozen_file_keeps_phase1_behavior(

--- a/tests/agentcheck/test_representative_inputs.py
+++ b/tests/agentcheck/test_representative_inputs.py
@@ -167,6 +167,24 @@ def test_credential_shaped_value_is_refused(tmp_path: Path) -> None:
         load_representative_inputs(tmp_path, _spec(update_seat))
 
 
+def test_generated_placeholder_is_refused_with_an_actionable_error(
+    tmp_path: Path,
+) -> None:
+    """The template marker is not evidence of a representative input."""
+
+    _write(tmp_path, _pack(confirmation_number="REPLACE_ME"))
+
+    with pytest.raises(
+        ConfigurationError,
+        match=(
+            r"update_seat\.confirmation_number still contains the generated "
+            r"REPLACE_ME placeholder; replace it with a representative synthetic "
+            r"test value before generating or testing the suite"
+        ),
+    ):
+        load_representative_inputs(tmp_path, _spec(update_seat))
+
+
 def test_environment_reference_is_refused_rather_than_half_supported(
     tmp_path: Path,
 ) -> None:

--- a/tests/agentcheck/test_representative_inputs.py
+++ b/tests/agentcheck/test_representative_inputs.py
@@ -179,7 +179,7 @@ def test_generated_placeholder_is_refused_with_an_actionable_error(
         match=(
             r"update_seat\.confirmation_number still contains the generated "
             r"REPLACE_ME placeholder; replace it with a representative synthetic "
-            r"test value before generating or testing the suite"
+            r"test value, then regenerate the suite"
         ),
     ):
         load_representative_inputs(tmp_path, _spec(update_seat))


### PR DESCRIPTION
## Problem

`agentcheck fixtures init` writes `REPLACE_ME` template values, but fixture validation accepted those exact sentinels as representative inputs. Generation could therefore report an action path as representative even though the developer had not supplied usable test data.

## Fix

- reject the exact normalized generator-owned `REPLACE_ME` sentinel at fixture validation
- identify the exact `tool.parameter` and tell the developer to replace it, then regenerate
- prove generation writes no frozen suite when a placeholder remains
- preserve existing frozen-suite semantics: old suites are not heuristically scanned for a literal that may be intentional

## Validation

- red regression failed before the loader change (`DID NOT RAISE ConfigurationError`)
- 104 focused tests passed during implementation/review
- actual generated-template `generate --force` smoke blocked with exit 2 and preserved the existing suite byte-for-byte
- corrected synthetic fixture generated successfully; bundled offline execution completed 47 cases
- Ruff, mypy, and diff checks passed
- independent final review found no blocking issues at `e521946`

No provider calls, credentials, network-enabled target execution, CLI redesign, or containment changes.
