### PR TITLE
Certify source snapshots across execution phases

### DIFF
--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -527,9 +527,18 @@ def replay_suite(
     # Untrusted manifest is parsed before the target is imported.
     manifest = load_replay_manifest(root, manifest_path)
     suite_run_id = run_id or new_run_id()
-    verify_replay_source_bindings(manifest, root=root, config=config)
+    source_snapshot = verify_replay_source_bindings(
+        manifest,
+        root=root,
+        config=config,
+    )
     _warn_legacy_source_binding(manifest)
-    source_snapshot = capture_source_snapshot(root, config)
+    verify_source_snapshot(
+        source_snapshot,
+        root=root,
+        config=config,
+        phase="before replay target inspection",
+    )
     revision = source_snapshot.git_revision
     inspection = inspect_in_subprocess(root, config)
     packs = resolve_policy_packs(root, config, spec=inspection.require_value())
@@ -615,14 +624,30 @@ def shrink_suite(
             "refusing to overwrite the source replay manifest; pass a different --run-id"
         )
 
-    verify_replay_source_bindings(source_manifest, root=root, config=config)
+    source_snapshot = verify_replay_source_bindings(
+        source_manifest,
+        root=root,
+        config=config,
+    )
     _warn_legacy_source_binding(source_manifest)
+    verify_source_snapshot(
+        source_snapshot,
+        root=root,
+        config=config,
+        phase="before shrink target inspection",
+    )
     inspection = inspect_in_subprocess(root, config)
     packs = resolve_policy_packs(root, config)
     spec = attach_declared_policies(inspection.require_value(), packs)
     pack_ids = tuple(pack.pack_id for pack in packs)
     verify_replay_spec_bindings(
         source_manifest, spec=spec, policy_pack_ids=pack_ids
+    )
+    verify_source_snapshot(
+        source_snapshot,
+        root=root,
+        config=config,
+        phase="after shrink target inspection",
     )
 
     original, original_evaluation = _select_shrink_target(
@@ -652,6 +677,12 @@ def shrink_suite(
         execute=execute_candidate,
         max_candidates=max_candidates,
         max_rounds=max_rounds,
+    )
+    verify_source_snapshot(
+        source_snapshot,
+        root=root,
+        config=config,
+        phase="after shrink scenario workers",
     )
     minimized = _annotate_minimized(outcome.scenario, original)
     if secret_shaped_reason(minimized) is not None:

--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -81,14 +81,17 @@ from agentcheck.report import render_report
 from agentcheck.replay import (
     ReplayManifest,
     build_replay_manifest,
-    collect_source_file_set,
-    entrypoint_digest,
     git_revision,
     load_replay_manifest,
     secret_shaped_reason,
     verify_replay_source_bindings,
     verify_replay_spec_bindings,
     write_replay_manifest,
+)
+from agentcheck.replay.bind import (
+    SourceSnapshot,
+    capture_source_snapshot,
+    verify_source_snapshot,
 )
 from agentcheck.replay.manifest import replay_manifest_relative_path
 from agentcheck.shrink import (
@@ -158,6 +161,7 @@ class SuiteExecution:
     run_id: str
     seed: int
     git_revision: str | None
+    source_snapshot: SourceSnapshot
     spec: AgentSpec
     frozen_suite: FrozenSuite | None
     scenarios: tuple[Scenario, ...]
@@ -357,8 +361,11 @@ def execute_suite(
     # target is imported, so a malformed file never reaches model or tool code.
     configured = configured_frozen_suite(root, config)
     suite_run_id = run_id or new_run_id()
-    # Freeze repository identity before importing or executing target code.
-    revision = _git_revision(root)
+    # Capture bounded source bytes and named-commit eligibility before the first
+    # target import. Later endpoint comparisons are ordinary trusted-code
+    # controls, not hostile filesystem immutability or ABA protection.
+    source_snapshot = capture_source_snapshot(root, config)
+    revision = source_snapshot.git_revision
     inspection = inspect_in_subprocess(root, config)
     packs = resolve_policy_packs(
         root, config, spec=_require_supported_spec(inspection)
@@ -491,6 +498,7 @@ def execute_suite(
         suite_run_id=suite_run_id,
         effective_seed=effective_seed,
         revision=revision,
+        source_snapshot=source_snapshot,
         valid=tuple(valid),
         invalid=tuple(invalid),
         reference_scenarios=reference_scenarios,
@@ -519,9 +527,10 @@ def replay_suite(
     # Untrusted manifest is parsed before the target is imported.
     manifest = load_replay_manifest(root, manifest_path)
     suite_run_id = run_id or new_run_id()
-    revision = _git_revision(root)
     verify_replay_source_bindings(manifest, root=root, config=config)
     _warn_legacy_source_binding(manifest)
+    source_snapshot = capture_source_snapshot(root, config)
+    revision = source_snapshot.git_revision
     inspection = inspect_in_subprocess(root, config)
     packs = resolve_policy_packs(root, config, spec=inspection.require_value())
     spec = attach_declared_policies(inspection.require_value(), packs)
@@ -559,6 +568,7 @@ def replay_suite(
         suite_run_id=suite_run_id,
         effective_seed=manifest.seed,
         revision=revision,
+        source_snapshot=source_snapshot,
         valid=tuple(valid),
         invalid=(),
         reference_scenarios=tuple(valid),
@@ -817,6 +827,7 @@ def _execute_valid_scenarios(
     suite_run_id: str,
     effective_seed: int,
     revision: str | None,
+    source_snapshot: SourceSnapshot,
     valid: tuple[Scenario, ...],
     invalid: tuple[InvalidScenario, ...],
     reference_scenarios: tuple[Scenario, ...],
@@ -827,6 +838,12 @@ def _execute_valid_scenarios(
     persist_store: bool,
     policy_pack_ids: tuple[str, ...],
 ) -> SuiteExecution:
+    verify_source_snapshot(
+        source_snapshot,
+        root=root,
+        config=config,
+        phase="after inspection and preparation, before scenario workers",
+    )
     valid_scenarios = tuple(valid)
     behavioral_coverage = analyze_behavioral_coverage(
         spec,
@@ -885,6 +902,12 @@ def _execute_valid_scenarios(
     ordered = tuple(indexed_results[index] for index in range(len(valid)))
     runs = tuple(case_run for case_run, _ in ordered if case_run is not None)
     evaluations = tuple(evaluation for _, evaluation in ordered)
+    verify_source_snapshot(
+        source_snapshot,
+        root=root,
+        config=config,
+        phase="after scenario workers",
+    )
     findings = analyze_failures(valid_scenarios, evaluations)
     artifacts = ArtifactStore(root, config.artifacts_directory, suite_run_id)
     artifacts.write_json("agent-spec.json", spec)
@@ -957,7 +980,7 @@ def _execute_valid_scenarios(
         run_id=suite_run_id,
         seed=effective_seed,
         scenarios=valid_scenarios,
-        revision=revision,
+        source_snapshot=source_snapshot,
         policy_pack_ids=policy_pack_ids,
     )
     execution = SuiteExecution(
@@ -966,6 +989,7 @@ def _execute_valid_scenarios(
         run_id=suite_run_id,
         seed=effective_seed,
         git_revision=revision,
+        source_snapshot=source_snapshot,
         spec=spec,
         frozen_suite=frozen,
         scenarios=valid_scenarios,
@@ -992,24 +1016,22 @@ def _emit_replay_manifest(
     run_id: str,
     seed: int,
     scenarios: tuple[Scenario, ...],
-    revision: str | None,
+    source_snapshot: SourceSnapshot,
     policy_pack_ids: tuple[str, ...],
 ) -> Path | None:
     """Write a pre-redaction replay manifest. Failures never change a verdict."""
 
     try:
-        digest = entrypoint_digest(root, config.entrypoint)
-        file_set = collect_source_file_set(root)
         manifest, omitted = build_replay_manifest(
             run_id=run_id,
             seed=seed,
             spec=spec,
             config=config,
             scenarios=scenarios,
-            git_revision=revision,
-            entrypoint_digest=digest,
+            git_revision=source_snapshot.git_revision,
+            entrypoint_digest=source_snapshot.entrypoint_digest,
             policy_pack_ids=policy_pack_ids,
-            file_set=file_set,
+            file_set=source_snapshot.file_set,
         )
         if manifest is None:
             print(

--- a/agentcheck/replay/bind.py
+++ b/agentcheck/replay/bind.py
@@ -15,7 +15,6 @@ from agentcheck.identity import identity_mismatch_hint, spec_identity_matches
 from .fileset import (
     SourceSnapshot,
     build_source_snapshot,
-    collect_source_file_set,
     describe_file_set_mismatch,
     describe_source_snapshot_mismatch,
     git_command_env,
@@ -140,8 +139,13 @@ def verify_replay_source_bindings(
     *,
     root: Path,
     config: AgentCheckConfig,
-) -> None:
-    """Refuse replay when source/config identity differs. Does not import the target."""
+) -> SourceSnapshot:
+    """Return the exact captured source after proving its replay bindings.
+
+    The returned snapshot is the same object compared with the input manifest;
+    callers must execute from this capture rather than recollecting a new
+    replay baseline. This does not import the target.
+    """
 
     binding = manifest.spec_binding
     if config.adapter != binding.adapter:
@@ -156,11 +160,6 @@ def verify_replay_source_bindings(
         )
 
     source = manifest.source_binding
-    live_digest = entrypoint_digest(root, config.entrypoint)
-    if live_digest != source.entrypoint_digest:
-        raise ConfigurationError(
-            "entrypoint source digest does not match the replay manifest"
-        )
     if source.git_revision is not None:
         live_revision = git_revision(root)
         if live_revision != source.git_revision:
@@ -171,6 +170,19 @@ def verify_replay_source_bindings(
             raise ConfigurationError(
                 "target git worktree is dirty; replay refuses a dirty tree"
             )
+
+    snapshot = capture_source_snapshot(root, config)
+    if snapshot.entrypoint_digest != source.entrypoint_digest:
+        raise ConfigurationError(
+            "entrypoint source digest does not match the replay manifest"
+        )
+    if (
+        source.git_revision is not None
+        and snapshot.git_revision != source.git_revision
+    ):
+        raise ConfigurationError(
+            "git revision does not match the replay manifest"
+        )
 
     required = manifest.environment_requirements.names
     live_allowlist = tuple(sorted(config.environment_allowlist))
@@ -186,11 +198,11 @@ def verify_replay_source_bindings(
         )
 
     if source.file_set is None:
-        return
-    live_files = collect_source_file_set(root)
-    reason = describe_file_set_mismatch(source.file_set, live_files)
+        return snapshot
+    reason = describe_file_set_mismatch(source.file_set, snapshot.file_set)
     if reason:
         raise ConfigurationError(reason)
+    return snapshot
 
 
 def verify_replay_spec_bindings(

--- a/agentcheck/replay/bind.py
+++ b/agentcheck/replay/bind.py
@@ -12,7 +12,14 @@ from agentcheck.domain import AgentSpec
 from agentcheck.errors import ConfigurationError
 from agentcheck.identity import identity_mismatch_hint, spec_identity_matches
 
-from .fileset import collect_source_file_set, describe_file_set_mismatch, git_command_env
+from .fileset import (
+    SourceSnapshot,
+    build_source_snapshot,
+    collect_source_file_set,
+    describe_file_set_mismatch,
+    describe_source_snapshot_mismatch,
+    git_command_env,
+)
 from .manifest import ReplayManifest
 
 
@@ -78,6 +85,54 @@ def entrypoint_digest(root: Path, entrypoint: str) -> str:
         if descriptor >= 0:
             os.close(descriptor)
     return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def capture_source_snapshot(
+    root: Path,
+    config: AgentCheckConfig,
+) -> SourceSnapshot:
+    """Capture bounded source identity before target import or execution.
+
+    The revision is checked on both sides of collection. This proves ordinary
+    endpoint equality, not hostile filesystem immutability or ABA resistance.
+    """
+
+    revision_before = git_revision(root)
+    source, _attribute = resolve_entrypoint(root, config.entrypoint)
+    try:
+        entrypoint_path = source.relative_to(root.resolve()).as_posix()
+    except ValueError as exc:  # defensive; resolve_entrypoint already contains it
+        raise ConfigurationError(
+            "entrypoint must remain inside the source snapshot root"
+        ) from exc
+    digest = entrypoint_digest(root, config.entrypoint)
+    snapshot = build_source_snapshot(
+        root,
+        git_revision=revision_before,
+        entrypoint_path=entrypoint_path,
+        entrypoint_digest=digest,
+    )
+    revision_after = git_revision(root)
+    if revision_after != revision_before:
+        raise ConfigurationError(
+            "git revision changed while the initial source snapshot was captured"
+        )
+    return snapshot
+
+
+def verify_source_snapshot(
+    bound: SourceSnapshot,
+    *,
+    root: Path,
+    config: AgentCheckConfig,
+    phase: str,
+) -> None:
+    """Refuse when an endpoint capture differs from the initial source snapshot."""
+
+    live = capture_source_snapshot(root, config)
+    reason = describe_source_snapshot_mismatch(bound, live)
+    if reason:
+        raise ConfigurationError(f"source snapshot mismatch {phase}: {reason}")
 
 
 def verify_replay_source_bindings(
@@ -187,10 +242,13 @@ def verify_replay_bindings(
 
 
 __all__ = [
+    "SourceSnapshot",
+    "capture_source_snapshot",
     "entrypoint_digest",
     "git_revision",
     "git_worktree_is_dirty",
     "verify_replay_bindings",
     "verify_replay_source_bindings",
     "verify_replay_spec_bindings",
+    "verify_source_snapshot",
 ]

--- a/agentcheck/replay/fileset.py
+++ b/agentcheck/replay/fileset.py
@@ -14,6 +14,7 @@ import hmac
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
@@ -39,10 +40,14 @@ def git_command_env() -> dict[str, str]:
 SOURCE_FILE_SET_CONTRACT_VERSION: Literal["agentcheck.source_file_set.v1"] = (
     "agentcheck.source_file_set.v1"
 )
+SOURCE_SNAPSHOT_CONTRACT_VERSION: Literal["agentcheck.source_snapshot.v1"] = (
+    "agentcheck.source_snapshot.v1"
+)
 MAX_SOURCE_FILES = 256
 MAX_SOURCE_FILE_BYTES = 1 * 1024 * 1024
 MAX_WALK_DEPTH = 8
 _SAFE_RELATIVE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._/-]*$")
+_GIT_REVISION_RE = re.compile(r"^[0-9a-f]{40,64}$")
 _INCLUDED_SUFFIXES = (".py", ".json", ".toml", ".yaml", ".yml")
 _EXCLUDED_DIR_NAMES = frozenset(
     {
@@ -140,6 +145,74 @@ class SourceFileSet(ContractModel):
         return self
 
 
+class SourceSnapshot(ContractModel):
+    """One bounded source identity and its separate commit eligibility.
+
+    The file-set fingerprint describes exact captured bytes. ``commit_bindable``
+    answers the narrower, independent question of whether every one of those
+    bytes is present identically in ``git_revision``. It is false for non-Git
+    targets and for allowed ignored source that is outside the named commit.
+    """
+
+    schema_version: Literal["agentcheck.source_snapshot.v1"] = (
+        SOURCE_SNAPSHOT_CONTRACT_VERSION
+    )
+    git_revision: str | None = Field(default=None, max_length=64)
+    entrypoint_path: str = Field(min_length=1, max_length=500)
+    entrypoint_digest: str = Field(min_length=8, max_length=80)
+    file_set: SourceFileSet
+    commit_bindable: bool
+    commit_unbound_paths: tuple[str, ...] = Field(max_length=MAX_SOURCE_FILES)
+    fingerprint: str = ""
+
+    def expected_fingerprint(self) -> str:
+        return canonical_hash(self.model_dump(mode="json", exclude={"fingerprint"}))
+
+    @model_validator(mode="after")
+    def validate_snapshot(self) -> "SourceSnapshot":
+        if (
+            self.git_revision is not None
+            and _GIT_REVISION_RE.fullmatch(self.git_revision) is None
+        ):
+            raise ValueError("git_revision must be a full lowercase hex object name")
+        if not _is_safe_relative_path(self.entrypoint_path):
+            raise ValueError("entrypoint_path must be a safe relative source path")
+        if not self.entrypoint_digest.startswith("sha256:"):
+            raise ValueError("entrypoint_digest must be a sha256 digest")
+        entries = {item.path: item.digest for item in self.file_set.files}
+        if entries.get(self.entrypoint_path) != self.entrypoint_digest:
+            raise ValueError(
+                "entrypoint digest must match the captured source file-set entry"
+            )
+        if tuple(sorted(self.commit_unbound_paths)) != self.commit_unbound_paths:
+            raise ValueError("commit-unbound source paths must be sorted")
+        if len(self.commit_unbound_paths) != len(set(self.commit_unbound_paths)):
+            raise ValueError("commit-unbound source paths must be unique")
+        if any(path not in entries for path in self.commit_unbound_paths):
+            raise ValueError("commit-unbound paths must belong to the source file-set")
+        expected_bindable = (
+            self.git_revision is not None and not self.commit_unbound_paths
+        )
+        if self.commit_bindable != expected_bindable:
+            raise ValueError(
+                "commit_bindable must reflect the revision and commit-unbound paths"
+            )
+        expected = self.expected_fingerprint()
+        if self.fingerprint and not _digest_equal(self.fingerprint, expected):
+            raise ValueError("source snapshot fingerprint does not match its contents")
+        if not self.fingerprint:
+            object.__setattr__(self, "fingerprint", expected)
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class _GitSourcePaths:
+    committed: tuple[str, ...]
+    tracked: tuple[str, ...]
+    untracked: tuple[str, ...]
+    ignored: tuple[str, ...]
+
+
 def collect_source_file_set(root: Path) -> SourceFileSet:
     """Inventory relevant files under ``root`` without importing the target.
 
@@ -190,6 +263,80 @@ def collect_source_file_set(root: Path) -> SourceFileSet:
     return SourceFileSet(mode=mode, complete=True, files=entries)
 
 
+def build_source_snapshot(
+    root: Path,
+    *,
+    git_revision: str | None,
+    entrypoint_path: str,
+    entrypoint_digest: str,
+) -> SourceSnapshot:
+    """Capture source bytes and prove their separate named-commit eligibility.
+
+    This is an endpoint check for ordinary trusted-code operation. It does not
+    claim an immutable filesystem or detect a transient/ABA change between
+    captures.
+    """
+
+    resolved = root.resolve()
+    git_paths = _git_source_paths(resolved, git_revision=git_revision)
+    if git_revision is not None:
+        if git_paths is None:
+            raise ConfigurationError(
+                "unable to bind the source snapshot to the named git revision"
+            )
+        if git_paths.untracked:
+            raise ConfigurationError(
+                "relevant non-ignored untracked source is not commit-bound: "
+                f"{git_paths.untracked[0]}"
+            )
+
+    file_set = collect_source_file_set(resolved)
+    entries = {item.path: item.digest for item in file_set.files}
+    if entries.get(entrypoint_path) != entrypoint_digest:
+        raise ConfigurationError(
+            "entrypoint source changed while the initial snapshot was captured"
+        )
+
+    if git_revision is None:
+        commit_unbound_paths = tuple(item.path for item in file_set.files)
+    else:
+        assert git_paths is not None
+        committed_paths = set(git_paths.committed)
+        staged_additions = sorted(set(git_paths.tracked) - committed_paths)
+        if staged_additions:
+            raise ConfigurationError(
+                "tracked source is absent from git revision "
+                f"{git_revision}: {staged_additions[0]}"
+            )
+        for path in git_paths.committed:
+            live_digest = entries.get(path)
+            if live_digest is None:
+                raise ConfigurationError(
+                    "committed source is absent from the bounded working file-set: "
+                    f"{path}"
+                )
+            committed_digest = _git_blob_digest(resolved, git_revision, path)
+            if committed_digest is None:
+                raise ConfigurationError(
+                    f"tracked source is absent from git revision {git_revision}: {path}"
+                )
+            if not _digest_equal(live_digest, committed_digest):
+                raise ConfigurationError(
+                    "tracked source bytes differ from git revision "
+                    f"{git_revision}: {path}"
+                )
+        commit_unbound_paths = git_paths.ignored
+
+    return SourceSnapshot(
+        git_revision=git_revision,
+        entrypoint_path=entrypoint_path,
+        entrypoint_digest=entrypoint_digest,
+        file_set=file_set,
+        commit_bindable=git_revision is not None and not commit_unbound_paths,
+        commit_unbound_paths=commit_unbound_paths,
+    )
+
+
 def describe_file_set_mismatch(bound: SourceFileSet, live: SourceFileSet) -> str:
     """Return a fail-closed reason when two inventories are not identical."""
 
@@ -215,6 +362,27 @@ def describe_file_set_mismatch(bound: SourceFileSet, live: SourceFileSet) -> str
             f"source inventory mode {live.mode} does not match bound mode {bound.mode}"
         )
     return "source file-set fingerprint does not match the replay manifest"
+
+
+def describe_source_snapshot_mismatch(
+    bound: SourceSnapshot, live: SourceSnapshot
+) -> str:
+    """Return a bounded reason when two endpoint snapshots are not identical."""
+
+    if _digest_equal(bound.fingerprint, live.fingerprint):
+        return ""
+    if bound.git_revision != live.git_revision:
+        return "git revision changed since the initial source snapshot"
+    reason = describe_file_set_mismatch(bound.file_set, live.file_set)
+    if reason:
+        return reason
+    if bound.entrypoint_digest != live.entrypoint_digest:
+        return "entrypoint source changed since the initial source snapshot"
+    if bound.commit_bindable != live.commit_bindable:
+        return "source commit bindability changed since the initial snapshot"
+    if bound.commit_unbound_paths != live.commit_unbound_paths:
+        return "commit-unbound source paths changed since the initial snapshot"
+    return "source snapshot fingerprint does not match the initial capture"
 
 
 def _normalize_relative(relative: str) -> str:
@@ -370,6 +538,45 @@ def _git_z_paths(root: Path, extra_args: list[str]) -> tuple[str, ...] | None:
     return tuple(paths)
 
 
+def _git_source_paths(
+    root: Path, *, git_revision: str | None
+) -> _GitSourcePaths | None:
+    """Classify relevant Git paths without hashing or importing target code."""
+
+    tracked = _git_z_paths(root, ["ls-files", "-z", "--", "."])
+    if tracked is None:
+        return None
+    untracked = _git_z_paths(
+        root,
+        ["ls-files", "-z", "--others", "--exclude-standard", "--", "."],
+    )
+    ignored = _git_z_paths(
+        root,
+        ["ls-files", "-z", "--others", "--ignored", "--exclude-standard", "--", "."],
+    )
+    if untracked is None or ignored is None:
+        raise ConfigurationError(
+            "unable to classify tracked, untracked, and ignored source files"
+        )
+    committed: tuple[str, ...] = ()
+    if git_revision is not None:
+        committed_raw = _git_z_paths(
+            root,
+            ["ls-tree", "-r", "-z", "--name-only", git_revision, "--", "."],
+        )
+        if committed_raw is None:
+            raise ConfigurationError(
+                "unable to inventory source paths from the named git revision"
+            )
+        committed = tuple(sorted(_select_relevant_paths(committed_raw, root=root)))
+    return _GitSourcePaths(
+        committed=committed,
+        tracked=tuple(sorted(_select_relevant_paths(tracked, root=root))),
+        untracked=tuple(sorted(_select_relevant_paths(untracked, root=root))),
+        ignored=tuple(sorted(_select_relevant_paths(ignored, root=root))),
+    )
+
+
 def _local_paths(root: Path) -> tuple[str, ...]:
     collected: list[str] = []
     root_resolved = root.resolve()
@@ -445,6 +652,61 @@ def _hash_contained_file(root: Path, relative: str) -> str:
     return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
+def _git_blob_digest(root: Path, revision: str, relative: str) -> str | None:
+    """Hash one exact commit blob, bounded independently from working bytes."""
+
+    if _GIT_REVISION_RE.fullmatch(revision) is None:
+        raise ConfigurationError("git revision is not a full lowercase hex object name")
+    if not _is_safe_relative_path(relative):
+        raise ConfigurationError(
+            f"source file path is not a safe relative path: {relative}"
+        )
+    object_name = f"{revision}:./{relative}"
+    try:
+        size_result = subprocess.run(
+            ["git", "-C", str(root), "cat-file", "-s", object_name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=git_command_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ConfigurationError(
+            f"unable to inspect committed source file {relative}: {exc}"
+        ) from exc
+    if size_result.returncode != 0:
+        return None
+    try:
+        size = int(size_result.stdout.strip())
+    except ValueError as exc:
+        raise ConfigurationError(
+            f"git returned an invalid size for committed source file {relative}"
+        ) from exc
+    if size > MAX_SOURCE_FILE_BYTES:
+        raise ConfigurationError(
+            f"committed source file {relative} exceeds the "
+            f"{MAX_SOURCE_FILE_BYTES} byte bound"
+        )
+    try:
+        blob_result = subprocess.run(
+            ["git", "-C", str(root), "cat-file", "blob", object_name],
+            check=False,
+            capture_output=True,
+            timeout=5,
+            env=git_command_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ConfigurationError(
+            f"unable to read committed source file {relative}: {exc}"
+        ) from exc
+    if blob_result.returncode != 0 or len(blob_result.stdout) != size:
+        raise ConfigurationError(
+            f"unable to read the complete committed source file {relative}"
+        )
+    return f"sha256:{hashlib.sha256(blob_result.stdout).hexdigest()}"
+
+
 def omit_absent_file_set(data: dict[str, Any]) -> dict[str, Any]:
     """Drop a missing file-set so Slice 1 manifests keep their fingerprints."""
 
@@ -467,10 +729,14 @@ __all__ = [
     "MAX_SOURCE_FILES",
     "MAX_WALK_DEPTH",
     "SOURCE_FILE_SET_CONTRACT_VERSION",
+    "SOURCE_SNAPSHOT_CONTRACT_VERSION",
     "SourceFileEntry",
     "SourceFileSet",
+    "SourceSnapshot",
+    "build_source_snapshot",
     "collect_source_file_set",
     "describe_file_set_mismatch",
+    "describe_source_snapshot_mismatch",
     "git_command_env",
     "omit_absent_file_set",
 ]

--- a/agentcheck/replay/fileset.py
+++ b/agentcheck/replay/fileset.py
@@ -13,6 +13,7 @@ import hashlib
 import hmac
 import os
 import re
+import stat
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,13 +29,15 @@ _GIT_ENV_PREFIX = "GIT_"
 
 
 def git_command_env() -> dict[str, str]:
-    """Environment for git plumbing. Drops GIT_* so GIT_DIR cannot retarget us."""
+    """Environment for exact Git plumbing without caller or replacement overrides."""
 
-    return {
+    environment = {
         key: value
         for key, value in os.environ.items()
         if not key.startswith(_GIT_ENV_PREFIX)
     }
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return environment
 
 
 SOURCE_FILE_SET_CONTRACT_VERSION: Literal["agentcheck.source_file_set.v1"] = (
@@ -236,8 +239,18 @@ def collect_source_file_set(root: Path) -> SourceFileSet:
             raise ConfigurationError(
                 "unable to inventory ignored source files for replay binding"
             )
-        git_candidates = _unique_paths(tracked + ignored)
-        git_relevant = _select_relevant_paths(git_candidates, root=resolved)
+        tracked_relevant = _select_relevant_paths(tracked, root=resolved)
+        # Preserve PR #52's no-commit local fallback, but never let a mutable
+        # marker suppress Git-reported paths once tracked source makes the
+        # inventory eligible for commit certification.
+        ignored_relevant = _select_relevant_paths(
+            ignored,
+            root=resolved,
+            allow_virtualenv_exclusion=not tracked_relevant,
+        )
+        git_relevant = list(
+            _unique_paths(tuple(tracked_relevant) + tuple(ignored_relevant))
+        )
         if git_relevant:
             relevant = git_relevant
             mode: Literal["git_tracked", "local_files"] = "git_tracked"
@@ -278,7 +291,11 @@ def build_source_snapshot(
     """
 
     resolved = root.resolve()
-    git_paths = _git_source_paths(resolved, git_revision=git_revision)
+    git_paths = (
+        _git_source_paths(resolved, git_revision=git_revision)
+        if git_revision is not None
+        else None
+    )
     if git_revision is not None:
         if git_paths is None:
             raise ConfigurationError(
@@ -414,8 +431,8 @@ def _is_virtualenv_root(directory: Path) -> bool:
         return False
 
 
-def _excluded_by_location(relative: str, *, root: Path) -> bool:
-    """Exclude build, cache, and tool-reserved directories from source inventory.
+def _excluded_by_static_location(relative: str) -> bool:
+    """Whether a path is outside source policy without consulting live bytes.
 
     .github/, .vscode/, .idea/, .vs/, .claude/ are reserved for GitHub, IDE, and
     coding-assistant tooling (Claude Code's own project settings and subagent
@@ -435,11 +452,6 @@ def _excluded_by_location(relative: str, *, root: Path) -> bool:
     parts = relative.split("/")
     if any(part in _EXCLUDED_DIR_NAMES or part.endswith(".egg-info") for part in parts[:-1]):
         return True
-    accumulated = root
-    for part in parts[:-1]:
-        accumulated = accumulated / part
-        if _is_virtualenv_root(accumulated):
-            return True
     name = parts[-1] if parts else ""
     if name in _EXCLUDED_FILE_NAMES or name.startswith(".env"):
         return True
@@ -451,8 +463,20 @@ def _has_included_suffix(relative: str) -> bool:
     return any(name.endswith(suffix) for suffix in _INCLUDED_SUFFIXES)
 
 
+def _excluded_by_virtualenv(relative: str, *, root: Path) -> bool:
+    accumulated = root
+    for part in relative.split("/")[:-1]:
+        accumulated = accumulated / part
+        if _is_virtualenv_root(accumulated):
+            return True
+    return False
+
+
 def _select_relevant_paths(
-    paths: tuple[str, ...] | list[str], *, root: Path
+    paths: tuple[str, ...] | list[str],
+    *,
+    root: Path,
+    allow_virtualenv_exclusion: bool = False,
 ) -> list[str]:
     selected: list[str] = []
     seen: set[str] = set()
@@ -460,7 +484,10 @@ def _select_relevant_paths(
         relative = _normalize_relative(raw)
         if not relative or relative in seen:
             continue
-        if _excluded_by_location(relative, root=root) or not _has_included_suffix(relative):
+        if _excluded_by_static_location(relative) or not _has_included_suffix(relative):
+            continue
+        _reject_symlink_components(root, relative)
+        if allow_virtualenv_exclusion and _excluded_by_virtualenv(relative, root=root):
             continue
         if not _is_safe_relative_path(relative):
             raise ConfigurationError(
@@ -471,6 +498,35 @@ def _select_relevant_paths(
         seen.add(relative)
         selected.append(relative)
     return selected
+
+
+def _reject_symlink_components(root: Path, relative: str) -> None:
+    """Reject a live file path with any symlink component below ``root``."""
+
+    parts = relative.split("/")
+    if (
+        relative.startswith("/")
+        or "\\" in relative
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ConfigurationError(
+            f"source file path is not a contained relative path: {relative}"
+        )
+    candidate = root
+    for part in parts:
+        candidate = candidate / part
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise ConfigurationError(
+                f"unable to inspect source path {relative} for symlinks: {exc}"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ConfigurationError(
+                f"refusing to follow source symlink component at {relative}"
+            )
 
 
 def _unique_paths(paths: tuple[str, ...]) -> tuple[str, ...]:
@@ -593,20 +649,24 @@ def _local_paths(root: Path) -> tuple[str, ...]:
             raise ConfigurationError(
                 f"source file-set walk exceeded the {MAX_WALK_DEPTH} directory depth bound"
             )
-        dirnames[:] = sorted(
+        candidate_dirnames = sorted(
             name
             for name in dirnames
             if name not in _EXCLUDED_DIR_NAMES
             and not name.endswith(".egg-info")
             and not name.startswith(".")
-            and not _is_virtualenv_root(current / name)
         )
-        for name in dirnames:
+        for name in candidate_dirnames:
             child = current / name
             if child.is_symlink():
                 raise ConfigurationError(
                     f"refusing to follow source directory symlink {child}"
                 )
+        dirnames[:] = [
+            name
+            for name in candidate_dirnames
+            if not _is_virtualenv_root(current / name)
+        ]
         for name in sorted(filenames):
             child = current / name
             if relative_dir == Path("."):
@@ -620,6 +680,7 @@ def _local_paths(root: Path) -> tuple[str, ...]:
 def _hash_contained_file(root: Path, relative: str) -> str:
     if not _is_safe_relative_path(relative):
         raise ConfigurationError(f"source file path is not a safe relative path: {relative}")
+    _reject_symlink_components(root, relative)
     candidate = root / Path(*relative.split("/"))
     if candidate.is_symlink():
         raise ConfigurationError(

--- a/tests/agentcheck/test_source_certification.py
+++ b/tests/agentcheck/test_source_certification.py
@@ -684,6 +684,294 @@ def test_clean_execution_replay_uses_initial_snapshot_and_outputs_do_not_drift(
     )
 
 
+def test_replay_refuses_ignored_source_change_after_manifest_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, helper = _copy_committed_target(
+        tmp_path,
+        import_helper=True,
+        ignore_helper=True,
+        create_helper_before_commit=False,
+    )
+    _install_fast_execution(monkeypatch)
+    first = application.execute_suite(
+        target,
+        run_id="ignored-source-before-replay",
+        persist_store=False,
+    )
+    assert first.replay_manifest_path is not None
+    manifest_path = first.replay_manifest_path.relative_to(target).as_posix()
+    original_verify = application.verify_replay_source_bindings
+    original_inspect = application.inspect_in_subprocess
+    verified_snapshots: list[object] = []
+    verification_calls: list[str] = []
+    inspection_calls: list[str] = []
+    worker_calls: list[str] = []
+
+    def verify_then_mutate(*args: object, **kwargs: object) -> object:
+        snapshot = original_verify(*args, **kwargs)  # type: ignore[arg-type]
+        verified_snapshots.append(snapshot)
+        verification_calls.append("verified")
+        helper.write_text(
+            "VALUE = 'changed-after-manifest-verification'\n",
+            encoding="utf-8",
+        )
+        return snapshot
+
+    def inspected(*args: object, **kwargs: object) -> object:
+        inspection_calls.append("inspected")
+        return original_inspect(*args, **kwargs)
+
+    def forbidden_worker(*_args: object, **_kwargs: object) -> None:
+        worker_calls.append("worker")
+        raise AssertionError("replay source drift must refuse before scenario workers")
+
+    monkeypatch.setattr(
+        application,
+        "verify_replay_source_bindings",
+        verify_then_mutate,
+    )
+    monkeypatch.setattr(application, "inspect_in_subprocess", inspected)
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden_worker)
+
+    with pytest.raises(ConfigurationError, match="source snapshot mismatch"):
+        application.replay_suite(
+            target,
+            manifest_path,
+            run_id="ignored-source-after-verification",
+            persist_store=False,
+        )
+
+    assert verification_calls == ["verified"]
+    assert inspection_calls == []
+    assert worker_calls == []
+    assert verified_snapshots == [first.source_snapshot]
+    assert helper.read_text(encoding="utf-8") == (
+        "VALUE = 'changed-after-manifest-verification'\n"
+    )
+
+
+def test_replay_refuses_non_git_source_change_after_manifest_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "local-target"
+    shutil.copytree(EXAMPLE, target, symlinks=False)
+    _install_fast_execution(monkeypatch)
+    first = application.execute_suite(
+        target,
+        run_id="non-git-source-before-replay",
+        persist_store=False,
+    )
+    assert first.source_snapshot.git_revision is None
+    assert first.replay_manifest_path is not None
+    manifest_path = first.replay_manifest_path.relative_to(target).as_posix()
+    entrypoint = target / "agent.py"
+    original_verify = application.verify_replay_source_bindings
+    original_inspect = application.inspect_in_subprocess
+    verified_snapshots: list[object] = []
+    verification_calls: list[str] = []
+    inspection_calls: list[str] = []
+    worker_calls: list[str] = []
+
+    def verify_then_mutate(*args: object, **kwargs: object) -> object:
+        snapshot = original_verify(*args, **kwargs)  # type: ignore[arg-type]
+        verified_snapshots.append(snapshot)
+        verification_calls.append("verified")
+        entrypoint.write_text(
+            entrypoint.read_text(encoding="utf-8")
+            + "\n# changed after manifest verification\n",
+            encoding="utf-8",
+        )
+        return snapshot
+
+    def inspected(*args: object, **kwargs: object) -> object:
+        inspection_calls.append("inspected")
+        return original_inspect(*args, **kwargs)
+
+    def forbidden_worker(*_args: object, **_kwargs: object) -> None:
+        worker_calls.append("worker")
+        raise AssertionError("replay source drift must refuse before scenario workers")
+
+    monkeypatch.setattr(
+        application,
+        "verify_replay_source_bindings",
+        verify_then_mutate,
+    )
+    monkeypatch.setattr(application, "inspect_in_subprocess", inspected)
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden_worker)
+
+    with pytest.raises(ConfigurationError, match="source snapshot mismatch"):
+        application.replay_suite(
+            target,
+            manifest_path,
+            run_id="non-git-source-after-verification",
+            persist_store=False,
+        )
+
+    assert verification_calls == ["verified"]
+    assert inspection_calls == []
+    assert worker_calls == []
+    assert verified_snapshots == [first.source_snapshot]
+    assert entrypoint.read_text(encoding="utf-8").endswith(
+        "# changed after manifest verification\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "source_mode",
+    ["tracked-git", "ignored-git", "non-git"],
+    ids=["tracked-git-source", "ignored-git-source", "non-git-source"],
+)
+def test_shrink_refuses_source_change_after_manifest_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_mode: str,
+) -> None:
+    if source_mode == "tracked-git":
+        target, changed_path = _copy_committed_target(
+            tmp_path,
+            import_helper=True,
+        )
+        (target / ".gitignore").write_text(".agentcheck/\n", encoding="utf-8")
+        _git(target, "add", ".gitignore")
+        _git(
+            target,
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=AgentCheck Test",
+            "commit",
+            "-q",
+            "-m",
+            "ignore local artifacts",
+        )
+        changed_bytes = "VALUE = 'changed-after-shrink-verification'\n"
+    elif source_mode == "ignored-git":
+        target, changed_path = _copy_committed_target(
+            tmp_path,
+            import_helper=True,
+            ignore_helper=True,
+            create_helper_before_commit=False,
+        )
+        changed_bytes = "VALUE = 'changed-after-shrink-verification'\n"
+    else:
+        target = tmp_path / "local-target"
+        shutil.copytree(EXAMPLE, target, symlinks=False)
+        changed_path = target / "agent.py"
+        changed_bytes = (
+            changed_path.read_text(encoding="utf-8")
+            + "\n# changed after shrink verification\n"
+        )
+    _install_fast_execution(monkeypatch)
+    first = application.execute_suite(
+        target,
+        run_id=f"{source_mode}-before-shrink",
+        persist_store=False,
+    )
+    assert first.replay_manifest_path is not None
+    manifest_path = first.replay_manifest_path.relative_to(target).as_posix()
+    original_verify = application.verify_replay_source_bindings
+    original_inspect = application.inspect_in_subprocess
+    verified_snapshots: list[object] = []
+    verification_calls: list[str] = []
+    inspection_calls: list[str] = []
+    selection_calls: list[str] = []
+
+    def verify_then_mutate(*args: object, **kwargs: object) -> object:
+        snapshot = original_verify(*args, **kwargs)  # type: ignore[arg-type]
+        verified_snapshots.append(snapshot)
+        verification_calls.append("verified")
+        changed_path.write_text(changed_bytes, encoding="utf-8")
+        return snapshot
+
+    def inspected(*args: object, **kwargs: object) -> object:
+        inspection_calls.append("inspected")
+        return original_inspect(*args, **kwargs)
+
+    def forbidden_selection(*_args: object, **_kwargs: object) -> None:
+        selection_calls.append("selection")
+        raise AssertionError("shrink source drift must refuse before source workers")
+
+    monkeypatch.setattr(
+        application,
+        "verify_replay_source_bindings",
+        verify_then_mutate,
+    )
+    monkeypatch.setattr(application, "inspect_in_subprocess", inspected)
+    monkeypatch.setattr(application, "_select_shrink_target", forbidden_selection)
+
+    with pytest.raises(
+        ConfigurationError,
+        match="source snapshot mismatch|tracked source bytes differ|worktree is dirty",
+    ):
+        application.shrink_suite(
+            target,
+            manifest_path,
+            run_id=f"{source_mode}-after-verification",
+            persist_store=False,
+        )
+
+    assert verification_calls == ["verified"]
+    assert inspection_calls == []
+    assert selection_calls == []
+    assert verified_snapshots == [first.source_snapshot]
+    assert changed_path.read_text(encoding="utf-8") == changed_bytes
+
+
+def test_shrink_refuses_source_change_after_candidate_workers_before_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, helper = _copy_committed_target(
+        tmp_path,
+        import_helper=True,
+        ignore_helper=True,
+        create_helper_before_commit=False,
+    )
+    _install_fast_execution(monkeypatch)
+    first = application.execute_suite(
+        target,
+        run_id="source-before-shrink-workers",
+        persist_store=False,
+    )
+    assert first.replay_manifest_path is not None
+    manifest_path = first.replay_manifest_path.relative_to(target).as_posix()
+    shrink_calls: list[str] = []
+    artifact_calls: list[str] = []
+
+    monkeypatch.setattr(
+        application,
+        "_select_shrink_target",
+        lambda *_args, **_kwargs: (first.scenarios[0], first.evaluations[0]),
+    )
+
+    def mutating_shrink(*_args: object, **_kwargs: object) -> object:
+        shrink_calls.append("shrink")
+        helper.write_text("VALUE = 'changed-during-shrink-workers'\n", encoding="utf-8")
+        return object()
+
+    def forbidden_artifact(*_args: object, **_kwargs: object) -> None:
+        artifact_calls.append("artifact")
+        raise AssertionError("shrink source drift must refuse before artifacts")
+
+    monkeypatch.setattr(application, "shrink_scenario", mutating_shrink)
+    monkeypatch.setattr(application, "write_replay_manifest", forbidden_artifact)
+    monkeypatch.setattr(application, "write_shrink_result", forbidden_artifact)
+
+    with pytest.raises(ConfigurationError, match="source snapshot mismatch"):
+        application.shrink_suite(
+            target,
+            manifest_path,
+            run_id="source-after-shrink-workers",
+            persist_store=False,
+        )
+
+    assert shrink_calls == ["shrink"]
+    assert artifact_calls == []
+    assert helper.read_text(encoding="utf-8") == (
+        "VALUE = 'changed-during-shrink-workers'\n"
+    )
+
+
 def test_source_snapshot_contract_rejects_tampering_and_unknown_versions(
     tmp_path: Path,
 ) -> None:

--- a/tests/agentcheck/test_source_certification.py
+++ b/tests/agentcheck/test_source_certification.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from pydantic import ValidationError
+
+import agentcheck.application as application
+from agentcheck.adapters import OpenAIAgentsAdapter
+from agentcheck.config import AgentCheckConfig, load_config
+from agentcheck.domain import (
+    AssertionResult,
+    CanonicalRun,
+    CaseEvaluation,
+    RunTermination,
+    Scenario,
+    Verdict,
+    utc_now,
+)
+from agentcheck.errors import ConfigurationError
+from agentcheck.generate.templates import build_account_support_suite
+from agentcheck.inspect import load_target
+from agentcheck.replay import load_replay_manifest
+from agentcheck.replay import bind as replay_bind
+from agentcheck.replay.fileset import git_command_env
+from agentcheck.runner.orchestrator import ProcessResult
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+EXAMPLE = REPOSITORY_ROOT / "examples" / "evaluation" / "account_agent"
+
+
+def _git(target: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(target), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=git_command_env(),
+    )
+
+
+def _copy_committed_target(
+    tmp_path: Path,
+    *,
+    import_helper: bool = False,
+    ignore_helper: bool = False,
+    create_helper_before_commit: bool = True,
+) -> tuple[Path, Path]:
+    target = tmp_path / "target"
+    shutil.copytree(EXAMPLE, target, symlinks=False)
+    helper = target / "runtime_helper.py"
+    if import_helper:
+        source = target / "agent.py"
+        source.write_text(
+            source.read_text(encoding="utf-8").replace(
+                "import json\n", "import json\nimport runtime_helper\n", 1
+            ),
+            encoding="utf-8",
+        )
+    if ignore_helper:
+        (target / ".gitignore").write_text(
+            ".agentcheck/\nruntime_helper.py\n", encoding="utf-8"
+        )
+    if create_helper_before_commit:
+        helper.write_text("VALUE = 'initial'\n", encoding="utf-8")
+    _git(target, "init", "-q")
+    _git(target, "add", ".")
+    _git(
+        target,
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=AgentCheck Test",
+        "commit",
+        "-q",
+        "-m",
+        "fixture",
+    )
+    if not create_helper_before_commit:
+        helper.write_text("VALUE = 'outside-commit'\n", encoding="utf-8")
+    return target, helper
+
+
+def _example_spec() -> object:
+    loaded, source = load_target(EXAMPLE)
+    return OpenAIAgentsAdapter().inspect(loaded, source=source)
+
+
+def _passing_evaluation(scenario: Scenario, run: CanonicalRun) -> CaseEvaluation:
+    now = utc_now()
+    return CaseEvaluation(
+        evaluation_id=f"evaluation-{run.run_id}",
+        scenario_id=scenario.scenario_id,
+        run_id=run.run_id,
+        verdict=Verdict.PASS,
+        assertions=(
+            AssertionResult(
+                assertion_id="source-certification-test",
+                criterion="controlled test evaluation passes",
+                result=Verdict.PASS,
+                oracle_ids=("source-certification-test",),
+                rationale="This test isolates source certification ordering.",
+            ),
+        ),
+        started_at=now,
+        completed_at=now,
+        summary="Controlled passing evaluation.",
+    )
+
+
+def _install_fast_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    run: Callable[..., ProcessResult[CanonicalRun]] | None = None,
+) -> Scenario:
+    spec = _example_spec()
+    scenario = build_account_support_suite()[0]
+
+    def default_run(
+        _root: Path,
+        _config: AgentCheckConfig,
+        case: Scenario,
+        case_run_id: str,
+        *,
+        expected_target_id: str,
+    ) -> ProcessResult[CanonicalRun]:
+        now = utc_now()
+        return ProcessResult(
+            value=CanonicalRun(
+                run_id=case_run_id,
+                scenario_id=case.scenario_id,
+                target_id=expected_target_id,
+                started_at=now,
+                ended_at=now,
+                termination=RunTermination.COMPLETED,
+                initial_world_state=case.initial_world_state,
+                final_world_state=case.initial_world_state,
+            ),
+            infrastructure_error=None,
+        )
+
+    monkeypatch.setattr(
+        application,
+        "inspect_in_subprocess",
+        lambda *_args, **_kwargs: ProcessResult(
+            value=spec,  # type: ignore[arg-type]
+            infrastructure_error=None,
+        ),
+    )
+    monkeypatch.setattr(application, "_suite", lambda *_args: (scenario,))
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", run or default_run)
+    monkeypatch.setattr(application, "evaluate_run", _passing_evaluation)
+    return scenario
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "modified",
+        "staged",
+        "deleted",
+        "staged_deleted",
+        "staged_renamed_to_excluded",
+    ],
+)
+def test_tracked_source_change_refuses_before_target_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    change: str,
+) -> None:
+    target, helper = _copy_committed_target(tmp_path, import_helper=True)
+    if change in {"deleted", "staged_deleted"}:
+        helper.unlink()
+        if change == "staged_deleted":
+            _git(target, "add", "-u", "--", "runtime_helper.py")
+    elif change == "staged_renamed_to_excluded":
+        (target / "dist").mkdir()
+        _git(target, "mv", "runtime_helper.py", "dist/runtime_helper.py")
+    else:
+        helper.write_text("VALUE = 'changed'\n", encoding="utf-8")
+        if change == "staged":
+            _git(target, "add", "runtime_helper.py")
+
+    calls: list[str] = []
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        calls.append("called")
+        raise AssertionError(
+            "source refusal must precede target inspection and workers"
+        )
+
+    monkeypatch.setattr(application, "inspect_in_subprocess", forbidden)
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden)
+
+    with pytest.raises(ConfigurationError, match="source|commit"):
+        application.execute_suite(target, run_id=f"tracked-{change}")
+
+    assert calls == []
+    assert not (target / ".agentcheck" / "runs" / f"tracked-{change}").exists()
+
+
+def test_nonignored_untracked_import_refuses_before_target_inspection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, _helper = _copy_committed_target(
+        tmp_path,
+        import_helper=True,
+        create_helper_before_commit=False,
+    )
+    calls: list[str] = []
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        calls.append("called")
+        raise AssertionError("untracked imported source must refuse before inspection")
+
+    monkeypatch.setattr(application, "inspect_in_subprocess", forbidden)
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden)
+
+    with pytest.raises(ConfigurationError, match="untracked source.*runtime_helper.py"):
+        application.execute_suite(target, run_id="untracked-source")
+
+    assert calls == []
+    assert not (target / ".agentcheck" / "runs" / "untracked-source").exists()
+
+
+def test_ignored_relevant_source_is_exactly_bound_but_not_commit_bindable(
+    tmp_path: Path,
+) -> None:
+    target, helper = _copy_committed_target(
+        tmp_path,
+        import_helper=True,
+        ignore_helper=True,
+        create_helper_before_commit=False,
+    )
+    root, config = load_config(target)
+
+    assert _git(target, "status", "--porcelain").stdout == ""
+    assert (
+        subprocess.run(
+            ["git", "-C", str(target), "cat-file", "-e", "HEAD:./runtime_helper.py"],
+            check=False,
+            capture_output=True,
+            env=git_command_env(),
+        ).returncode
+        != 0
+    )
+
+    snapshot = replay_bind.capture_source_snapshot(root, config)
+    entries = {item.path: item.digest for item in snapshot.file_set.files}
+
+    assert snapshot.schema_version == "agentcheck.source_snapshot.v1"
+    assert snapshot.commit_bindable is False
+    assert snapshot.commit_unbound_paths == ("runtime_helper.py",)
+    assert entries["runtime_helper.py"] == (
+        "sha256:" + hashlib.sha256(helper.read_bytes()).hexdigest()
+    )
+
+
+def test_clean_tracked_source_is_byte_identical_and_commit_bindable(
+    tmp_path: Path,
+) -> None:
+    target, _helper = _copy_committed_target(tmp_path, import_helper=True)
+    root, config = load_config(target)
+
+    snapshot = replay_bind.capture_source_snapshot(root, config)
+
+    assert snapshot.commit_bindable is True
+    assert snapshot.commit_unbound_paths == ()
+    assert snapshot.git_revision == _git(target, "rev-parse", "HEAD").stdout.strip()
+    for entry in snapshot.file_set.files:
+        committed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(target),
+                "cat-file",
+                "blob",
+                f"{snapshot.git_revision}:./{entry.path}",
+            ],
+            check=True,
+            capture_output=True,
+            env=git_command_env(),
+        ).stdout
+        assert entry.digest == "sha256:" + hashlib.sha256(committed).hexdigest()
+
+
+@pytest.mark.parametrize("callback_name", ["on_inspected", "on_prepared"])
+def test_inspection_and_preparation_mutation_refuses_before_scenario_workers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    callback_name: str,
+) -> None:
+    target, helper = _copy_committed_target(tmp_path, import_helper=True)
+    _install_fast_execution(monkeypatch)
+    worker_calls: list[str] = []
+    callback_calls: list[str] = []
+
+    def forbidden_worker(*_args: object, **_kwargs: object) -> None:
+        worker_calls.append("worker")
+        raise AssertionError("phase mismatch must refuse before scenario workers")
+
+    def mutate(*_args: object, **_kwargs: object) -> None:
+        callback_calls.append(callback_name)
+        helper.write_text("VALUE = 'initial'\n# phase mutation\n", encoding="utf-8")
+
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden_worker)
+
+    with pytest.raises(ConfigurationError, match="source|commit"):
+        application.execute_suite(
+            target,
+            run_id=f"phase-{callback_name}",
+            persist_store=False,
+            **{callback_name: mutate},
+        )
+
+    assert worker_calls == []
+    assert callback_calls == [callback_name]
+    assert helper.read_text(encoding="utf-8").endswith("# phase mutation\n")
+    assert not (target / ".agentcheck" / "runs" / f"phase-{callback_name}").exists()
+
+
+def test_during_worker_mutation_refuses_after_passing_behavior_before_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, helper = _copy_committed_target(tmp_path, import_helper=True)
+    worker_calls: list[str] = []
+    evaluated_verdicts: list[Verdict] = []
+
+    def mutating_run(
+        _root: Path,
+        _config: AgentCheckConfig,
+        scenario: Scenario,
+        case_run_id: str,
+        *,
+        expected_target_id: str,
+    ) -> ProcessResult[CanonicalRun]:
+        worker_calls.append(scenario.scenario_id)
+        helper.write_text("VALUE = 'initial'\n# worker mutation\n", encoding="utf-8")
+        now = utc_now()
+        return ProcessResult(
+            value=CanonicalRun(
+                run_id=case_run_id,
+                scenario_id=scenario.scenario_id,
+                target_id=expected_target_id,
+                started_at=now,
+                ended_at=now,
+                termination=RunTermination.COMPLETED,
+                initial_world_state=scenario.initial_world_state,
+                final_world_state=scenario.initial_world_state,
+            ),
+            infrastructure_error=None,
+        )
+
+    scenario = _install_fast_execution(monkeypatch, run=mutating_run)
+
+    def recorded_passing_evaluation(
+        evaluated_scenario: Scenario, run: CanonicalRun
+    ) -> CaseEvaluation:
+        result = _passing_evaluation(evaluated_scenario, run)
+        evaluated_verdicts.append(result.verdict)
+        return result
+
+    monkeypatch.setattr(application, "evaluate_run", recorded_passing_evaluation)
+
+    with pytest.raises(ConfigurationError, match="source|commit"):
+        application.execute_suite(
+            target,
+            run_id="during-worker-mutation",
+            persist_store=False,
+        )
+
+    assert worker_calls == [scenario.scenario_id]
+    assert evaluated_verdicts == [Verdict.PASS]
+    assert not (target / ".agentcheck" / "runs" / "during-worker-mutation").exists()
+    assert not (
+        target / ".agentcheck" / "replay" / "during-worker-mutation.json"
+    ).exists()
+
+
+def test_clean_execution_replay_uses_initial_snapshot_and_outputs_do_not_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, _helper = _copy_committed_target(tmp_path, import_helper=True)
+    _install_fast_execution(monkeypatch)
+    emitted_snapshots: list[object] = []
+    captured_snapshots: list[object] = []
+    events: list[str] = []
+    original_emit = application._emit_replay_manifest
+    original_capture = application.capture_source_snapshot
+    original_inspect = application.inspect_in_subprocess
+
+    def traced_capture(*args: object, **kwargs: object) -> object:
+        snapshot = original_capture(*args, **kwargs)  # type: ignore[arg-type]
+        captured_snapshots.append(snapshot)
+        events.append("capture")
+        return snapshot
+
+    def traced_inspect(*args: object, **kwargs: object) -> object:
+        events.append("inspect")
+        return original_inspect(*args, **kwargs)
+
+    def traced_emit(**kwargs: object) -> Path | None:
+        emitted_snapshots.append(kwargs["source_snapshot"])
+        events.append("emit")
+        return original_emit(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(application, "capture_source_snapshot", traced_capture)
+    monkeypatch.setattr(replay_bind, "capture_source_snapshot", traced_capture)
+    monkeypatch.setattr(application, "inspect_in_subprocess", traced_inspect)
+    monkeypatch.setattr(application, "_emit_replay_manifest", traced_emit)
+    first = application.execute_suite(
+        target,
+        run_id="source-snapshot-clean-1",
+        persist_store=False,
+    )
+    second = application.execute_suite(
+        target,
+        run_id="source-snapshot-clean-2",
+        persist_store=False,
+    )
+
+    assert first.source_snapshot.commit_bindable is True
+    assert first.source_snapshot == second.source_snapshot
+    assert events == [
+        "capture",
+        "inspect",
+        "capture",
+        "capture",
+        "emit",
+        "capture",
+        "inspect",
+        "capture",
+        "capture",
+        "emit",
+    ]
+    assert len(captured_snapshots) == 6
+    assert emitted_snapshots == [first.source_snapshot, second.source_snapshot]
+    assert emitted_snapshots[0] is captured_snapshots[0]
+    assert emitted_snapshots[0] is not captured_snapshots[1]
+    assert emitted_snapshots[0] is not captured_snapshots[2]
+    assert emitted_snapshots[1] is captured_snapshots[3]
+    assert first.replay_manifest_path is not None
+    manifest = load_replay_manifest(
+        target,
+        first.replay_manifest_path.relative_to(target).as_posix(),
+    )
+    assert manifest.source_binding.git_revision == first.source_snapshot.git_revision
+    assert manifest.source_binding.entrypoint_digest == (
+        first.source_snapshot.entrypoint_digest
+    )
+    assert manifest.source_binding.file_set == first.source_snapshot.file_set
+
+    (target / "agentcheck-suite.json").write_text("{}\n", encoding="utf-8")
+    (target / "agentcheck-baseline.json").write_text("{}\n", encoding="utf-8")
+    replay_bind.verify_source_snapshot(
+        first.source_snapshot,
+        root=target,
+        config=first.config,
+        phase="after generated outputs",
+    )
+
+
+def test_source_snapshot_contract_rejects_tampering_and_unknown_versions(
+    tmp_path: Path,
+) -> None:
+    target, _helper = _copy_committed_target(tmp_path, import_helper=True)
+    root, config = load_config(target)
+    snapshot = replay_bind.capture_source_snapshot(root, config)
+    snapshot_type = type(snapshot)
+
+    document = snapshot.model_dump(mode="json")
+    document["unexpected"] = True
+    with pytest.raises(ValidationError):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = snapshot.model_dump(mode="json")
+    document["schema_version"] = "agentcheck.source_snapshot.v0"
+    with pytest.raises(ValidationError):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = snapshot.model_dump(mode="json")
+    document["fingerprint"] = "sha256:" + "0" * 64
+    with pytest.raises(ValidationError, match="fingerprint"):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = snapshot.model_dump(mode="json")
+    document["commit_bindable"] = False
+    with pytest.raises(ValidationError, match="commit_bindable"):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = snapshot.model_dump(mode="json")
+    document["commit_unbound_paths"] = ["runtime_helper.py"]
+    with pytest.raises(ValidationError, match="commit_bindable"):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = snapshot.model_dump(mode="json")
+    document["commit_bindable"] = False
+    document["commit_unbound_paths"] = ["runtime_helper.py"]
+    with pytest.raises(ValidationError, match="fingerprint"):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    ignored_parent = tmp_path / "ignored"
+    ignored_parent.mkdir()
+    ignored_target, _ignored_helper = _copy_committed_target(
+        ignored_parent,
+        import_helper=True,
+        ignore_helper=True,
+        create_helper_before_commit=False,
+    )
+    ignored_root, ignored_config = load_config(ignored_target)
+    ignored = replay_bind.capture_source_snapshot(ignored_root, ignored_config)
+    assert ignored.commit_bindable is False
+    assert ignored.commit_unbound_paths == ("runtime_helper.py",)
+
+    document = ignored.model_dump(mode="json")
+    document["commit_bindable"] = True
+    with pytest.raises(ValidationError, match="commit_bindable"):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = ignored.model_dump(mode="json")
+    document["commit_unbound_paths"] = []
+    with pytest.raises(ValidationError, match="commit_bindable"):
+        snapshot_type.model_validate_json(json.dumps(document))
+
+    document = ignored.model_dump(mode="json")
+    document["commit_bindable"] = True
+    document["commit_unbound_paths"] = []
+    with pytest.raises(ValidationError, match="fingerprint"):
+        snapshot_type.model_validate_json(json.dumps(document))

--- a/tests/agentcheck/test_source_certification.py
+++ b/tests/agentcheck/test_source_certification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -85,6 +86,35 @@ def _copy_committed_target(
     if not create_helper_before_commit:
         helper.write_text("VALUE = 'outside-commit'\n", encoding="utf-8")
     return target, helper
+
+
+def _copy_committed_package_target(tmp_path: Path) -> tuple[Path, Path]:
+    target = tmp_path / "target"
+    package = target / "pkg"
+    package.mkdir(parents=True)
+    (target / "agent.py").write_text(
+        "from pkg import helper\nagent = helper.VALUE\n", encoding="utf-8"
+    )
+    (target / "agentcheck.json").write_text(
+        '{"schema_version":"agentcheck.config.v1","entrypoint":"agent.py:agent"}\n',
+        encoding="utf-8",
+    )
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "helper.py").write_text("VALUE = 'committed'\n", encoding="utf-8")
+    _git(target, "init", "-q")
+    _git(target, "add", ".")
+    _git(
+        target,
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=AgentCheck Test",
+        "commit",
+        "-q",
+        "-m",
+        "fixture",
+    )
+    return target, package
 
 
 def _example_spec() -> object:
@@ -227,6 +257,194 @@ def test_nonignored_untracked_import_refuses_before_target_inspection(
 
     assert calls == []
     assert not (target / ".agentcheck" / "runs" / "untracked-source").exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="directory symlink probe")
+@pytest.mark.parametrize(
+    "with_venv_marker", [False, True], ids=["plain", "venv-marker"]
+)
+def test_outbound_intermediate_directory_symlink_refuses_before_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    with_venv_marker: bool,
+) -> None:
+    target, package = _copy_committed_package_target(tmp_path)
+    outside = tmp_path / "outside-package"
+    package.rename(outside)
+    if with_venv_marker:
+        (outside / "helper.py").write_text(
+            "VALUE = 'outside-and-different'\n", encoding="utf-8"
+        )
+        (outside / "pyvenv.cfg").write_text("version = 3.12\n", encoding="utf-8")
+    os.symlink(outside, package, target_is_directory=True)
+    calls: list[str] = []
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        calls.append("inspect")
+        raise AssertionError("outbound source symlink must refuse before inspection")
+
+    monkeypatch.setattr(application, "inspect_in_subprocess", forbidden)
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden)
+
+    with pytest.raises(ConfigurationError, match="symlink|outside|contain"):
+        application.execute_suite(
+            target,
+            run_id=f"outbound-directory-symlink-{with_venv_marker}",
+            persist_store=False,
+        )
+
+    assert calls == []
+
+
+def test_untracked_venv_marker_cannot_hide_tracked_source_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, package = _copy_committed_package_target(tmp_path)
+    (package / "helper.py").write_text(
+        "VALUE = 'modified-and-executed'\n", encoding="utf-8"
+    )
+    (package / "pyvenv.cfg").write_text("version = 3.12\n", encoding="utf-8")
+    calls: list[str] = []
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        calls.append("inspect")
+        raise AssertionError("tracked source mismatch must refuse before inspection")
+
+    monkeypatch.setattr(application, "inspect_in_subprocess", forbidden)
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", forbidden)
+
+    with pytest.raises(ConfigurationError, match="tracked source bytes differ"):
+        application.execute_suite(
+            target,
+            run_id="untracked-venv-marker",
+            persist_store=False,
+        )
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "tracked_package_init", [True, False], ids=["regular-package", "namespace-package"]
+)
+def test_venv_marker_cannot_hide_ignored_relevant_source(
+    tmp_path: Path, tracked_package_init: bool
+) -> None:
+    target = tmp_path / "target"
+    package = target / "pkg"
+    package.mkdir(parents=True)
+    (target / "agent.py").write_text(
+        "from pkg import ignored_runtime\nagent = ignored_runtime.VALUE\n",
+        encoding="utf-8",
+    )
+    (target / "agentcheck.json").write_text(
+        '{"schema_version":"agentcheck.config.v1","entrypoint":"agent.py:agent"}\n',
+        encoding="utf-8",
+    )
+    (target / ".gitignore").write_text("pkg/ignored_runtime.py\n", encoding="utf-8")
+    if tracked_package_init:
+        (package / "__init__.py").write_text("", encoding="utf-8")
+    _git(target, "init", "-q")
+    _git(target, "add", ".")
+    _git(
+        target,
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=AgentCheck Test",
+        "commit",
+        "-q",
+        "-m",
+        "fixture",
+    )
+    ignored = package / "ignored_runtime.py"
+    ignored.write_text("VALUE = 'ignored-runtime-source'\n", encoding="utf-8")
+    (package / "pyvenv.cfg").write_text("version = 3.12\n", encoding="utf-8")
+    assert _git(target, "check-ignore", "pkg/ignored_runtime.py").stdout.strip()
+
+    root, config = load_config(target)
+    snapshot = replay_bind.capture_source_snapshot(root, config)
+    entries = {item.path: item.digest for item in snapshot.file_set.files}
+
+    assert entries["pkg/ignored_runtime.py"] == (
+        "sha256:" + hashlib.sha256(ignored.read_bytes()).hexdigest()
+    )
+    assert snapshot.commit_bindable is False
+    assert snapshot.commit_unbound_paths == ("pkg/ignored_runtime.py",)
+
+
+def test_live_gitignore_cannot_hide_untracked_namespace_source(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    package = target / "pkg"
+    package.mkdir(parents=True)
+    (target / "agent.py").write_text(
+        "from pkg import ignored_runtime\nagent = ignored_runtime.VALUE\n",
+        encoding="utf-8",
+    )
+    (target / "agentcheck.json").write_text(
+        '{"schema_version":"agentcheck.config.v1","entrypoint":"agent.py:agent"}\n',
+        encoding="utf-8",
+    )
+    gitignore = target / ".gitignore"
+    gitignore.write_text("# committed ignore policy\n", encoding="utf-8")
+    _git(target, "init", "-q")
+    _git(target, "add", ".")
+    _git(
+        target,
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=AgentCheck Test",
+        "commit",
+        "-q",
+        "-m",
+        "fixture",
+    )
+    gitignore.write_text("pkg/\n", encoding="utf-8")
+    ignored = package / "ignored_runtime.py"
+    ignored.write_text("VALUE = 'live-ignore-source'\n", encoding="utf-8")
+    (package / "pyvenv.cfg").write_text("version = 3.12\n", encoding="utf-8")
+    assert _git(target, "check-ignore", "pkg/ignored_runtime.py").stdout.strip()
+
+    root, config = load_config(target)
+    snapshot = replay_bind.capture_source_snapshot(root, config)
+    entries = {item.path: item.digest for item in snapshot.file_set.files}
+
+    assert entries["pkg/ignored_runtime.py"] == (
+        "sha256:" + hashlib.sha256(ignored.read_bytes()).hexdigest()
+    )
+    assert snapshot.commit_bindable is False
+    assert snapshot.commit_unbound_paths == ("pkg/ignored_runtime.py",)
+
+
+def test_git_replace_ref_cannot_redefine_named_revision_bytes(tmp_path: Path) -> None:
+    target, package = _copy_committed_package_target(tmp_path)
+    original_revision = _git(target, "rev-parse", "HEAD").stdout.strip()
+    (package / "helper.py").write_text(
+        "VALUE = 'replacement-object'\n", encoding="utf-8"
+    )
+    _git(target, "add", "pkg/helper.py")
+    _git(
+        target,
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=AgentCheck Test",
+        "commit",
+        "-q",
+        "-m",
+        "replacement",
+    )
+    replacement_revision = _git(target, "rev-parse", "HEAD").stdout.strip()
+    _git(target, "checkout", "-q", "--detach", original_revision)
+    (package / "helper.py").write_text(
+        "VALUE = 'replacement-object'\n", encoding="utf-8"
+    )
+    _git(target, "replace", original_revision, replacement_revision)
+    assert _git(target, "replace", "-l").stdout.strip() == original_revision
+
+    root, config = load_config(target)
+    with pytest.raises(ConfigurationError, match="tracked source bytes differ"):
+        replay_bind.capture_source_snapshot(root, config)
 
 
 def test_ignored_relevant_source_is_exactly_bound_but_not_commit_bindable(

--- a/tests/agentcheck/test_source_fileset.py
+++ b/tests/agentcheck/test_source_fileset.py
@@ -10,7 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from agentcheck.application import execute_suite, replay_suite, shrink_suite
-from agentcheck.config import AgentCheckConfig
+from agentcheck.config import AgentCheckConfig, load_config
 from agentcheck.errors import ConfigurationError
 from agentcheck.generate.templates import build_account_support_suite
 from agentcheck.replay import (
@@ -24,6 +24,7 @@ from agentcheck.replay import (
     load_replay_manifest,
 )
 from agentcheck.replay.fileset import MAX_WALK_DEPTH, SourceFileEntry, git_command_env
+from agentcheck.replay.bind import capture_source_snapshot
 from agentcheck.replay.manifest import ReplayManifest
 
 
@@ -666,6 +667,26 @@ def test_an_arbitrarily_named_gitignored_virtualenv_is_excluded_in_git_mode(
     paths = {item.path for item in inventory.files}
     assert "agent.py" in paths
     assert not any(".test-venv" in path for path in paths)
+    root, config = load_config(target)
+    snapshot = capture_source_snapshot(root, config)
+    assert snapshot.git_revision is None
+    assert snapshot.commit_bindable is False
+    assert snapshot.file_set == inventory
+
+
+def test_arbitrarily_named_venv_cannot_reclassify_commit_certified_paths(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "agent.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git_init(target)
+    (target / ".gitignore").write_text(".test-venv/\n", encoding="utf-8")
+    _git_track(target, "agent.py", ".gitignore")
+    _write_virtualenv(target, ".test-venv")
+
+    with pytest.raises(ConfigurationError, match="not a safe relative path"):
+        collect_source_file_set(target)
 
 
 def test_a_dot_prefixed_directory_that_is_not_a_virtualenv_still_fails_closed(


### PR DESCRIPTION
## Summary

- capture a versioned, bounded source snapshot before the first target inspection/import
- keep exact source file-set identity separate from named-commit eligibility
- refuse relevant nonignored untracked source and named-revision byte/path mismatches before inspection; include ignored relevant bytes while marking the snapshot non-commit-bindable
- reject relevant source paths containing symlink components before live classification or hashing
- prevent live virtualenv markers and Git replacement refs from redefining commit-certified source while preserving the accepted no-commit local virtualenv fallback
- make replay and shrink verify, retain, and execute from the exact manifest-bound snapshot instead of accepting a disconnected later capture
- verify that snapshot immediately before inspection, after inspection/before workers, and after workers/before trusted artifacts
- build replay source bindings from the verified initial snapshot instead of recollecting source after execution

## Base and scope

- exact base: `07aec42fcc358f9c82e07352ade65625e56c334e`
- exact current head: `74ec02ead179b43a580bc91ea58c41f7c400426b`
- exact current tree: `7e931041b6443987b03b5fbe6920ce32db10eedf`
- cumulative five-file diff: `agentcheck/application.py`, `agentcheck/replay/bind.py`, `agentcheck/replay/fileset.py`, `tests/agentcheck/test_source_certification.py`, and `tests/agentcheck/test_source_fileset.py` (`+1554/-42`)
- replay/shrink phase-binding commit `74ec02e` changes only application, replay binding, and source-certification tests (`+345/-14`)
- the complete correction since original implementation head `c990655` is the same five authorized files (`+663/-32`)
- this remains AC-P0-7 Slice 1 only; it does not add a replay-completeness contract or gate/report schema

The checks prove ordinary endpoint equality for AgentCheck's bounded relevant-source inventory. They do **not** prove hostile filesystem immutability, transient/ABA detection, exhaustive runtime dependency closure, provider or process containment, or persistence of commit bindability into replay/gate evidence.

## Evidence

Current-main red evidence was captured before the original implementation for four historical negatives: omitted nonignored untracked executed source, late replay source recollection, optional replay capture failure still allowing PASS, and ignored executed source absent from the named commit.

Independent Security review then invalidated `c990655` with stable reproductions for intermediate outbound directory symlinks, live `pyvenv.cfg` reclassification of tracked and ignored regular/namespace-package source, and Git replacement refs redefining named-revision bytes. Commit `49cacab` added the corresponding source-classification defenses and regressions.

Fresh Evidence review invalidated `49cacab`: replay verified the manifest and then accepted a disconnected later capture, while shrink discarded its verified snapshot before inspection and candidate work. Stable ignored/non-Git replay and tracked/ignored/non-Git shrink drift crossed those phase joins. Commit `74ec02e` makes `verify_replay_source_bindings()` capture, compare, and return one exact snapshot; replay and shrink retain that object and apply explicit pre-inspection, post-inspection/pre-worker, and post-worker/pre-artifact checks. The decisive regressions require zero inspection calls for post-verifier drift and zero artifact calls for post-candidate drift.

Exact committed-byte owner validation:

- six decisive replay/shrink phase nodes: `6 passed in 1.36s`; independent root rerun: `6 passed in 1.48s`
- retained seven-case Security successor probe: `7 passed in 0.36s`
- complete source-certification + source-fileset + replay modules: `88 passed in 180.47s`; all 26 certification nodes are included
- complete application + generation + gate + shrink modules: `74 passed in 219.05s`
- Ruff: all five changed files passed
- mypy: `Success: no issues found in 101 source files`
- `py_compile`: all five changed Python files passed
- secret scan: no high-signal credential pattern found
- `git diff --check`, exact name/status, stat, numstat, and scope checks: passed

Independent Evidence matched the exact five pre-commit hashes, reran adapted replay/shrink probes, Security probes, both complete test groups, and static checks, and found no blocker to this normal commit/push. That moving-byte clearance is not a substitute for fresh clean-context exact-head Evidence and Security review. All CI/review evidence for `49cacab` and `c990655` is invalidated for readiness at this head.

Fresh exact-head dependency-review run `33361283534` and CI run `33361283527` are terminal successful. Dependency `99392980268`, classifier `99393041842`, Python 3.10/3.11/3.12 `99393064672`/`99393064658`/`99393064662`, quality/packaging `99393064618`, and aggregate Required CI `99400417951` are all green. Fresh exact-head Evidence and Security reviews are READY; required human/codeowner review is the sole remaining merge blocker.

## Merge gate

Keep this PR draft. Do not merge until fresh independent exact-head Evidence and Security reviews return no finding and every required check for exact `74ec02e` is terminal green. This PR must not be treated as closing the broader AC-P0-7 source-provenance objective.
