### PR TITLE
Require complete replay before trusted artifacts

### DIFF
--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -869,6 +869,11 @@ def _execute_valid_scenarios(
     persist_store: bool,
     policy_pack_ids: tuple[str, ...],
 ) -> SuiteExecution:
+    # Reserve the run ID before scenario workers so a collision cannot replace
+    # an existing replay or begin a second execution under the same identity.
+    # The empty directory is deliberately not a trusted stored run: the loader
+    # requires the complete artifact set written only after replay succeeds.
+    artifacts = ArtifactStore(root, config.artifacts_directory, suite_run_id)
     verify_source_snapshot(
         source_snapshot,
         root=root,
@@ -940,7 +945,16 @@ def _execute_valid_scenarios(
         phase="after scenario workers",
     )
     findings = analyze_failures(valid_scenarios, evaluations)
-    artifacts = ArtifactStore(root, config.artifacts_directory, suite_run_id)
+    replay_path = _require_complete_replay_manifest(
+        root=root,
+        config=config,
+        spec=spec,
+        run_id=suite_run_id,
+        seed=effective_seed,
+        scenarios=valid_scenarios,
+        source_snapshot=source_snapshot,
+        policy_pack_ids=policy_pack_ids,
+    )
     artifacts.write_json("agent-spec.json", spec)
     artifacts.write_json(
         "suite.json",
@@ -1004,16 +1018,6 @@ def _execute_valid_scenarios(
         _coverage_reference_scenarios=reference_scenarios,
     )
     report_path = artifacts.write_text("report.html", report)
-    replay_path = _emit_replay_manifest(
-        root=root,
-        config=config,
-        spec=spec,
-        run_id=suite_run_id,
-        seed=effective_seed,
-        scenarios=valid_scenarios,
-        source_snapshot=source_snapshot,
-        policy_pack_ids=policy_pack_ids,
-    )
     execution = SuiteExecution(
         target_root=root,
         config=config,
@@ -1039,7 +1043,7 @@ def _execute_valid_scenarios(
     return execution
 
 
-def _emit_replay_manifest(
+def _require_complete_replay_manifest(
     *,
     root: Path,
     config: AgentCheckConfig,
@@ -1049,8 +1053,8 @@ def _emit_replay_manifest(
     scenarios: tuple[Scenario, ...],
     source_snapshot: SourceSnapshot,
     policy_pack_ids: tuple[str, ...],
-) -> Path | None:
-    """Write a pre-redaction replay manifest. Failures never change a verdict."""
+) -> Path:
+    """Write one replay case per executed scenario or fail the execution."""
 
     try:
         manifest, omitted = build_replay_manifest(
@@ -1064,30 +1068,31 @@ def _emit_replay_manifest(
             policy_pack_ids=policy_pack_ids,
             file_set=source_snapshot.file_set,
         )
-        if manifest is None:
-            print(
-                "AgentCheck warning: replay manifest omitted because every case "
-                "failed secret screening",
-                file=sys.stderr,
+        if manifest is None or omitted or manifest.omitted:
+            omitted_count = max(
+                len(omitted),
+                len(manifest.omitted) if manifest is not None else 0,
             )
-            return None
-        path = write_replay_manifest(root, config, manifest)
-        if omitted:
-            print(
-                "AgentCheck warning: "
-                f"{len(omitted)} scenario(s) omitted from the replay manifest",
-                file=sys.stderr,
+            raise ConfigurationError(
+                "complete replay manifest required: "
+                f"{omitted_count or len(scenarios)} of {len(scenarios)} "
+                "scenario(s) could not be serialized safely"
             )
-        return path
+        if tuple(manifest.cases) != scenarios:
+            raise ConfigurationError(
+                "complete replay manifest required: replay cases do not match "
+                "each executed scenario exactly once"
+            )
+        return write_replay_manifest(root, config, manifest)
     except (KeyboardInterrupt, SystemExit):
         raise
+    except ConfigurationError:
+        raise
     except Exception as exc:
-        print(
-            "AgentCheck warning: replay manifest failed: "
-            + redact_log_text(str(exc)),
-            file=sys.stderr,
-        )
-        return None
+        message = redact_log_text(str(exc)) or type(exc).__name__
+        raise ConfigurationError(
+            f"unable to produce complete replay manifest: {message}"
+        ) from exc
 
 
 def _warn_legacy_source_binding(manifest: ReplayManifest) -> None:

--- a/agentcheck/application.py
+++ b/agentcheck/application.py
@@ -869,11 +869,6 @@ def _execute_valid_scenarios(
     persist_store: bool,
     policy_pack_ids: tuple[str, ...],
 ) -> SuiteExecution:
-    # Reserve the run ID before scenario workers so a collision cannot replace
-    # an existing replay or begin a second execution under the same identity.
-    # The empty directory is deliberately not a trusted stored run: the loader
-    # requires the complete artifact set written only after replay succeeds.
-    artifacts = ArtifactStore(root, config.artifacts_directory, suite_run_id)
     verify_source_snapshot(
         source_snapshot,
         root=root,
@@ -888,6 +883,9 @@ def _execute_valid_scenarios(
         reference_scope=reference_scope,
         suite_fingerprint=frozen.fingerprint if frozen is not None else None,
     )
+    # Reserve the run ID before scenario workers so a collision cannot replace
+    # an existing replay or begin a second execution under the same identity.
+    artifacts = ArtifactStore(root, config.artifacts_directory, suite_run_id)
     indexed_results: dict[int, tuple[CanonicalRun | None, CaseEvaluation]] = {}
     with ThreadPoolExecutor(
         max_workers=min(config.max_concurrency, max(1, len(valid))),
@@ -938,23 +936,27 @@ def _execute_valid_scenarios(
     ordered = tuple(indexed_results[index] for index in range(len(valid)))
     runs = tuple(case_run for case_run, _ in ordered if case_run is not None)
     evaluations = tuple(evaluation for _, evaluation in ordered)
-    verify_source_snapshot(
-        source_snapshot,
-        root=root,
-        config=config,
-        phase="after scenario workers",
-    )
-    findings = analyze_failures(valid_scenarios, evaluations)
-    replay_path = _require_complete_replay_manifest(
-        root=root,
-        config=config,
-        spec=spec,
-        run_id=suite_run_id,
-        seed=effective_seed,
-        scenarios=valid_scenarios,
-        source_snapshot=source_snapshot,
-        policy_pack_ids=policy_pack_ids,
-    )
+    try:
+        verify_source_snapshot(
+            source_snapshot,
+            root=root,
+            config=config,
+            phase="after scenario workers",
+        )
+        findings = analyze_failures(valid_scenarios, evaluations)
+        replay_path = _emit_replay_manifest(
+            root=root,
+            config=config,
+            spec=spec,
+            run_id=suite_run_id,
+            seed=effective_seed,
+            scenarios=valid_scenarios,
+            source_snapshot=source_snapshot,
+            policy_pack_ids=policy_pack_ids,
+        )
+    except BaseException:
+        _remove_empty_run_reservation(artifacts.root)
+        raise
     artifacts.write_json("agent-spec.json", spec)
     artifacts.write_json(
         "suite.json",
@@ -1043,7 +1045,7 @@ def _execute_valid_scenarios(
     return execution
 
 
-def _require_complete_replay_manifest(
+def _emit_replay_manifest(
     *,
     root: Path,
     config: AgentCheckConfig,
@@ -1093,6 +1095,15 @@ def _require_complete_replay_manifest(
         raise ConfigurationError(
             f"unable to produce complete replay manifest: {message}"
         ) from exc
+
+
+def _remove_empty_run_reservation(path: Path) -> None:
+    """Remove only an empty failed-run reservation; never clean recursively."""
+
+    try:
+        path.rmdir()
+    except OSError:
+        pass
 
 
 def _warn_legacy_source_binding(manifest: ReplayManifest) -> None:

--- a/agentcheck/gate.py
+++ b/agentcheck/gate.py
@@ -105,13 +105,12 @@ class GateResult:
 
 
 def gate_error_result(message: str) -> GateResult:
-    """A gate answer for a run that never started.
+    """A gate answer when execution produced no certifiable result.
 
-    A suite that failed to load or a target that no longer matches it stops
-    before any scenario executes, so there is no run and no report. That is
-    still an answer to the release question -- the strongest one available is
-    "not certifiable" -- and a caller reading `--json` needs it as a document
-    rather than as an empty stdout it has to parse.
+    The failure may occur before workers or after they finish but before the
+    required evidence is complete. Either way there is no trusted run or
+    report. The strongest answer available is "not certifiable", and a caller
+    reading `--json` needs it as a document rather than as empty stdout.
 
     `counts` is deliberately empty rather than zeroed. Zeros would read as
     "nothing failed", which is a claim this run is in no position to make.
@@ -122,7 +121,7 @@ def gate_error_result(message: str) -> GateResult:
         exit_code=EXIT_NOT_CERTIFIABLE,
         reason=message,
         detail=(
-            "the suite did not execute, so no behavioural claim is made",
+            "no certifiable result was produced, so no behavioural claim is made",
             "this is not recorded as a behavioural regression",
         ),
         summary_block="",

--- a/tests/agentcheck/test_replay_completeness.py
+++ b/tests/agentcheck/test_replay_completeness.py
@@ -78,7 +78,7 @@ def _require_replay(
     *,
     run_id: str = "complete-replay",
 ) -> Path:
-    return application._require_complete_replay_manifest(
+    return application._emit_replay_manifest(
         root=root,
         config=AgentCheckConfig(),
         spec=_stub_spec(),  # type: ignore[arg-type]
@@ -199,13 +199,12 @@ def test_forced_replay_write_failure_leaves_no_loadable_or_baselineable_run(
 
     run_path = target / ".agentcheck" / "runs" / run_id
     replay_path = target / ".agentcheck" / "replay" / f"{run_id}.json"
-    assert run_path.is_dir()
-    assert tuple(run_path.iterdir()) == ()
+    assert run_path.exists() is False
     assert replay_path.exists() is False
     assert persisted is False
-    with pytest.raises(ConfigurationError, match="missing required artifact"):
+    with pytest.raises(ConfigurationError, match="run artifacts were not found"):
         load_stored_run(target, run_id=run_id, latest=False)
-    with pytest.raises(ConfigurationError, match="missing required artifact"):
+    with pytest.raises(ConfigurationError, match="run artifacts were not found"):
         create_baseline(target, run_id=run_id)
     assert not (target / "agentcheck-baseline.json").exists()
 

--- a/tests/agentcheck/test_replay_completeness.py
+++ b/tests/agentcheck/test_replay_completeness.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import agentcheck.application as application
+import agentcheck.cli as cli
+from agentcheck.baseline.service import create_baseline
+from agentcheck.config import AgentCheckConfig
+from agentcheck.errors import ConfigurationError, InfrastructureError
+from agentcheck.gate import EXIT_NOT_CERTIFIABLE, GateDecision, run_gate
+from agentcheck.generate.templates import build_account_support_suite
+from agentcheck.replay import (
+    ReplayManifest,
+    SourceFileEntry,
+    SourceFileSet,
+    build_replay_manifest,
+    load_replay_manifest,
+)
+from agentcheck.replay.fileset import SourceSnapshot
+from agentcheck.report import load_stored_run
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+EXAMPLE = REPOSITORY_ROOT / "examples" / "evaluation" / "account_agent"
+SECRET = "sk-thisisafakesecretvalue12"
+
+
+def _copy_example(tmp_path: Path) -> Path:
+    target = tmp_path / "account_agent"
+    shutil.copytree(EXAMPLE, target, symlinks=False)
+    return target
+
+
+def _stub_spec() -> SimpleNamespace:
+    return SimpleNamespace(
+        spec_id="agentspec-replay-completeness",
+        identity=SimpleNamespace(
+            framework=SimpleNamespace(value="openai_agents"),
+            framework_version=SimpleNamespace(value="0.20.0"),
+        ),
+    )
+
+
+def _source_snapshot() -> SourceSnapshot:
+    digest = "sha256:" + "a" * 64
+    file_set = SourceFileSet(
+        mode="local_files",
+        complete=True,
+        files=(SourceFileEntry(path="agent.py", digest=digest),),
+    )
+    return SourceSnapshot(
+        git_revision=None,
+        entrypoint_path="agent.py",
+        entrypoint_digest=digest,
+        file_set=file_set,
+        commit_bindable=False,
+        commit_unbound_paths=("agent.py",),
+    )
+
+
+def _taint(scenario_index: int) -> Any:
+    scenario = build_account_support_suite(seed=1729)[scenario_index]
+    payload = json.loads(scenario.model_dump_json())
+    payload["conversation_turns"][0]["content"] = SECRET
+    payload["fingerprint"] = ""
+    return type(scenario).model_validate_json(json.dumps(payload))
+
+
+def _require_replay(
+    root: Path,
+    scenarios: tuple[Any, ...],
+    *,
+    run_id: str = "complete-replay",
+) -> Path:
+    return application._require_complete_replay_manifest(
+        root=root,
+        config=AgentCheckConfig(),
+        spec=_stub_spec(),  # type: ignore[arg-type]
+        run_id=run_id,
+        seed=1729,
+        scenarios=scenarios,
+        source_snapshot=_source_snapshot(),
+        policy_pack_ids=(),
+    )
+
+
+def test_complete_replay_uses_the_initial_snapshot_and_every_case(
+    tmp_path: Path,
+) -> None:
+    scenarios = tuple(build_account_support_suite(seed=1729)[:2])
+
+    replay_path = _require_replay(tmp_path, scenarios)
+    manifest = load_replay_manifest(
+        tmp_path,
+        replay_path.relative_to(tmp_path).as_posix(),
+    )
+
+    assert manifest.omitted == ()
+    assert tuple(
+        (scenario.scenario_id, scenario.fingerprint) for scenario in manifest.cases
+    ) == tuple((scenario.scenario_id, scenario.fingerprint) for scenario in scenarios)
+    assert manifest.source_binding.entrypoint_digest == _source_snapshot().entrypoint_digest
+    assert manifest.source_binding.file_set == _source_snapshot().file_set
+
+
+@pytest.mark.parametrize("include_clean_case", [False, True])
+def test_secret_omissions_refuse_before_any_replay_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    include_clean_case: bool,
+) -> None:
+    suite = build_account_support_suite(seed=1729)
+    scenarios = ((_taint(1),) if not include_clean_case else (suite[0], _taint(1)))
+    writer_called = False
+
+    def record_write(*_args: object, **_kwargs: object) -> Path:
+        nonlocal writer_called
+        writer_called = True
+        return tmp_path / "unexpected.json"
+
+    monkeypatch.setattr(application, "write_replay_manifest", record_write)
+
+    with pytest.raises(ConfigurationError, match="complete replay manifest") as exc_info:
+        _require_replay(tmp_path, scenarios)
+
+    assert writer_called is False
+    assert SECRET not in str(exc_info.value)
+    assert not (tmp_path / ".agentcheck").exists()
+
+
+def test_case_mismatch_refuses_even_when_builder_reports_no_omissions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenarios = tuple(build_account_support_suite(seed=1729)[:2])
+    real_builder = application.build_replay_manifest
+    writer_called = False
+
+    def incomplete_builder(**kwargs: Any) -> tuple[ReplayManifest | None, tuple[Any, ...]]:
+        kwargs["scenarios"] = kwargs["scenarios"][:1]
+        return real_builder(**kwargs)
+
+    def record_write(*_args: object, **_kwargs: object) -> Path:
+        nonlocal writer_called
+        writer_called = True
+        return tmp_path / "unexpected.json"
+
+    monkeypatch.setattr(application, "build_replay_manifest", incomplete_builder)
+    monkeypatch.setattr(application, "write_replay_manifest", record_write)
+
+    with pytest.raises(ConfigurationError, match="exactly once"):
+        _require_replay(tmp_path, scenarios)
+
+    assert writer_called is False
+
+
+def test_unexpected_replay_failure_is_redacted_and_propagated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def explode(**_kwargs: Any) -> Any:
+        raise RuntimeError(f"writer exposed {SECRET}")
+
+    monkeypatch.setattr(application, "build_replay_manifest", explode)
+
+    with pytest.raises(ConfigurationError, match="unable to produce") as exc_info:
+        _require_replay(tmp_path, (build_account_support_suite(seed=1729)[0],))
+
+    assert SECRET not in str(exc_info.value)
+    assert "[REDACTED]" in str(exc_info.value)
+
+
+def test_forced_replay_write_failure_leaves_no_loadable_or_baselineable_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _copy_example(tmp_path)
+    run_id = "forced-replay-write-failure"
+    persisted = False
+
+    def fail_replay_write(*_args: object, **_kwargs: object) -> Path:
+        raise ConfigurationError("forced replay write failure")
+
+    def record_persist(*_args: object, **_kwargs: object) -> None:
+        nonlocal persisted
+        persisted = True
+
+    monkeypatch.setattr(application, "write_replay_manifest", fail_replay_write)
+    monkeypatch.setattr(application, "_persist_execution", record_persist)
+
+    with pytest.raises(ConfigurationError, match="forced replay write failure"):
+        run_gate(target, run_id=run_id, persist_store=True)
+
+    run_path = target / ".agentcheck" / "runs" / run_id
+    replay_path = target / ".agentcheck" / "replay" / f"{run_id}.json"
+    assert run_path.is_dir()
+    assert tuple(run_path.iterdir()) == ()
+    assert replay_path.exists() is False
+    assert persisted is False
+    with pytest.raises(ConfigurationError, match="missing required artifact"):
+        load_stored_run(target, run_id=run_id, latest=False)
+    with pytest.raises(ConfigurationError, match="missing required artifact"):
+        create_baseline(target, run_id=run_id)
+    assert not (target / "agentcheck-baseline.json").exists()
+
+
+def test_run_id_collision_precedes_workers_and_preserves_prior_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _copy_example(tmp_path)
+    run_id = "existing-run"
+    run_path = target / ".agentcheck" / "runs" / run_id
+    replay_path = target / ".agentcheck" / "replay" / f"{run_id}.json"
+    run_path.mkdir(parents=True)
+    replay_path.parent.mkdir(parents=True)
+    replay_path.write_bytes(b"prior replay evidence\n")
+    prior_replay = replay_path.read_bytes()
+
+    def worker_must_not_run(*_args: object, **_kwargs: object) -> Any:
+        raise AssertionError("scenario worker ran after a run-ID collision")
+
+    monkeypatch.setattr(application, "run_scenario_in_subprocess", worker_must_not_run)
+
+    with pytest.raises(InfrastructureError, match="unable to create run artifact"):
+        application.execute_suite(target, run_id=run_id, persist_store=False)
+
+    assert replay_path.read_bytes() == prior_replay
+    assert tuple(run_path.iterdir()) == ()
+
+
+def test_gate_json_reports_no_certifiable_result_after_late_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_gate(*_args: object, **_kwargs: object) -> Any:
+        raise ConfigurationError("forced replay write failure")
+
+    monkeypatch.setattr(cli, "run_gate", fail_gate)
+
+    exit_code = cli._gate_command(
+        str(tmp_path),
+        baseline=None,
+        seed=None,
+        run_id="late-failure",
+        persist_store=False,
+        as_json=True,
+        python_executable=None,
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == EXIT_NOT_CERTIFIABLE
+    assert payload["decision"] == GateDecision.BLOCK
+    assert payload["counts"] == {}
+    assert any("no certifiable result" in item for item in payload["detail"])
+    assert "suite did not execute" not in captured.out
+
+
+def test_test_cli_redacts_replay_failure_and_exits_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_execution(*_args: object, **_kwargs: object) -> Any:
+        raise ConfigurationError(f"writer exposed {SECRET}")
+
+    monkeypatch.setattr(cli, "execute_suite", fail_execution)
+
+    assert cli.main(["test", str(tmp_path), "--run-id", "late-failure"]) == 2
+    captured = capsys.readouterr()
+    assert SECRET not in captured.err
+    assert "[REDACTED]" in captured.err
+
+
+def test_lower_level_partial_manifest_contract_remains_readable() -> None:
+    suite = build_account_support_suite(seed=1729)
+    manifest, omitted = build_replay_manifest(
+        run_id="legacy-partial",
+        seed=1729,
+        spec=_stub_spec(),  # type: ignore[arg-type]
+        config=AgentCheckConfig(),
+        scenarios=(suite[0], _taint(1)),
+        git_revision=None,
+        entrypoint_digest=_source_snapshot().entrypoint_digest,
+        file_set=_source_snapshot().file_set,
+    )
+
+    assert manifest is not None
+    assert len(manifest.cases) == 1
+    assert len(omitted) == 1
+    assert ReplayManifest.model_validate_json(manifest.model_dump_json()) == manifest


### PR DESCRIPTION
## Summary

- reserve the run ID before scenario workers so a collision cannot replace prior replay/run evidence
- require one complete replay case for every executed scenario after the verified post-worker SourceSnapshot check and before any trusted required run artifact is written
- propagate replay `ConfigurationError`, redact unexpected replay failures, and return no successful fresh `SuiteExecution` without a replay path
- preserve the established `_emit_replay_manifest` test seam and remove only an empty failed run-ID reservation; non-empty directories are never removed
- use accurate no-certifiable-result gate wording for failures that can occur after workers
- preserve lower-level partial/legacy replay manifest construction and readability

## Exact reviewed successor identity

- base: `d3d2b9b2e68259123055e5f5149e8d1e5c561f7a`
- successor commit: `1c15bab2902f3610f2c4ddad7d77a45cdf567d0a`
- successor parent: `158d75b6edd71e2150044f8463446406a0183a03`
- successor tree: `d8bfb0792f047db92525a5f338a7fe18e2bb6eab`
- reviewed three-file SHA-256 aggregate: `98e558b293a2eb8c7e80ff0b8031b825c1f4c69321d45bb2cff902273422d4e4`
- scope: `agentcheck/application.py`, `agentcheck/gate.py`, and `tests/agentcheck/test_replay_completeness.py` only

## Evidence

- current-main forced replay-writer negative: 12 PASS, gate pass/exit 0, no replay, stored run loadable 12/12/12
- original PR-head CI negative: run `33400966826`, Python 3.12 job `99516924419` failed 4, passed 1714, skipped 1; Required CI `99535155688` failed closed
- the four failures were the three source-certification reservation-absence compatibility nodes and the clean-execution `_emit_replay_manifest` seam node
- exact-four pre-fix reproduction: 4 failed; exact-four final successor bytes: 4 passed in 0.74s
- focused Slice 2 final successor bytes: 10 passed in 25.95s
- final successor bytes: Ruff, scoped mypy, `py_compile`, repository secret scan, and `git diff --check` passed
- fresh sequential independent review of exact successor aggregate: READY, 9 passed in 76.10s, no finding
- successor review report SHA-256: `1c4556c88e46a2262e447139a5e71b395a2ab78c3676c0ddfe93929a049cd84c`
- exact-successor dependency run `33408737920`, job `99542738872`: SUCCESS
- exact-successor CI run `33408737924`: classifier `99542740038`, Python 3.10 `99542779101`, Python 3.11 `99542779057`, Python 3.12 `99542779113`, quality/package/workflow trust `99542779102`, and Required CI `99560395265` all completed SUCCESS

The earlier failing hosted run applies to the superseded parent bytes. No exhaustive local suite was rerun because the exact-successor hosted Python 3.12 job owns that full-suite evidence. One earlier integration test passed before the final no-op wrapper removal and is not claimed as final-byte evidence.

## NOT PROVEN / out of scope

Merge, exact-main integration, and release readiness are not proven. This PR does not establish a completion-marker/schema contract, all-artifact transactionality, persisted certification policy fields, commit bindability in gate output, hostile filesystem immutability, ABA resistance, exhaustive dependency closure, or provider/process containment.
