### PR TITLE
Fix published README links on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AgentCheck
 
 [![PyPI version](https://img.shields.io/pypi/v/agentcheck-ai.svg)](https://pypi.org/project/agentcheck-ai/)
-[![Python 3.10–3.12](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-3776AB?logo=python&logoColor=white)](pyproject.toml)
-[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-2ea44f.svg)](LICENSE)
+[![Python 3.10–3.12](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-3776AB?logo=python&logoColor=white)](https://github.com/WaseemGhanem98/AgentCheck/blob/main/pyproject.toml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-2ea44f.svg)](https://github.com/WaseemGhanem98/AgentCheck/blob/main/LICENSE)
 
 **Behavioral testing for AI agents.**
 
@@ -65,7 +65,7 @@ agentcheck gate .
 It runs the frozen suite, compares the result against a trusted baseline, and
 returns a single status: `0` allow, `1` a behavioral failure is new, `2` the run
 was not certifiable, `3` the suite could not decide. Failures a baseline already
-accepts do not block. See [the CI gate](docs/ci-gate.md).
+accepts do not block. See [the CI gate](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/ci-gate.md).
 
 The target directory must already exist. `generate` and `test` may inspect the
 target again because each command independently validates current source instead
@@ -97,7 +97,7 @@ what the agent does when a tool does not cooperate, not only when it does.
 Which tools get them depends on how the tool's side-effect risk was
 established, with an explicit precedence: developer declaration, then genuine
 framework metadata, then inference, then unknown. A [custom Python
-agent](docs/custom-agents.md) can state it directly on the tool
+agent](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/custom-agents.md) can state it directly on the tool
 (`ToolDefinition(state_changing=True, destructive=True)`), and every adapter
 can be told through `agentcheck.json`'s `tool_risk` block — a declared axis is
 always authoritative. Neither the OpenAI Agents SDK nor PydanticAI carries
@@ -113,11 +113,11 @@ classification. Generic dispatch names such as `bash`, `execute_python`, or
 `execute_command` remain `UNKNOWN` and receive no risk-scoped fault family
 until declared. Inferred risk remains non-authoritative, so coverage reports
 `risk_metadata_not_authoritative` rather than implying the tool was checked.
-See [fault testing](docs/fault-testing.md) and, to declare your own
-contracts, [behavioral policies](docs/behavioral-policies.md). Multiple tool
+See [fault testing](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/fault-testing.md) and, to declare your own
+contracts, [behavioral policies](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/behavioral-policies.md). Multiple tool
 calls decided in one model response, and what AgentCheck can and cannot test
 about that, are covered in
-[concurrent tool decisions](docs/concurrent-tool-decisions.md).
+[concurrent tool decisions](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/concurrent-tool-decisions.md).
 
 ## What AgentCheck catches
 
@@ -171,9 +171,9 @@ closed as `INFRA_ERROR`; AgentCheck does not invent a plausible tool result.
 
 | Integration | Install | Guide |
 |---|---|---|
-| OpenAI Agents SDK | `agentcheck-ai[openai-agents]` | [Worked example](examples/evaluation/account_agent/README.md) |
-| PydanticAI | `agentcheck-ai[pydantic-ai]` | [Setup and offline evaluation](docs/pydantic-ai.md) |
-| Custom Python agents | `agentcheck-ai` | [Integration contract](docs/custom-agents.md) |
+| OpenAI Agents SDK | `agentcheck-ai[openai-agents]` | [Worked example](https://github.com/WaseemGhanem98/AgentCheck/blob/main/examples/evaluation/account_agent/README.md) |
+| PydanticAI | `agentcheck-ai[pydantic-ai]` | [Setup and offline evaluation](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/pydantic-ai.md) |
+| Custom Python agents | `agentcheck-ai` | [Integration contract](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/custom-agents.md) |
 
 The native adapters are pinned to verified SDK minor versions and reject
 unsupported versions rather than guessing. Custom Python support is a lightweight
@@ -197,7 +197,7 @@ Network denial is not a general operating-system sandbox. Target imports execute
 and direct filesystem writes, subprocess execution, or direct database access
 from arbitrary Python orchestration are outside the declared-tool guarantee.
 
-Read [SECURITY.md](SECURITY.md) before evaluating a new target.
+Read [SECURITY.md](https://github.com/WaseemGhanem98/AgentCheck/blob/main/SECURITY.md) before evaluating a new target.
 
 ## Reports and artifacts
 
@@ -215,7 +215,7 @@ Review artifacts before sharing them; they may contain prompts, model output,
 tool inputs, and absolute paths.
 
 The `generate` command and run reports also show [declared behavioral
-coverage](docs/behavioral-coverage.md): which declared-tool success, failure,
+coverage](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/behavioral-coverage.md): which declared-tool success, failure,
 and timeout requirements—and which explicitly represented retry, confirmation,
 duplicate-action, and prerequisite contracts—the suite covers or leaves
 missing. This is not a claim that every real-world behavior was observed.
@@ -225,24 +225,24 @@ configuration, specification, and scenario bindings before running again. It
 reproduces inputs and harness behavior; it does not capture provider output or
 make stochastic model execution deterministic.
 
-For CI, start from the [credential-free workflow example](.github/workflows/agentcheck-example.yml)
-and read the [CI trust model](docs/ci-trust-model.md).
+For CI, start from the [credential-free workflow example](https://github.com/WaseemGhanem98/AgentCheck/blob/main/.github/workflows/agentcheck-example.yml)
+and read the [CI trust model](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/ci-trust-model.md).
 
 ## Documentation
 
-- [OpenAI Agents SDK worked example](examples/evaluation/account_agent/README.md)
-- [PydanticAI setup and offline evaluation](docs/pydantic-ai.md)
-- [Custom Python agent contract](docs/custom-agents.md)
-- [Validation evidence and claim boundaries](docs/validation-evidence.md)
-- [Portable target identity](docs/portable-identity.md)
-- [Decision stages and happens-before](docs/behavioral-launch.md)
-- [Declared behavioral coverage](docs/behavioral-coverage.md)
-- [Fault testing](docs/fault-testing.md)
-- [Behavioral policies](docs/behavioral-policies.md)
-- [The CI gate](docs/ci-gate.md)
-- [Behavioral regression comparison](docs/behavioral-regression.md)
-- [CI trust model](docs/ci-trust-model.md)
-- [Changelog](CHANGELOG.md)
+- [OpenAI Agents SDK worked example](https://github.com/WaseemGhanem98/AgentCheck/blob/main/examples/evaluation/account_agent/README.md)
+- [PydanticAI setup and offline evaluation](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/pydantic-ai.md)
+- [Custom Python agent contract](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/custom-agents.md)
+- [Validation evidence and claim boundaries](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/validation-evidence.md)
+- [Portable target identity](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/portable-identity.md)
+- [Decision stages and happens-before](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/behavioral-launch.md)
+- [Declared behavioral coverage](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/behavioral-coverage.md)
+- [Fault testing](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/fault-testing.md)
+- [Behavioral policies](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/behavioral-policies.md)
+- [The CI gate](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/ci-gate.md)
+- [Behavioral regression comparison](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/behavioral-regression.md)
+- [CI trust model](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/ci-trust-model.md)
+- [Changelog](https://github.com/WaseemGhanem98/AgentCheck/blob/main/CHANGELOG.md)
 - [PyPI package](https://pypi.org/project/agentcheck-ai/)
 
 ## Contributing
@@ -255,20 +255,20 @@ provider calls. The complete local suite is:
 python -m pytest tests -q -n 2
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, focused tests, and the safety
+See [CONTRIBUTING.md](https://github.com/WaseemGhanem98/AgentCheck/blob/main/CONTRIBUTING.md) for setup, focused tests, and the safety
 invariants that changes must preserve.
 
 ## Security
 
 Do not file vulnerabilities as public issues. Use GitHub Private Vulnerability
-Reporting as described in [SECURITY.md](SECURITY.md). Never put credentials or
+Reporting as described in [SECURITY.md](https://github.com/WaseemGhanem98/AgentCheck/blob/main/SECURITY.md). Never put credentials or
 production data in configuration, fixture packs, frozen suites, or run artifacts.
 
 ## License
 
 Copyright © 2026 Waseem Ghanem.
 
-Current source is licensed under the [Apache License 2.0](LICENSE). AgentCheck
+Current source is licensed under the [Apache License 2.0](https://github.com/WaseemGhanem98/AgentCheck/blob/main/LICENSE). AgentCheck
 `0.1.0` and `0.1.1` were distributed under the MIT License; that license
-continues to govern those release artifacts. See [NOTICE](NOTICE) for the
+continues to govern those release artifacts. See [NOTICE](https://github.com/WaseemGhanem98/AgentCheck/blob/main/NOTICE) for the
 project's copyright notice.

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -32,8 +32,16 @@ FORBIDDEN = (
     (re.compile(r"(^|/)dist/"), "nested distributions"),
 )
 
-MARKDOWN_DESTINATION = re.compile(
-    r"\]\(\s*(?P<destination><[^>\r\n]+>|[^\s)\r\n]+)"
+MARKDOWN_INLINE_DESTINATION = re.compile(
+    r"\]\(\s*(?P<destination><[^>\r\n]*>|[^\s)\r\n]*)"
+)
+MARKDOWN_REFERENCE_DEFINITION = re.compile(
+    r"\[(?:\\.|[^\]\r\n])+\]:"
+)
+HTML_DESTINATION = re.compile(
+    r"\b(?:href|src)\s*=\s*(?:\"(?P<double>[^\"]*)\"|"
+    r"'(?P<single>[^']*)'|(?P<unquoted>[^\s>]+))",
+    re.IGNORECASE,
 )
 ABSOLUTE_URI = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 
@@ -117,13 +125,42 @@ def _metadata(path: pathlib.Path) -> tuple[str, str]:
         return member.name, extracted.read().decode("utf-8")
 
 
-def _relative_markdown_destinations(text: str) -> set[str]:
-    destinations: set[str] = set()
-    for match in MARKDOWN_DESTINATION.finditer(text):
-        destination = match.group("destination").strip("<>")
-        if not destination.startswith("#") and ABSOLUTE_URI.match(destination) is None:
-            destinations.add(destination)
-    return destinations
+def _is_absolute_or_same_page(destination: str) -> bool:
+    return destination.startswith("#") or ABSOLUTE_URI.match(destination) is not None
+
+
+def _long_description_link_violations(text: str) -> list[str]:
+    """Enforce AgentCheck's deliberately small README link syntax.
+
+    The public README uses inline Markdown links and images only. Reference-style
+    definitions are disallowed, as are relative raw-HTML destinations. Keeping
+    that authoring rule explicit avoids a dependency or a partial Markdown parser.
+    Link-shaped literals in README prose or code must use a different spelling.
+    """
+
+    violations: set[str] = set()
+    for match in MARKDOWN_INLINE_DESTINATION.finditer(text):
+        candidate = match.group("destination")
+        destination = (
+            candidate[1:-1]
+            if candidate.startswith("<") and candidate.endswith(">")
+            else candidate
+        )
+        if not _is_absolute_or_same_page(destination):
+            violations.add(f"relative Markdown destination {destination!r}")
+
+    if MARKDOWN_REFERENCE_DEFINITION.search(text) is not None:
+        violations.add(
+            "reference-style Markdown definitions are not allowed; "
+            "use inline absolute links"
+        )
+
+    for match in HTML_DESTINATION.finditer(text):
+        destination = next(group for group in match.groups() if group is not None)
+        if not _is_absolute_or_same_page(destination):
+            violations.add(f"relative HTML destination {destination!r}")
+
+    return sorted(violations)
 
 
 def main() -> int:
@@ -174,10 +211,9 @@ def main() -> int:
         except (OSError, UnicodeDecodeError, ValueError) as error:
             failures.append(f"{artifact.name}: invalid distribution metadata ({error})")
         else:
-            for destination in sorted(_relative_markdown_destinations(metadata)):
+            for violation in _long_description_link_violations(metadata):
                 failures.append(
-                    f"{artifact.name}: {metadata_name}: relative Markdown destination "
-                    f"{destination!r}"
+                    f"{artifact.name}: {metadata_name}: {violation}"
                 )
 
     if failures:

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -5,6 +5,9 @@ gets mirrored. Both are easy to pollute by accident: a stray run artifact, a
 local checkout, an .env someone was testing with. This runs over the built
 artifacts rather than the source tree, because the source tree is not what
 gets published.
+
+PyPI also renders the README from distribution metadata, where repository-
+relative Markdown links resolve against the package index instead of the repo.
 """
 
 from __future__ import annotations
@@ -28,6 +31,11 @@ FORBIDDEN = (
     (re.compile(r"\.sqlite3?$"), "local database"),
     (re.compile(r"(^|/)dist/"), "nested distributions"),
 )
+
+MARKDOWN_DESTINATION = re.compile(
+    r"\]\(\s*(?P<destination><[^>\r\n]+>|[^\s)\r\n]+)"
+)
+ABSOLUTE_URI = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 
 # The wheel is the installed package. Tests, examples, and docs belong in the
 # sdist and the repository, not in every user's site-packages.
@@ -80,6 +88,44 @@ def _members(path: pathlib.Path) -> list[str]:
         return [name.split("/", 1)[1] for name in archive.getnames() if "/" in name]
 
 
+def _metadata(path: pathlib.Path) -> tuple[str, str]:
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            names = [
+                name
+                for name in archive.namelist()
+                if re.fullmatch(r"[^/]+\.dist-info/METADATA", name)
+            ]
+            if len(names) != 1:
+                raise ValueError(f"expected one wheel METADATA file, found {len(names)}")
+            name = names[0]
+            return name, archive.read(name).decode("utf-8")
+
+    with tarfile.open(path) as archive:
+        members = [
+            member
+            for member in archive.getmembers()
+            if member.isfile()
+            and re.fullmatch(r"[^/]+/PKG-INFO", member.name)
+        ]
+        if len(members) != 1:
+            raise ValueError(f"expected one sdist PKG-INFO file, found {len(members)}")
+        member = members[0]
+        extracted = archive.extractfile(member)
+        if extracted is None:
+            raise ValueError(f"could not read {member.name}")
+        return member.name, extracted.read().decode("utf-8")
+
+
+def _relative_markdown_destinations(text: str) -> set[str]:
+    destinations: set[str] = set()
+    for match in MARKDOWN_DESTINATION.finditer(text):
+        destination = match.group("destination").strip("<>")
+        if not destination.startswith("#") and ABSOLUTE_URI.match(destination) is None:
+            destinations.add(destination)
+    return destinations
+
+
 def main() -> int:
     dist = pathlib.Path("dist")
     artifacts = sorted(dist.glob("*.whl")) + sorted(dist.glob("*.tar.gz"))
@@ -121,6 +167,17 @@ def main() -> int:
             if count != 1:
                 failures.append(
                     f"{artifact.name}: expected exactly one packaged {filename}, found {count}"
+                )
+
+        try:
+            metadata_name, metadata = _metadata(artifact)
+        except (OSError, UnicodeDecodeError, ValueError) as error:
+            failures.append(f"{artifact.name}: invalid distribution metadata ({error})")
+        else:
+            for destination in sorted(_relative_markdown_destinations(metadata)):
+                failures.append(
+                    f"{artifact.name}: {metadata_name}: relative Markdown destination "
+                    f"{destination!r}"
                 )
 
     if failures:

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -92,7 +92,7 @@ def _members(path: pathlib.Path) -> list[str]:
         with zipfile.ZipFile(path) as archive:
             return archive.namelist()
     with tarfile.open(path) as archive:
-        # Strip the leading "agentcheck-0.1.0/" component an sdist always has.
+        # Strip the generated top-level distribution-and-version directory.
         return [name.split("/", 1)[1] for name in archive.getnames() if "/" in name]
 
 

--- a/tests/agentcheck/test_cli_diagnostics.py
+++ b/tests/agentcheck/test_cli_diagnostics.py
@@ -21,6 +21,7 @@ from agentcheck.evaluate import infrastructure_evaluation
 from agentcheck.errors import ConfigurationError
 from agentcheck.generate import build_account_support_suite
 from agentcheck.initialize import write_initial_config
+from scripts.check_distribution import _long_description_link_violations
 
 
 def _empty_behavioral_coverage() -> BehavioralCoverage:
@@ -500,6 +501,29 @@ def test_public_safety_docs_keep_the_declared_tool_boundary_narrow() -> None:
     assert "Network denial is not a general operating-system sandbox" in custom
 
 
+def test_distribution_readme_link_policy_is_conservative() -> None:
+    markdown = """
+[absolute](https://example.com/guide) [fragment](#guide)
+![image](https://example.com/image.png)
+[relative](docs/guide.md)
+[reference]: https://example.com/reference
+<a href="docs/raw-html.md">relative HTML</a>
+<img src=images/raw-html.png>
+"""
+    reference_error = (
+        "reference-style Markdown definitions are not allowed; use inline absolute links"
+    )
+
+    assert _long_description_link_violations(markdown) == [
+        reference_error,
+        "relative HTML destination 'docs/raw-html.md'",
+        "relative HTML destination 'images/raw-html.png'",
+        "relative Markdown destination 'docs/guide.md'",
+    ]
+    for reference in (r"[foo\]bar]: docs/guide.md", "> [guide]: docs/guide.md"):
+        assert _long_description_link_violations(reference) == [reference_error]
+
+
 def test_allowed_public_alpha_polish_does_not_drift() -> None:
     root = Path(__file__).parents[2]
     readme = (root / "README.md").read_text(encoding="utf-8")
@@ -512,6 +536,11 @@ def test_allowed_public_alpha_polish_does_not_drift() -> None:
     assert "python -m pytest tests -q -n 2" in readme
     assert "964 tests" not in ci_docs
     assert "381 of 964" not in ci_docs
+    link_violations = _long_description_link_violations(readme)
+    assert not link_violations, (
+        "README links are copied into distribution metadata: "
+        f"{link_violations}"
+    )
     assert "integration shape, not a finished agent policy" in " ".join(custom.split())
     assert "first generated evaluation can contain behavioral `FAIL`" in custom
     assert "not a CLI demonstration of the three planted handoff defects" in " ".join(handoff.split())


### PR DESCRIPTION
## What and why

PyPI renders the repository README from wheel/sdist metadata, where the 31
repository-relative link occurrences had no repository context. Security,
integration, example, CI, license, and contributor links therefore did not
reach their AgentCheck source targets from the published package page.

This change converts those destinations to canonical GitHub `blob/main` URLs
and extends the existing distribution audit to inspect wheel `METADATA` and
sdist `PKG-INFO`. The deliberately small authoring policy permits inline
absolute/same-page destinations and rejects relative Markdown/HTML and
reference-style definitions, including escaped-label and blockquote forms.

## Safety and compatibility

- [x] Original declared tool handlers still never execute during simulated evaluation.
- [x] Unknown tools still fail closed; no plausible result is synthesized.
- [x] Worker isolation, network denial, source integrity, and verdict semantics are unchanged or explicitly reviewed.
- [x] No safety or wall-clock budget was widened.
- [x] Fingerprint, schema, protocol, and stored-artifact compatibility impact is stated.
- [x] Replay is not described as deterministic provider-output replay.

Compatibility impact: documentation and packaging validation only. Runtime,
serialized contracts, fingerprints, provider behavior, and replay are
unchanged.

## Validation

- `python -m pytest tests/agentcheck/test_cli_diagnostics.py -q` — 21 passed
- `python -m ruff check scripts/check_distribution.py tests/agentcheck/test_cli_diagnostics.py` — passed
- `python -m mypy scripts/check_distribution.py` — passed
- fresh no-index wheel/sdist build plus `python scripts/check_distribution.py` — 2 artifacts passed
- `twine check --strict dist/*` — wheel and sdist passed
- secret scan, `py_compile`, `git diff --check`, and `git show --check` — passed
- Independent final-diff review: no findings
- Provider requests: 0
- API spend: $0
