### PR TITLE
Correct identity and determinism evidence docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,10 @@ verdict logic. Do not widen an SDK version gate without evidence that the new
 minor version was tested. Dependency and workflow changes require owner review
 and are never auto-merged.
 
-Package and frozen-suite generator versions are currently coupled: the package
-version is recorded in suite provenance and participates in suite fingerprints.
-Until that contract is separated deliberately, version changes can re-identify
-newly generated otherwise-equivalent suites and must be reviewed as compatibility
-events.
+Package releases and frozen-suite generation compatibility use separate
+versions. The distribution release (`agentcheck.__version__`) records which
+build executed a run and does not participate in suite provenance or suite
+fingerprints. `GENERATOR_COMPATIBILITY_VERSION` is recorded in suite provenance
+and does participate in suite fingerprints; raise it only when changed
+generation semantics should re-identify otherwise-equivalent suites. A package
+release alone is not a suite compatibility event.

--- a/docs/validation-evidence.md
+++ b/docs/validation-evidence.md
@@ -16,9 +16,9 @@ Progressive targets exposed progressively harder problems:
 **Targets #1 and #2** reached the evaluation boundary but were limited. A
 tool-less agent with a declared `output_type` produces one output-schema case;
 an agent whose tools are all read-only gives the trajectory oracles little to
-observe. Runs were deterministic — identical suite fingerprints across repeated
-runs — but a deterministic run of a target with nothing consequential to do is a
-weak signal, and was treated as one.
+observe. Suite generation was reproducible — repeated generation produced
+identical suite fingerprints — but a reproducibly generated suite for a target
+with nothing consequential to do is a weak signal, and was treated as one.
 
 **Target #3** was the first target that owns a state-changing action itself and
 whose own instructions document the rule that action should be judged against.
@@ -199,9 +199,11 @@ and none is quoted here or anywhere else.** The benchmark remains unfinished.
 
 Deterministic:
 
-- scenario generation, suite freezing, and fingerprinting — the same target
-  location, configuration, seed, and generator version freeze a byte-identical
-  suite;
+- scenario generation, suite freezing, and fingerprinting from identical
+  complete local generation inputs when provider realization is not used.
+  Those inputs include target identity, configuration, seed, generator
+  compatibility version, fixtures, declared policy packs, scenario requests,
+  and prerequisite outcomes; checkout location itself is excluded;
 - tool simulation, fixture and fault injection;
 - oracle evaluation and verdict assignment given the same recorded inputs;
 - offline evaluation through the controlled model, which is why the bundled
@@ -217,10 +219,18 @@ provider replay. It reproduces the inputs and the harness; it does not replay
 recorded model output as though the model were deterministic, and it should not
 be described as if it does.
 
-## Fingerprints are per-location
+## Target and suite identity are portable across checkout locations
 
-Suite fingerprints incorporate the target's absolute entrypoint path, so an
-identical target at a different path fingerprints differently. Fingerprints are
-therefore stable per machine and per location, not portable across them. This is
-pre-existing behaviour and worth knowing before treating a fingerprint as a
-global identity.
+Current target identity uses the entrypoint relative to the target root, not the
+absolute checkout path. An unchanged target therefore receives the same
+`spec_id` in a developer checkout and a CI checkout. Given identical complete
+generation inputs, its frozen suite fingerprints the same way too. If provider
+realization is enabled, identical recorded realization output is also required;
+a real provider can vary that output. A semantic change to the target, including
+a different relative entrypoint, still changes identity.
+
+Artifacts created before portable target identity remain location-bound. They
+are recognized only when an inspection at the original location reproduces
+their legacy absolute-path identity. Regenerating such an artifact from the
+current checkout produces a portable identity; AgentCheck does not infer that a
+legacy artifact from another location is equivalent.

--- a/tests/agentcheck/test_portable_identity.py
+++ b/tests/agentcheck/test_portable_identity.py
@@ -51,7 +51,7 @@ def _weather_agent(agents: Any, *, instructions: str = "You report weather.") ->
 
 
 # --------------------------------------------------------------------------
-# Reproduction: identity currently depends on the absolute checkout location.
+# Regression: identity used to depend on the absolute checkout location.
 # --------------------------------------------------------------------------
 
 
@@ -135,6 +135,23 @@ def test_portable_identity_is_deterministic_across_repeated_inspections(
     ids = {inspect_target(target)[2].value.spec_id for _ in range(3)}
 
     assert len(ids) == 1
+
+
+def test_validation_evidence_describes_portable_identity() -> None:
+    documentation = (REPOSITORY_ROOT / "docs" / "validation-evidence.md").read_text(
+        encoding="utf-8"
+    )
+    prose = " ".join(documentation.split())
+
+    assert "identity are portable across checkout locations" in prose
+    assert "entrypoint relative to the target root" in prose
+    assert "identical complete generation inputs" in prose
+    assert "provider realization" in prose
+    assert (
+        "Artifacts created before portable target identity remain location-bound"
+        in prose
+    )
+    assert "## Fingerprints are per-location" not in documentation
 
 
 # --------------------------------------------------------------------------

--- a/tests/agentcheck/test_version_decoupling.py
+++ b/tests/agentcheck/test_version_decoupling.py
@@ -244,3 +244,18 @@ def test_the_release_version_is_declared_once_in_effect() -> None:
         f"pyproject.toml declares {match.group(1)!r} but "
         f"agentcheck.__version__ is {agentcheck.__version__!r}"
     )
+
+
+def test_contributing_docs_keep_release_and_generator_versions_separate() -> None:
+    contributing = Path(__file__).resolve().parents[2] / "CONTRIBUTING.md"
+    text = contributing.read_text(encoding="utf-8")
+    prose = " ".join(text.split())
+
+    assert (
+        "Package releases and frozen-suite generation compatibility use separate"
+        in prose
+    )
+    assert "A package release alone is not a suite compatibility event" in prose
+    assert (
+        "Package and frozen-suite generator versions are currently coupled" not in text
+    )


### PR DESCRIPTION
## Problem

Public validation/contributor docs still described three superseded contracts:

- identical suite fingerprints were summarized as deterministic runs
- current fingerprints were described as absolute-path/location-bound
- distribution releases and suite-generation compatibility were described as coupled

Those claims contradict current portable identity, legacy compatibility, and release/version-decoupling behavior.

## Fix

- narrow repeated-fingerprint evidence to reproducible suite generation
- state the complete-input boundary, including fixtures/policies/requests/prerequisites and provider-realization caveats
- describe portable current identity and the bounded location-bound legacy bridge
- document distribution version versus `GENERATOR_COMPATIBILITY_VERSION`
- add focused public-doc consistency sentinels beside the semantic contract tests

## Validation

- complete `test_portable_identity.py` + `test_version_decoupling.py`: 48 passed (parent run) and 48 passed (independent review)
- final focused docs/fixture/policy/realization identity batch: 16 passed
- Ruff and diff checks passed
- independent final review found no remaining findings

Documentation and tests only. No provider calls, credentials, runtime evidence changes, or containment work.
