### PR TITLE
Clarify OpenAI SandboxAgent refusal boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,17 @@ closed as `INFRA_ERROR`; AgentCheck does not invent a plausible tool result.
 | PydanticAI | `agentcheck-ai[pydantic-ai]` | [Setup and offline evaluation](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/pydantic-ai.md) |
 | Custom Python agents | `agentcheck-ai` | [Integration contract](https://github.com/WaseemGhanem98/AgentCheck/blob/main/docs/custom-agents.md) |
 
-The native adapters are pinned to verified SDK minor versions and reject
-unsupported versions rather than guessing. Custom Python support is a lightweight
-integration contract: the target declares inert tools and routes declared calls
-through the AgentCheck-supplied `ToolRuntime`. It is not universal framework
-support.
+The OpenAI Agents SDK native adapter supports SDK 0.20–0.22 only for exact
+ordinary `agents.Agent` targets whose exact `FunctionTool` tools can be safely
+replaced and observed through `ToolGateway`. SDK 0.22 `SandboxAgent` targets are
+refused for behavioral evaluation: their runtime-materialized sandbox capability
+surface is outside that replaceable/observed contract. The refusal happens at the
+agent-type boundary; AgentCheck does not enumerate those capabilities.
+
+The native adapters reject unsupported SDK versions rather than guessing. Custom
+Python support is a lightweight integration contract: the target declares inert
+tools and routes declared calls through the AgentCheck-supplied `ToolRuntime`. It
+is not universal framework support.
 
 ## Safety boundaries
 

--- a/agentcheck/adapters/openai_agents.py
+++ b/agentcheck/adapters/openai_agents.py
@@ -2492,21 +2492,33 @@ class OpenAIAgentsAdapter(FrameworkAdapter):
                 )
             )
         if type(target) is not Agent:
+            target_type = type(target)
+            is_sdk_sandbox_agent = (
+                target_type.__module__ == "agents.sandbox.sandbox_agent"
+                and target_type.__name__ == "SandboxAgent"
+            )
             guess = guess_other_adapter(target)
             suggestion = (
-                f" The configured entrypoint resolved to {type(target).__module__}."
-                f"{type(target).__name__}, which looks like a {guess!r} target; "
+                f" The configured entrypoint resolved to {target_type.__module__}."
+                f"{target_type.__name__}, which looks like a {guess!r} target; "
                 f'set "adapter": {guess!r} in agentcheck.json instead.'
                 if guess is not None and guess != FRAMEWORK_NAME
                 else ""
             )
+            message = "Phase 1 requires an exact agents.Agent instance." + suggestion
+            if is_sdk_sandbox_agent:
+                message = (
+                    "Behavioral execution is not authorized for SDK SandboxAgent "
+                    "targets because their runtime-materialized sandbox capability "
+                    "surface is outside this adapter's safely replaceable and observed "
+                    "exact FunctionTool contract. Use an exact ordinary agents.Agent "
+                    "target with exact FunctionTool tools."
+                )
             issues.append(
                 SupportIssue(
                     code="unsupported_agent_type",
-                    message=(
-                        "Phase 1 requires an exact agents.Agent instance." + suggestion
-                    ),
-                    location=type(target).__name__,
+                    message=message,
+                    location=target_type.__name__,
                 )
             )
             return PreflightReport(framework=FRAMEWORK_NAME, issues=tuple(issues))

