### PR TITLE
Fix the copyable AgentCheck CI template

### DIFF
--- a/.github/workflows/agentcheck-example.yml
+++ b/.github/workflows/agentcheck-example.yml
@@ -2,21 +2,23 @@
 #
 # Copy this workflow into a repository that has an AgentCheck target, then:
 #   1. Set AGENTCHECK_TARGET to that directory (often ".").
-#   2. Commit a trusted baseline produced by an explicit command, not by a
+#   2. Replace the target-dependency step with your repository's own locked
+#      install. AgentCheck's adapter extras install one supported SDK; they do
+#      not install the rest of an arbitrary target application's dependencies.
+#   3. Commit a trusted baseline produced by an explicit command, not by a
 #      failing CI run:
 #         agentcheck test "$AGENTCHECK_TARGET" --no-store
 #         agentcheck baseline create "$AGENTCHECK_TARGET" --latest --out agentcheck-baseline.json
-#   3. Enable pull_request/push triggers if you want this on every change.
+#   4. Enable pull_request/push triggers if you want this on every change.
 #
 # This workflow does not call a hosted AgentCheck service, does not use the
-# GitHub API, and does not supply provider credentials. It fails only on new
-# or changed authoritative FAIL identities, not on historical failures and
-# not on INCONCLUSIVE.
+# GitHub API, and does not supply provider credentials. `agentcheck gate` is
+# the sole decision authority: the YAML does not reinterpret its exit status.
 #
 # This repository is not itself an AgentCheck target at its root. The default
 # below points at the bundled deterministic example. There is no committed
-# example baseline here; workflow_dispatch will exit 2 until you create one
-# locally or in a consuming project.
+# example baseline here. Without a baseline, all-PASS can exit 0, any FAIL
+# exits 1, and INCONCLUSIVE exits 3; baseline absence alone is not exit 2.
 
 # Runner note: this workflow is deliberately GitHub-hosted so the copied
 # template does not expose a personal runner to pull-request code. It is
@@ -57,27 +59,38 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
       - name: Install AgentCheck
         run: |
           python -m pip install --upgrade "pip==26.1.2" "setuptools==83.0.0"
-          python -m pip install ".[openai-agents]"
+          python -m pip install "agentcheck-ai==0.5.2"
+          agentcheck --version
+
+      - name: Install target dependencies
+        # This repository's bundled example imports the OpenAI Agents SDK.
+        # Replace this step in a consuming repository with that target's own
+        # locked dependency install. For an OpenAI or PydanticAI target, the
+        # corresponding exact AgentCheck extra is a convenient SDK install:
+        #   agentcheck-ai[openai-agents]==0.5.2
+        #   agentcheck-ai[pydantic-ai]==0.5.2
+        # Custom targets use the base package plus their own dependencies.
+        run: |
+          python -m pip install "openai-agents>=0.20,<0.23" "websockets>=15,<16"
 
       - name: Gate the change on agent behaviour
         # One command for the whole flow: run the frozen suite, compare it to
         # the trusted baseline, and return one status.
         #
-        #   0  no new behavioural failure -- historical failures the baseline
-        #      already accepts do not block
-        #   1  a behavioural failure is new against the baseline
-        #   2  the run is not certifiable (infrastructure, or a suite / source /
-        #      baseline mismatch). Deliberately not reported as a regression:
-        #      a suite that could not execute has not said anything about the
-        #      agent, and calling that a behavioural result is how a broken
-        #      harness becomes a green build.
-        #   3  the suite could not decide. Never treated as a pass.
+        #   0  allow: no new behavioural failure against a trusted baseline;
+        #      without one, every case passed. Accepted historical failures
+        #      may pass only when the current run is otherwise certifiable.
+        #   1  block: a behavioural failure is new against the baseline; without
+        #      one, any behavioural failure blocks.
+        #   2  block: the run or comparison is not certifiable (infrastructure,
+        #      incomplete execution evidence, or a suite/source/baseline
+        #      mismatch). A missing baseline by itself does not force exit 2.
+        #   3  block: the available evidence is INCONCLUSIVE. AgentCheck 0.5.2
+        #      does not let a baseline turn missing current evidence into PASS.
         run: |
           agentcheck gate "$AGENTCHECK_TARGET" \
             --baseline "$AGENTCHECK_BASELINE" \

--- a/tests/agentcheck/test_workflow_safety.py
+++ b/tests/agentcheck/test_workflow_safety.py
@@ -14,6 +14,7 @@ import yaml
 
 REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[2]
 WORKFLOWS = REPOSITORY_ROOT / ".github" / "workflows"
+AGENTCHECK_EXAMPLE = WORKFLOWS / "agentcheck-example.yml"
 TRUST_MODEL_DOC = REPOSITORY_ROOT / "docs" / "ci-trust-model.md"
 FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 
@@ -156,6 +157,75 @@ def test_process_heavy_pytest_commands_are_serial_on_hosted_runners() -> None:
     ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     assert "tests -q -n 1" in ci
     assert '"${compat[@]}" -q -n 1' in ci
