### PR TITLE
fix: narrow worker request transport

### DIFF
--- a/agentcheck/runner/orchestrator.py
+++ b/agentcheck/runner/orchestrator.py
@@ -16,7 +16,7 @@ import tempfile
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Any, Generic, TypeVar, cast
+from typing import IO, Any, Generic, Literal, TypeVar, cast
 
 from pydantic import ValidationError
 
@@ -40,9 +40,15 @@ from agentcheck.domain import (
 from agentcheck.errors import ConfigurationError
 from agentcheck.privacy import redact_log_text
 
+from .worker_protocol import (
+    WORKER_REQUEST_VERSION,
+    WORKER_RESPONSE_VERSION,
+    WorkerExecutionInput,
+    WorkerRequest,
+    WorkerRuntimeConfig,
+)
 
-WORKER_REQUEST_VERSION = "agentcheck.worker_request.v1"
-WORKER_RESPONSE_VERSION = "agentcheck.worker_response.v1"
+
 _MAX_DIAGNOSTIC_BYTES = 16 * 1024
 _PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 
@@ -249,7 +255,7 @@ def _worker_command(root: Path, config: AgentCheckConfig) -> list[str]:
 
 def _worker_environment(config: AgentCheckConfig) -> dict[str, str]:
     environment = child_environment(config)
-    # Never inherit PYTHONPATH from the caller.  This controlled path only makes
+    # Never inherit PYTHONPATH from the caller. This controlled path only makes
     # the AgentCheck package importable when running directly from a checkout.
     environment["PYTHONPATH"] = str(_PACKAGE_ROOT)
     return environment
@@ -329,11 +335,38 @@ def _failed_result(
     )
 
 
+def _worker_request(
+    *,
+    root: Path,
+    config: AgentCheckConfig,
+    operation: Literal["inspect", "run"],
+    scenario: Scenario | None,
+    run_id: str | None,
+) -> WorkerRequest:
+    """Build the strict worker request without serializing evaluator-only data."""
+
+    execution_input: WorkerExecutionInput | None = None
+    if operation == "run":
+        if scenario is None or run_id is None:
+            raise ValueError("run worker requests require a scenario and run_id")
+        execution_input = WorkerExecutionInput.from_scenario(scenario, run_id=run_id)
+    elif scenario is not None or run_id is not None:
+        raise ValueError(
+            "inspect worker requests cannot include scenario execution data"
+        )
+    return WorkerRequest(
+        operation=operation,
+        root=str(root),
+        runtime_config=WorkerRuntimeConfig.from_config(config),
+        execution_input=execution_input,
+    )
+
+
 def _execute_worker(
     *,
     root: Path,
     config: AgentCheckConfig,
-    operation: str,
+    operation: Literal["inspect", "run"],
     timeout_seconds: float,
     scenario: Scenario | None = None,
     run_id: str | None = None,
@@ -347,23 +380,20 @@ def _execute_worker(
     # Validate the containment boundary before starting trusted target code.
     resolve_entrypoint(root, config.entrypoint)
 
-    request: dict[str, Any] = {
-        "contract_version": WORKER_REQUEST_VERSION,
-        "operation": operation,
-        "root": str(root),
-        "config": config.model_dump(mode="json"),
-    }
-    if scenario is not None:
-        request["scenario"] = scenario.model_dump(mode="json")
-    if run_id is not None:
-        request["run_id"] = run_id
+    request = _worker_request(
+        root=root,
+        config=config,
+        operation=operation,
+        scenario=scenario,
+        run_id=run_id,
+    )
 
     with tempfile.TemporaryDirectory(prefix="agentcheck-worker-") as raw_directory:
         directory = Path(raw_directory)
         directory.chmod(0o700)
         request_path = directory / "request.json"
         response_path = directory / "response.json"
-        _write_private_json(request_path, request)
+        _write_private_json(request_path, request.model_dump(mode="json"))
         _write_private_json(
             response_path,
             {
@@ -611,9 +641,9 @@ def _execute_worker(
                     "expected": run_id,
                     "observed": value.run_id,
                 }
-            if scenario is None or value.scenario_id != scenario.scenario_id:
+            if value.scenario_id != run_id:
                 mismatches["scenario_id"] = {
-                    "expected": scenario.scenario_id if scenario is not None else None,
+                    "expected": run_id,
                     "observed": value.scenario_id,
                 }
             if expected_target_id is not None and value.target_id != expected_target_id:
@@ -635,6 +665,20 @@ def _execute_worker(
                     timed_out=False,
                     worker_pid=worker_pid,
                 )
+            if scenario is None:  # pragma: no cover - parent request invariant
+                return _failed_result(
+                    _infrastructure_error(
+                        code="worker_result_identity_mismatch",
+                        message="Canonical run had no parent scenario identity.",
+                        phase="worker_response",
+                    ),
+                    stdout=stdout,
+                    stderr=stderr,
+                    returncode=returncode,
+                    timed_out=False,
+                    worker_pid=worker_pid,
+                )
+            value = value.model_copy(update={"scenario_id": scenario.scenario_id})
 
         return ProcessResult(
             value=value,

--- a/agentcheck/runner/worker.py
+++ b/agentcheck/runner/worker.py
@@ -20,15 +20,10 @@ from agentcheck.adapters import (
     UnsupportedTargetError,
     encode_preflight_report,
 )
-from agentcheck.config import (
-    AgentCheckConfig,
-    portable_entrypoint,
-    resolve_entrypoint,
-)
+from agentcheck.config import portable_entrypoint, resolve_entrypoint
 from agentcheck.domain import (
     FaultType,
     InfrastructureError,
-    Scenario,
     SimulatedToolOutcome,
     SimulatedToolStatus,
     ToolFixture,
@@ -38,8 +33,13 @@ from agentcheck.mcp_manifest import load_mcp_manifest
 from agentcheck.privacy import redact_log_text
 
 from .network_guard import install_network_guard
-from .orchestrator import WORKER_REQUEST_VERSION, WORKER_RESPONSE_VERSION
 from .tool_gateway import ToolGateway
+from .worker_protocol import (
+    WORKER_RESPONSE_VERSION,
+    WorkerExecutionInput,
+    WorkerRequest,
+    WorkerRuntimeConfig,
+)
 from .world import WorldSimulator
 
 
@@ -151,16 +151,20 @@ def _safe_error(exc: BaseException, *, phase: str) -> InfrastructureError:
     )
 
 
-def _read_request(path: Path) -> dict[str, Any]:
+def _read_request(path: Path) -> WorkerRequest:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        payload = path.read_text(encoding="utf-8")
+        raw = json.loads(payload)
     except (OSError, json.JSONDecodeError, UnicodeError) as exc:
         raise ValueError("worker request must be valid UTF-8 JSON") from exc
     if not isinstance(raw, dict):
         raise ValueError("worker request must be a JSON object")
-    if raw.get("contract_version") != WORKER_REQUEST_VERSION:
-        raise ValueError("unsupported worker request contract")
-    return raw
+    try:
+        return WorkerRequest.model_validate_json(payload)
+    except ValidationError as exc:
+        raise ValueError(
+            "worker request does not match the supported contract"
+        ) from exc
 
 
 _ADAPTERS: dict[str, type[FrameworkAdapter]] = {
@@ -170,7 +174,7 @@ _ADAPTERS: dict[str, type[FrameworkAdapter]] = {
 }
 
 
-def _adapter_for(config: AgentCheckConfig) -> FrameworkAdapter:
+def _adapter_for(config: WorkerRuntimeConfig) -> FrameworkAdapter:
     """Resolve the configured adapter.
 
     The only place the framework name is dispatched on. Everything downstream
@@ -183,7 +187,7 @@ def _adapter_for(config: AgentCheckConfig) -> FrameworkAdapter:
     return factory()
 
 
-def _load_agent(root: Path, config: AgentCheckConfig) -> tuple[Any, str]:
+def _load_agent(root: Path, config: WorkerRuntimeConfig) -> tuple[Any, str]:
     if config.adapter not in _ADAPTERS:  # pragma: no cover - config narrows this
         raise ValueError(f"unsupported adapter {config.adapter!r}")
     resolve_entrypoint(root, config.entrypoint)
@@ -193,7 +197,7 @@ def _load_agent(root: Path, config: AgentCheckConfig) -> tuple[Any, str]:
     return load_target(root)
 
 
-def _fault_fixtures(scenario: Scenario) -> tuple[ToolFixture, ...]:
+def _fault_fixtures(execution_input: WorkerExecutionInput) -> tuple[ToolFixture, ...]:
     """Turn explicit injected faults into ordinary controlled gateway fixtures."""
 
     status_by_fault = {
@@ -205,7 +209,7 @@ def _fault_fixtures(scenario: Scenario) -> tuple[ToolFixture, ...]:
         FaultType.STALE_RESPONSE: SimulatedToolStatus.STALE,
     }
     fixtures: list[ToolFixture] = []
-    for fault in scenario.injected_faults:
+    for fault in execution_input.injected_faults:
         is_error = fault.fault_type in {FaultType.ERROR, FaultType.TIMEOUT}
         fixtures.append(
             ToolFixture(
@@ -227,25 +231,28 @@ def _fault_fixtures(scenario: Scenario) -> tuple[ToolFixture, ...]:
     return tuple(fixtures)
 
 
-def _controlled_fixtures(scenario: Scenario) -> tuple[ToolFixture, ...]:
+def _controlled_fixtures(
+    execution_input: WorkerExecutionInput,
+) -> tuple[ToolFixture, ...]:
     """Overlay injected faults on explicit fixtures for the same call slot."""
 
-    faults = _fault_fixtures(scenario)
+    faults = _fault_fixtures(execution_input)
     fault_slots = {
-        (fault.tool_name, fault.invocation_index) for fault in scenario.injected_faults
+        (fault.tool_name, fault.invocation_index)
+        for fault in execution_input.injected_faults
     }
-    if len(fault_slots) != len(scenario.injected_faults):
+    if len(fault_slots) != len(execution_input.injected_faults):
         raise ValueError("multiple injected faults target the same tool invocation")
     baseline = tuple(
         fixture
-        for fixture in scenario.tool_fixtures
+        for fixture in execution_input.tool_fixtures
         if (fixture.tool_name, fixture.invocation_index) not in fault_slots
     )
     return (*baseline, *faults)
 
 
 def _inspect(
-    root: Path, config: AgentCheckConfig
+    root: Path, config: WorkerRuntimeConfig
 ) -> tuple[Any, dict[str, Any], dict[str, Any] | None]:
     target, source = _load_agent(root, config)
     adapter = _adapter_for(config)
@@ -264,7 +271,11 @@ def _inspect(
     return spec, preflight, topology
 
 
-def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) -> Any:
+def _run(
+    root: Path,
+    config: WorkerRuntimeConfig,
+    execution_input: WorkerExecutionInput,
+) -> Any:
     target, source = _load_agent(root, config)
     adapter = _adapter_for(config)
     mcp_manifest = load_mcp_manifest(root)
@@ -276,13 +287,13 @@ def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) 
         mcp_manifest=mcp_manifest,
     )
     tools = tuple(item.value for item in spec.tools.items)
-    world = WorldSimulator(scenario.initial_world_state)
+    world = WorldSimulator(execution_input.initial_world_state)
     gateway = ToolGateway(
         tools,
-        _controlled_fixtures(scenario),
+        _controlled_fixtures(execution_input),
         world=world,
-        budgets=scenario.resource_budgets,
-        run_id=run_id,
+        budgets=execution_input.resource_budgets,
+        run_id=execution_input.run_id,
     )
     prepared = adapter.prepare(
         target,
@@ -297,11 +308,14 @@ def _run(root: Path, config: AgentCheckConfig, scenario: Scenario, run_id: str) 
     return asyncio.run(
         adapter.run(
             prepared,
-            scenario.conversation_turns,
-            followup_turns=scenario.followup_turns,
-            run_id=run_id,
-            max_turns=scenario.resource_budgets.max_model_turns,
-            scenario_id=scenario.scenario_id,
+            execution_input.conversation_turns,
+            followup_turns=execution_input.followup_turns,
+            run_id=execution_input.run_id,
+            max_turns=execution_input.resource_budgets.max_model_turns,
+            # The real Scenario ID can directly encode the evaluator's intent.
+            # Use the transport run identity inside the child; the parent
+            # validates and rebinds it only after accepting the CanonicalRun.
+            scenario_id=execution_input.run_id,
             target_id=spec.spec_id,
         )
     )
@@ -314,17 +328,17 @@ def execute_request(request_path: Path, response_path: Path) -> int:
     operation: str | None = None
     try:
         request = _read_request(request_path)
-        operation_value = request.get("operation")
-        if operation_value not in {"inspect", "run"}:
-            raise ValueError("worker operation must be 'inspect' or 'run'")
-        operation = operation_value
-        root_value = request.get("root")
-        if not isinstance(root_value, str) or not root_value:
-            raise ValueError("worker request requires a target root")
-        root = Path(root_value).expanduser().resolve()
+        operation = request.operation
+        root = Path(request.root).expanduser().resolve()
         if not root.is_dir():
             raise ValueError("worker target root must be an existing directory")
-        config = AgentCheckConfig.model_validate(request.get("config"))
+        config = request.runtime_config
+        try:
+            request_path.unlink()
+        except OSError as exc:
+            raise ValueError(
+                "worker request could not be hidden before target import"
+            ) from exc
         # Deny egress before any target module is imported, so import-time
         # network calls are contained too, not only calls made during a run.
         install_network_guard(
@@ -347,23 +361,15 @@ def execute_request(request_path: Path, response_path: Path) -> int:
                 result, preflight, topology = _inspect(root, config)
             else:
                 phase = "scenario"
-                scenario = Scenario.model_validate_json(
-                    json.dumps(
-                        request.get("scenario"),
-                        ensure_ascii=False,
-                        allow_nan=False,
-                        sort_keys=True,
-                    )
-                )
-                run_id = request.get("run_id")
-                if not isinstance(run_id, str) or not run_id or len(run_id) > 200:
-                    raise ValueError("run operation requires a valid run_id")
+                execution_input = request.execution_input
+                if execution_input is None:  # pragma: no cover - contract validator
+                    raise ValueError("run operation requires execution_input")
                 phase = "run"
                 _write_private_json(
                     response_path,
                     _response(status="running", phase=phase, operation=operation),
                 )
-                result = _run(root, config, scenario, run_id)
+                result = _run(root, config, execution_input)
 
             _write_private_json(
                 response_path,
@@ -410,6 +416,9 @@ def main(argv: list[str] | None = None) -> int:
         arguments = _parser().parse_args(argv)
     except SystemExit as exc:
         return int(exc.code or 2)
+    # The target imports in this process. Remove both private IPC paths from
+    # Python-visible arguments before any target code can inspect them.
+    sys.argv[:] = [sys.argv[0] if sys.argv else "agentcheck-worker"]
     return execute_request(arguments.request, arguments.response)
 
 

--- a/agentcheck/runner/worker_protocol.py
+++ b/agentcheck/runner/worker_protocol.py
@@ -1,0 +1,161 @@
+"""Strict parent/worker transport contracts.
+
+The child receives explicit allowlists for runtime configuration and scenario
+execution inputs instead of the parent evaluator's complete objects. This
+prevents new parent-side fields from silently crossing the request boundary;
+it is not a claim that same-process target code or target-root files are
+isolated from a hostile target.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from agentcheck.config import AgentCheckConfig, ToolRiskDeclaration
+from agentcheck.domain.base import ContractModel, JsonObject
+from agentcheck.domain.scenario import (
+    MAX_FOLLOWUP_TURNS,
+    ConversationRole,
+    ConversationTurn,
+    InjectedFault,
+    ResourceBudgets,
+    Scenario,
+    ToolFixture,
+)
+
+
+WORKER_REQUEST_VERSION: Literal["agentcheck.worker_request.v2"] = (
+    "agentcheck.worker_request.v2"
+)
+WORKER_EXECUTION_INPUT_VERSION: Literal["agentcheck.worker_execution_input.v1"] = (
+    "agentcheck.worker_execution_input.v1"
+)
+WORKER_RUNTIME_CONFIG_VERSION: Literal["agentcheck.worker_runtime_config.v1"] = (
+    "agentcheck.worker_runtime_config.v1"
+)
+WORKER_RESPONSE_VERSION: Literal["agentcheck.worker_response.v1"] = (
+    "agentcheck.worker_response.v1"
+)
+
+
+class WorkerExecutionInput(ContractModel):
+    """Only scenario material required to execute one child-process run."""
+
+    contract_version: Literal["agentcheck.worker_execution_input.v1"] = (
+        WORKER_EXECUTION_INPUT_VERSION
+    )
+    run_id: str = Field(min_length=1, max_length=200)
+    conversation_turns: tuple[ConversationTurn, ...] = Field(min_length=1)
+    followup_turns: tuple[ConversationTurn, ...] = Field(
+        default=(), max_length=MAX_FOLLOWUP_TURNS
+    )
+    initial_world_state: JsonObject = Field(default_factory=dict)
+    tool_fixtures: tuple[ToolFixture, ...] = ()
+    injected_faults: tuple[InjectedFault, ...] = ()
+    resource_budgets: ResourceBudgets = Field(default_factory=ResourceBudgets)
+
+    @classmethod
+    def from_scenario(
+        cls, scenario: Scenario, *, run_id: str
+    ) -> "WorkerExecutionInput":
+        """Project an evaluated Scenario onto its execution-only allowlist."""
+
+        return cls(
+            run_id=run_id,
+            conversation_turns=scenario.conversation_turns,
+            followup_turns=scenario.followup_turns,
+            initial_world_state=scenario.initial_world_state,
+            tool_fixtures=scenario.tool_fixtures,
+            injected_faults=scenario.injected_faults,
+            resource_budgets=scenario.resource_budgets,
+        )
+
+    @model_validator(mode="after")
+    def validate_turn_sequence(self) -> "WorkerExecutionInput":
+        non_user = sorted(
+            {
+                turn.role.value
+                for turn in self.followup_turns
+                if turn.role != ConversationRole.USER
+            }
+        )
+        if non_user:
+            raise ValueError(
+                "worker follow-up turns must be user turns; found "
+                f"{', '.join(non_user)}"
+            )
+        turn_ids = [
+            turn.turn_id for turn in (*self.conversation_turns, *self.followup_turns)
+        ]
+        if len(turn_ids) != len(set(turn_ids)):
+            raise ValueError(
+                "worker conversation and follow-up turn IDs must be unique"
+            )
+        return self
+
+
+class WorkerRuntimeConfig(ContractModel):
+    """Only configuration fields consumed by the child runtime.
+
+    Selection, generation, suite/replay lookup, artifact, store, provider-
+    realization, concurrency, timeout, environment construction, and Python-
+    executable settings remain parent-side. This explicit projection keeps a
+    future :class:`AgentCheckConfig` field from silently crossing into the
+    target process.
+    """
+
+    contract_version: Literal["agentcheck.worker_runtime_config.v1"] = (
+        WORKER_RUNTIME_CONFIG_VERSION
+    )
+    adapter: Literal["openai_agents", "pydantic_ai", "custom"]
+    entrypoint: str = Field(min_length=1, max_length=16_000)
+    allow_network: bool = False
+    controlled_model: bool = False
+    network_allowlist: tuple[str, ...] = ()
+    tool_risk: dict[str, ToolRiskDeclaration] | None = Field(
+        default=None, max_length=200
+    )
+
+    @classmethod
+    def from_config(cls, config: AgentCheckConfig) -> "WorkerRuntimeConfig":
+        """Project the validated application config onto child-only fields."""
+
+        return cls(
+            adapter=config.adapter,
+            entrypoint=config.entrypoint,
+            allow_network=config.allow_network,
+            controlled_model=config.controlled_model,
+            network_allowlist=config.network_allowlist,
+            tool_risk=config.tool_risk,
+        )
+
+
+class WorkerRequest(ContractModel):
+    """One complete, strict request accepted by the worker entrypoint."""
+
+    contract_version: Literal["agentcheck.worker_request.v2"] = WORKER_REQUEST_VERSION
+    operation: Literal["inspect", "run"]
+    root: str = Field(min_length=1, max_length=16_000)
+    runtime_config: WorkerRuntimeConfig
+    execution_input: WorkerExecutionInput | None = None
+
+    @model_validator(mode="after")
+    def validate_operation_input(self) -> "WorkerRequest":
+        if self.operation == "run" and self.execution_input is None:
+            raise ValueError("run worker requests require execution_input")
+        if self.operation == "inspect" and self.execution_input is not None:
+            raise ValueError("inspect worker requests cannot include execution_input")
+        return self
+
+
+__all__ = [
+    "WORKER_EXECUTION_INPUT_VERSION",
+    "WORKER_REQUEST_VERSION",
+    "WORKER_RUNTIME_CONFIG_VERSION",
+    "WORKER_RESPONSE_VERSION",
+    "WorkerExecutionInput",
+    "WorkerRequest",
+    "WorkerRuntimeConfig",
+]

--- a/tests/agentcheck/test_custom_agent_adapter.py
+++ b/tests/agentcheck/test_custom_agent_adapter.py
@@ -1463,10 +1463,15 @@ def _scenario(*, followups: Sequence[ConversationTurn] = ()) -> Scenario:
 
 def test_the_worker_selects_the_custom_adapter_from_config() -> None:
     from agentcheck.runner import worker
+    from agentcheck.runner.worker_protocol import WorkerRuntimeConfig
 
     assert worker._ADAPTERS["custom"] is CustomAgentAdapter
     assert (
-        type(worker._adapter_for(AgentCheckConfig(adapter="custom")))
+        type(
+            worker._adapter_for(
+                WorkerRuntimeConfig.from_config(AgentCheckConfig(adapter="custom"))
+            )
+        )
         is CustomAgentAdapter
     )
 
@@ -1673,7 +1678,7 @@ def test_the_shared_contracts_were_not_reshaped_to_fit_a_custom_agent() -> None:
     assert SCENARIO_CONTRACT_VERSION == "agentcheck.scenario.v1"
     assert CANONICAL_RUN_CONTRACT_VERSION == "agentcheck.canonical_run.v1"
     assert CANONICAL_EVENT_CONTRACT_VERSION == "agentcheck.canonical_event.v1"
-    assert WORKER_REQUEST_VERSION == "agentcheck.worker_request.v1"
+    assert WORKER_REQUEST_VERSION == "agentcheck.worker_request.v2"
     assert WORKER_RESPONSE_VERSION == "agentcheck.worker_response.v1"
 
     assert set(ToolDefinition.model_fields) == {

--- a/tests/agentcheck/test_worker_oracle_separation.py
+++ b/tests/agentcheck/test_worker_oracle_separation.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agentcheck.config import AgentCheckConfig, LlmRealizationConfig
+from agentcheck.domain import (
+    ConversationRole,
+    ConversationTurn,
+    OracleProvenance,
+    OracleStrength,
+    OutputCriterion,
+    OutputCriterionKind,
+    PostconditionOperator,
+    Scenario,
+    StatePostcondition,
+    ToolBehaviorConstraint,
+    TrajectoryConstraint,
+    TrajectoryConstraintKind,
+)
+from agentcheck.generate import build_account_support_suite
+from agentcheck.runner import run_scenario_in_subprocess
+from agentcheck.runner import orchestrator
+from agentcheck.runner.worker_protocol import (
+    WORKER_EXECUTION_INPUT_VERSION,
+    WORKER_REQUEST_VERSION,
+    WORKER_RUNTIME_CONFIG_VERSION,
+    WorkerExecutionInput,
+    WorkerRequest,
+    WorkerRuntimeConfig,
+)
+
+
+def _oracle_only_scenario(sentinel: str) -> Scenario:
+    oracle_id = "oracle-only"
+    return Scenario(
+        scenario_id=f"worker-oracle-separation-{sentinel}",
+        title=f"Evaluator title {sentinel}",
+        description=f"Evaluator description {sentinel}",
+        conversation_turns=(
+            ConversationTurn(
+                turn_id="turn-1",
+                role=ConversationRole.USER,
+                content="Return a short acknowledgement.",
+            ),
+        ),
+        expected_postconditions=(
+            StatePostcondition(
+                criterion_id="oracle-postcondition",
+                path="oracle.only",
+                operator=PostconditionOperator.EQUALS,
+                expected=sentinel,
+                oracle_ids=(oracle_id,),
+            ),
+        ),
+        required_tool_behavior=(
+            ToolBehaviorConstraint(
+                criterion_id="oracle-required-tool",
+                tool_name=f"required-{sentinel}",
+                min_calls=1,
+                max_calls=1,
+                oracle_ids=(oracle_id,),
+            ),
+        ),
+        allowed_tool_behavior=(
+            ToolBehaviorConstraint(
+                criterion_id="oracle-allowed-tool",
+                tool_name=f"allowed-{sentinel}",
+                max_calls=1,
+                oracle_ids=(oracle_id,),
+            ),
+        ),
+        forbidden_tool_behavior=(
+            ToolBehaviorConstraint(
+                criterion_id="oracle-forbidden-tool",
+                tool_name=f"forbidden-{sentinel}",
+                min_calls=0,
+                max_calls=0,
+                oracle_ids=(oracle_id,),
+            ),
+        ),
+        trajectory_constraints=(
+            TrajectoryConstraint(
+                criterion_id="oracle-trajectory",
+                kind=TrajectoryConstraintKind.OTHER,
+                description=f"Evaluator trajectory {sentinel}",
+                parameters={"oracle_sentinel": sentinel},
+                oracle_ids=(oracle_id,),
+            ),
+        ),
+        output_criteria=(
+            OutputCriterion(
+                criterion_id="oracle-output",
+                kind=OutputCriterionKind.OTHER,
+                description=f"Evaluator output {sentinel}",
+                parameters={"oracle_sentinel": sentinel},
+                oracle_ids=(oracle_id,),
+            ),
+        ),
+        dimension_tags=(f"oracle:{sentinel}",),
+        oracle_provenance=(
+            OracleProvenance(
+                oracle_id=oracle_id,
+                strength=OracleStrength.EXPLICIT_INSTRUCTION,
+                source=f"evaluator:{sentinel}",
+                confidence=1.0,
+                evidence_ids=(f"evidence:{sentinel}",),
+            ),
+        ),
+        generation_seed=7,
+    )
+
+
+def _oracle_bearing_config(sentinel: str) -> AgentCheckConfig:
+    return AgentCheckConfig(
+        adapter="custom",
+        entrypoint="agent.py:agent",
+        seed=8_675_309,
+        max_concurrency=7,
+        environment_allowlist=(f"{sentinel}_ENV",),
+        scenario_wall_clock_seconds=41.5,
+        include_instructions_in_report=True,
+        artifacts_directory=f"artifacts-{sentinel}",
+        suite_path=f"frozen-{sentinel}.json",
+        policy_packs=(f"policies/{sentinel}.json",),
+        store_path=f"stores/{sentinel}.sqlite",
+        max_cases=13,
+        llm_realization=LlmRealizationConfig(enabled=True, model=sentinel),
+    )
+
+
+def test_run_request_has_only_runtime_and_scenario_execution_fields(
+    tmp_path: Path,
+) -> None:
+    scenario_sentinel = "ORACLE_ONLY_SENTINEL_7F86A2"
+    config_sentinel = "PARENT_CONFIG_SENTINEL_91C43D"
+    scenario = _oracle_only_scenario(scenario_sentinel)
+    config = _oracle_bearing_config(config_sentinel)
+
+    request = orchestrator._worker_request(
+        root=tmp_path,
+        config=config,
+        operation="run",
+        scenario=scenario,
+        run_id="worker-oracle-run",
+    )
+    payload = request.model_dump(mode="json")
+
+    assert set(payload) == {
+        "contract_version",
+        "operation",
+        "root",
+        "runtime_config",
+        "execution_input",
+    }
+    assert payload["contract_version"] == WORKER_REQUEST_VERSION
+    runtime = payload["runtime_config"]
+    assert isinstance(runtime, dict)
+    assert set(runtime) == {
+        "contract_version",
+        "adapter",
+        "entrypoint",
+        "allow_network",
+        "controlled_model",
+        "network_allowlist",
+        "tool_risk",
+    }
+    assert runtime["contract_version"] == WORKER_RUNTIME_CONFIG_VERSION
+    assert runtime["adapter"] == "custom"
+    assert runtime["entrypoint"] == "agent.py:agent"
+    execution = payload["execution_input"]
+    assert isinstance(execution, dict)
+    assert set(execution) == {
+        "contract_version",
+        "run_id",
+        "conversation_turns",
+        "followup_turns",
+        "initial_world_state",
+        "tool_fixtures",
+        "injected_faults",
+        "resource_budgets",
+    }
+    assert execution["contract_version"] == WORKER_EXECUTION_INPUT_VERSION
+    assert execution["run_id"] == "worker-oracle-run"
+    serialized = json.dumps(payload, sort_keys=True)
+    assert scenario_sentinel not in serialized
+    assert config_sentinel not in serialized
+    assert "8675309" not in serialized
+    parent_only_config_fields = {
+        "schema_version",
+        "suite",
+        "seed",
+        "max_concurrency",
+        "environment_allowlist",
+        "scenario_wall_clock_seconds",
+        "include_instructions_in_report",
+        "artifacts_directory",
+        "suite_path",
+        "policy_packs",
+        "store_path",
+        "max_cases",
+        "llm_realization",
+        "python_executable",
+    }
+    assert parent_only_config_fields.isdisjoint(runtime)
+
+
+def test_worker_execution_contract_rejects_oracle_fields_and_legacy_request() -> None:
+    scenario = _oracle_only_scenario("ORACLE_ONLY_SENTINEL_7f86a2")
+    execution = WorkerExecutionInput.from_scenario(
+        scenario, run_id="worker-oracle-run"
+    ).model_dump(mode="json")
+    execution["expected_postconditions"] = []
+
+    with pytest.raises(ValidationError, match="expected_postconditions"):
+        WorkerExecutionInput.model_validate_json(json.dumps(execution))
+
+    runtime = WorkerRuntimeConfig.from_config(AgentCheckConfig()).model_dump(
+        mode="json"
+    )
+    runtime["suite_path"] = "answer-key.json"
+    with pytest.raises(ValidationError, match="suite_path"):
+        WorkerRuntimeConfig.model_validate_json(json.dumps(runtime))
+
+    legacy = {
+        "contract_version": "agentcheck.worker_request.v1",
+        "operation": "run",
+        "root": "/target",
+        "config": AgentCheckConfig().model_dump(mode="json"),
+        "scenario": scenario.model_dump(mode="json"),
+        "run_id": "worker-oracle-run",
+    }
+    with pytest.raises(ValidationError):
+        WorkerRequest.model_validate_json(json.dumps(legacy))
+
+
+def test_execution_inputs_remain_matchable_to_importable_builtin_generator() -> None:
+    """Record why request projection alone is not answer-key isolation."""
+
+    suite = build_account_support_suite(seed=1729)
+    scenario = suite[4]
+    execution = WorkerExecutionInput.from_scenario(
+        scenario, run_id="suite-run-case-4"
+    )
+    signature = execution.model_dump(
+        mode="json", exclude={"contract_version", "run_id"}
+    )
+
+    matches = [
+        candidate
+        for candidate in suite
+        if WorkerExecutionInput.from_scenario(
+            candidate, run_id="candidate"
+        ).model_dump(mode="json", exclude={"contract_version", "run_id"})
+        == signature
+    ]
+
+    assert execution.run_id.endswith("-case-4")
+    assert [candidate.scenario_id for candidate in matches] == [
+        scenario.scenario_id
+    ]
+    assert matches[0].expected_postconditions == scenario.expected_postconditions
+    assert matches[0].oracle_provenance == scenario.oracle_provenance
+
+
+def test_ordinary_target_import_sees_no_request_file_or_parent_sentinel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sentinel = "ORACLE_ONLY_SENTINEL_7F86A2"
+    worker_temp = tmp_path / "worker-temp"
+    worker_temp.mkdir()
+    monkeypatch.setattr(orchestrator.tempfile, "tempdir", str(worker_temp))
+
+    observed_path = tmp_path / "observed.json"
+    (tmp_path / "agent.py").write_text(
+        f"""
+import json
+import sys
+from pathlib import Path
+
+from agentcheck import TurnResult
+
+OBSERVED = Path({str(observed_path)!r})
+WORKER_TEMP = Path({str(worker_temp)!r})
+
+
+def observe(stage):
+    request_paths = sorted(WORKER_TEMP.glob("agentcheck-worker-*/request.json"))
+    request_text = []
+    for path in request_paths:
+        try:
+            request_text.append(path.read_text(encoding="utf-8"))
+        except OSError:
+            request_text.append("<unreadable>")
+    existing = json.loads(OBSERVED.read_text(encoding="utf-8")) if OBSERVED.exists() else []
+    existing.append({{
+        "stage": stage,
+        "argv": list(sys.argv),
+        "request_paths": [str(path) for path in request_paths],
+        "request_text": request_text,
+    }})
+    OBSERVED.write_text(json.dumps(existing), encoding="utf-8")
+
+
+observe("import")
+
+
+class ProbeAgent:
+    name = "worker-oracle-probe"
+    instructions = "Return an acknowledgement."
+    tools = ()
+
+    def start(self, message, tools):
+        observe("start")
+        return TurnResult(output="ack", state={{}})
+
+    def resume(self, state, message, tools):
+        return TurnResult(output="ack", state=state)
+
+
+agent = ProbeAgent()
+""".lstrip(),
+        encoding="utf-8",
+    )
+    config = _oracle_bearing_config(sentinel)
+    scenario = _oracle_only_scenario(sentinel)
+
+    result = run_scenario_in_subprocess(
+        tmp_path,
+        config,
+        scenario,
+        "worker-oracle-run",
+    )
+
+    run = result.require_value()
+    assert run.run_id == "worker-oracle-run"
+    assert run.scenario_id == scenario.scenario_id
+    observed = json.loads(observed_path.read_text(encoding="utf-8"))
+    assert [item["stage"] for item in observed] == ["import", "start"]
+    assert all(item["argv"] == ["-c"] for item in observed)
+    assert all(item["request_paths"] == [] for item in observed)
+    assert sentinel not in json.dumps(observed)

--- a/tests/agentcheck/test_worker_process.py
+++ b/tests/agentcheck/test_worker_process.py
@@ -28,6 +28,7 @@ from agentcheck.runner.orchestrator import (
 )
 from agentcheck.runner import orchestrator
 from agentcheck.runner.worker import execute_request
+from agentcheck.runner.worker_protocol import WorkerRuntimeConfig
 
 
 EXAMPLE = Path(__file__).parents[2] / "examples" / "evaluation" / "account_agent"
@@ -195,7 +196,9 @@ def test_inspect_worker_response_includes_preflight_report(tmp_path: Path) -> No
             "contract_version": WORKER_REQUEST_VERSION,
             "operation": "inspect",
             "root": str(root),
-            "config": config.model_dump(mode="json"),
+            "runtime_config": WorkerRuntimeConfig.from_config(config).model_dump(
+                mode="json"
+            ),
         },
     )
 
@@ -484,7 +487,9 @@ def test_valid_canonical_adapter_error_is_preserved_for_evaluation(
     now = utc_now()
     canonical_error = CanonicalRun(
         run_id="adapter-error-run",
-        scenario_id=scenario.scenario_id,
+        # The child uses the run ID as its transport-only case identity;
+        # the parent validates it before restoring the real Scenario ID.
+        scenario_id="adapter-error-run",
         target_id="target",
         started_at=now,
         ended_at=now,
@@ -537,6 +542,7 @@ def test_valid_canonical_adapter_error_is_preserved_for_evaluation(
     run = result.require_value()
     assert run.termination == RunTermination.ADAPTER_ERROR
     assert run.termination_reason == "Controlled adapter failure."
+    assert run.scenario_id == scenario.scenario_id
     assert result.infrastructure_error is None
 
 
@@ -724,7 +730,9 @@ def test_in_process_execute_request_restores_cwd(tmp_path: Path) -> None:
             "contract_version": WORKER_REQUEST_VERSION,
             "operation": "inspect",
             "root": str(root),
-            "config": config.model_dump(mode="json"),
+            "runtime_config": WorkerRuntimeConfig.from_config(config).model_dump(
+                mode="json"
+            ),
         },
     )
 


### PR DESCRIPTION
## Scope

- Introduce a versioned, extra-forbid WorkerRuntimeConfig projection instead of transporting the full AgentCheckConfig into the worker.
- Keep run requests on an explicit execution-only projection instead of the full Scenario, and use the run identity inside the child before parent-side Scenario ID rebinding.
- Remove the request file and Python-visible request/response argv before ordinary target import.
- Add decisive positive sentinels for excluded Scenario/config fields and a negative regression that proves deterministic built-in cases remain reconstructible.

## Security boundary

This closes direct full-Scenario and full-config request transport only. It does not prove answer-key isolation and does not close AC-P0-6.

A target can still match execution inputs and ordinal-bearing run IDs to the importable deterministic generator. Frozen/replay/prior artifact and policy/scenario files under the target-visible filesystem remain another answer-key channel. Same-interpreter startup hooks and ancestor-frame visibility also remain outside this mitigation. AC-P0-6 therefore stays BLOCKED pending a runtime/filesystem projection or containment design.

Do not merge until an independent Evidence/Security reviewer inspects this exact pushed head.

## Validation

- Worker oracle separation + worker process: 26 passed
- Custom adapter: 68 passed
- Interactive scenarios: 31 passed
- Tool-risk authority + package boundary: 121 passed
- Network containment/allowlist/scoped-provider slice: 25 passed (sandbox socket restriction required an unrestricted local rerun; no provider was contacted)
- Ruff on all six changed paths: passed
- Mypy on three source paths plus worker-process/oracle tests: passed
- Source distribution and wheel build: passed; both include worker_protocol.py; distribution audit passed
- High-signal secret scan and git diff --check: passed

One selected PydanticAI subprocess test exceeded a 30-second local diagnostic timeout on both this branch and an untouched archive of base b4819ba; two adjacent selected tests passed. This is recorded as a baseline/environment limitation, not evidence against the protocol change.