--- a/tests/agentcheck/test_openai_adapter.py
+++ b/tests/agentcheck/test_openai_adapter.py
@@ -12,6 +12,7 @@ from agents.handoffs import Handoff
 from agents.items import ModelResponse, TResponseInputItem, TResponseStreamEvent
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
+from agents.sandbox import SandboxAgent
 from agents.tool import Tool
 from agents.usage import Usage
 from openai.types.responses import (
@@ -435,6 +436,70 @@ def test_unsupported_tool_fails_preflight_before_model_execution() -> None:
     with pytest.raises(UnsupportedTargetError):
         adapter.prepare(agent, RecordingGateway())
     assert model.calls == 0
+
+
+def test_sandbox_agent_is_refused_at_the_replaceable_tool_boundary() -> None:
+    tripwire = {"called": False}
+
+    @function_tool
+    def declared_write(value: str) -> str:
+        """Write one value."""
+
+        tripwire["called"] = True
+        raise AssertionError("the original live handler was invoked")
+
+    sandbox_model = ScriptedModel([[_message("must not run")]])
+    sandbox_agent = SandboxAgent(
+        name="Sandbox target",
+        instructions="Write one value.",
+        tools=[declared_write],
+        model=sandbox_model,
+    )
+    adapter = OpenAIAgentsAdapter()
+
+    report = adapter.preflight(sandbox_agent)
+
+    assert report.supported is False
+    issue = next(issue for issue in report.issues if issue.code == "unsupported_agent_type")
+    assert issue.location == "SandboxAgent"
+    assert "Behavioral execution is not authorized for SDK SandboxAgent" in issue.message
+    assert "runtime-materialized sandbox capability surface" in issue.message
+    assert "safely replaceable and observed exact FunctionTool contract" in issue.message
+    with pytest.raises(UnsupportedTargetError) as exc_info:
+        adapter.prepare(sandbox_agent, RecordingGateway())
+    assert tuple(exc_info.value.issues) == report.issues
+    assert sandbox_model.calls == 0
+    assert tripwire["called"] is False
+
+    ordinary_model = ScriptedModel(
+        [
+            [_tool_call("declared_write", {"value": "simulated"}, "call-1")],
+            [_message("done")],
+        ]
+    )
+    ordinary_agent = Agent(
+        name="Ordinary target",
+        instructions="Write one value.",
+        tools=[declared_write],
+        model=ordinary_model,
+    )
+    gateway = RecordingGateway(result={"simulated": True})
+
+    assert adapter.preflight(ordinary_agent).supported is True
+    prepared = adapter.prepare(ordinary_agent, gateway)
+    run = asyncio.run(
+        adapter.run(
+            prepared,
+            "Write one value.",
+            run_id="ordinary-control",
+            max_turns=3,
+        )
+    )
+
+    assert gateway.calls == [("declared_write", {"value": "simulated"}, None)]
+    assert run.termination is RunTermination.COMPLETED
+    assert ordinary_model.calls == 2
+    assert tripwire["called"] is False
 
 
 def test_an_unsupported_sdk_version_is_named() -> None:


### PR DESCRIPTION
## Summary

- clarify that OpenAI Agents SDK 0.20–0.22 support covers exact ordinary `agents.Agent` targets with exact, safely replaceable `FunctionTool` surfaces
- keep the existing `unsupported_agent_type` exact-type refusal, while making the SDK `SandboxAgent` diagnostic explain that behavioral execution is not authorized because its runtime-materialized sandbox capability surface is outside the adapter's replaceable/observed contract
- add one focused regression proving `SandboxAgent` is refused before model or original-handler execution while an exact ordinary `Agent` remains supported through `ToolGateway`

## Evidence boundary

AC-P0-8 independently classified this as a category-B documentation/UX gap, not a fail-open defect. Public 0.5.2 and base `main@6b631f426dbe8aae2828a74e1151d9e783a5c1bb` already refused SDK 0.22 `SandboxAgent` before `AgentSpec`, model, or run execution; gate blocked with exit 2 and empty counts. This PR preserves that behavior and reason code.

This does not inspect or enumerate SandboxAgent capabilities, widen the adapter, add a sandbox or `EnvironmentProvider`, claim hostile containment, or authorize SandboxAgent behavioral evidence.

## Focused validation

- 3 focused OpenAI adapter tests passed (new boundary regression plus adjacent unsupported-tool and original-handler controls)
- candidate code passed scoped Ruff, mypy, `py_compile`, `git diff --check`, and the repository secret scan
- 2 focused public README/safety consistency tests passed
- frozen reproducer `6a81c290f09842175ed726715f8ab2b28ded11e3` under exact `openai-agents==0.22.0` reproduced the new `unsupported_agent_type` message with zero SandboxAgent model calls; the ordinary Agent control completed through `ToolGateway` with no original-handler tripwire

No full suite was run locally. Hosted CI should run the exhaustive suite once on this exact commit.