+
+
+def test_agentcheck_example_installs_the_exact_public_distribution() -> None:
+    workflow = _load(AGENTCHECK_EXAMPLE)
+    steps = workflow["jobs"]["regression-gate"]["steps"]
+    install = next(step for step in steps if step.get("name") == "Install AgentCheck")
+    script = install["run"]
+
+    assert 'python -m pip install "agentcheck-ai==0.5.2"' in script
+    assert "agentcheck --version" in script
+    assert 'pip install ".' not in script
+    assert "pyproject.toml" not in script
+
+
+def test_agentcheck_example_is_safe_without_consumer_cache_metadata() -> None:
+    workflow = _load(AGENTCHECK_EXAMPLE)
+    steps = workflow["jobs"]["regression-gate"]["steps"]
+    setup = next(step for step in steps if step.get("name") == "Set up Python")
+
+    assert setup["with"] == {"python-version": "3.12"}
+    assert "cache" not in setup["with"]
+    assert "cache-dependency-path" not in setup["with"]
+
+
+def test_agentcheck_example_separates_target_dependencies_from_the_evaluator() -> None:
+    workflow = _load(AGENTCHECK_EXAMPLE)
+    steps = workflow["jobs"]["regression-gate"]["steps"]
+    evaluator_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Install AgentCheck"
+    )
+    target_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Install target dependencies"
+    )
+    target_step = steps[target_index]
+    text = AGENTCHECK_EXAMPLE.read_text(encoding="utf-8")
+    prose = " ".join(line.lstrip("# ").strip() for line in text.splitlines())
+
+    assert evaluator_index < target_index
+    assert '"openai-agents>=0.20,<0.23"' in target_step["run"]
+    assert '"websockets>=15,<16"' in target_step["run"]
+    assert "replace this step" in prose.lower()
+    assert "do not install the rest of an arbitrary target" in prose.lower()
+    assert "agentcheck-ai[pydantic-ai]==0.5.2" in text
+    assert "custom targets use the base package plus their own dependencies" in prose.lower()
+
+
+def test_agentcheck_example_leaves_the_decision_to_gate() -> None:
+    workflow = _load(AGENTCHECK_EXAMPLE)
+    steps = workflow["jobs"]["regression-gate"]["steps"]
+    commands = "\n".join(
+        str(step.get("run", "")) for step in steps if isinstance(step, dict)
+    )
+    text = AGENTCHECK_EXAMPLE.read_text(encoding="utf-8")
+
+    assert commands.count("agentcheck gate") == 1
+    assert "agentcheck baseline check" not in commands
+    assert "continue-on-error" not in text
+    assert "sole decision authority" in text
+    for required in (
+        "0  allow:",
+        "1  block:",
+        "2  block:",
+        "3  block:",
+        "A missing baseline by itself does not force exit 2.",
+        "does not let a baseline turn missing current evidence into PASS",
+    ):
+        assert required in text
 
 
 def test_dependabot_preserves_supported_python_dependency_ranges() -> None:


### PR DESCRIPTION
## Summary

- install the exact public evaluator, `agentcheck-ai==0.5.2`, instead of the consuming repository's local project
- keep target dependencies in a separate, explicit step and explain that one adapter extra does not install an arbitrary target application's dependency set
- omit `setup-python` pip caching so repositories without a root lock file or `pyproject.toml` remain valid consumers
- document the fail-closed 0/1/2/3 gate and no-baseline behavior while leaving `agentcheck gate` as the sole decision authority
- add focused static regressions for the prior install, dependency, cache-path, and YAML-exit-semantics defects

## Validation

- `python -m pytest -p no:cacheprovider tests/agentcheck/test_workflow_safety.py -q` — 21 passed
- `python -m ruff check tests/agentcheck/test_workflow_safety.py` — passed
- `python scripts/check_workflow_safety.py` — passed (8 hosted, read-only, secret-free, environment-free, SHA-pinned jobs)
- `python scripts/check_no_secrets.py` — passed
- YAML parse, `py_compile`, `git diff --check`, exact two-file scope, and commit checks — passed

### Public-artifact consumer proof

A disposable Python 3.12 consumer repository contained only tracked `target/agent.py` and `target/agentcheck.json`; it had no root `pyproject.toml`, requirements file, or lock file. Using public PyPI with cache and extra-index configuration disabled:

- exact downloaded wheel SHA-256: `b99e56e910dc0d5bc27b3e4d39bec0e20a6b6c64bbb005727e2f1163cf925c94`
- distribution metadata, import, and CLI all reported `agentcheck-ai` / `agentcheck` 0.5.2 from the disposable venv's `site-packages`
- the target-dependency command separately resolved `openai-agents==0.22.0` and `websockets==15.0.1`; `pip check` passed
- no OpenAI, Anthropic, or Google provider credential was present
- `agentcheck gate target --baseline agentcheck-baseline.json --run-id consumer-proof-052 --json` correctly returned exit 1 and `block` for the deliberately flawed target: 7 PASS, 5 FAIL, no INCONCLUSIVE, no INFRA_ERROR, and no baseline comparison

The nonzero gate result is expected evidence that the copied workflow preserves AgentCheck's decision instead of forcing a green build.

## Boundaries and limitations

- The bundled command installs dependencies for the bundled OpenAI example only. Consumers must replace that step with their target's locked dependencies; this does not claim universal framework or application compatibility.
- The artifact proof exercises the public 0.5.2 wheel on Python 3.12. It does not repeat the already-independent full publication/sdist verification or the hosted Python matrix.
- The example remains `workflow_dispatch`-only and intentionally has no committed trusted baseline.
- No runtime, adapter, containment, release, tag, package, or README adoption surface changes here.
- Do not merge before one fresh sequential independent review of this exact head and terminal hosted CI.
