### PR TITLE
Register inert maintained-runtime smoke workflow

### DIFF
--- a/.github/workflows/maintained-runtime-smoke.yml
+++ b/.github/workflows/maintained-runtime-smoke.yml
@@ -1,0 +1,27 @@
+# Inert registration candidate only. If independently reviewed and later
+# accepted on the default branch, this path enables workflow_dispatch to select
+# a separately reviewed full workflow revision by exact ref. This bootstrap
+# itself never performs the smoke.
+
+name: Maintained runtime harmless smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  registration-only:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      contents: none
+    steps:
+      - name: Refuse execution of the inert bootstrap
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "This inert default-branch registration does not run the smoke." >&2
+          echo "Select a separately reviewed full workflow revision by exact ref." >&2
+          exit 1


### PR DESCRIPTION
## Summary

- register the future maintained-runtime smoke workflow path on the default branch
- keep the registered workflow inert: manual-only, actionless, checkout-free, and always fail closed
- perform no Docker, gVisor, AgentCheck, provider, credential, or repository-content operation

## Why

GitHub requires a workflow_dispatch workflow to exist on the default branch before an exact feature-branch ref can be selected. This PR adds only the independently reviewed inert registration bytes; it does not add or run the later smoke.

## Validation

- 24 workflow-safety tests passed
- repository workflow-safety checker passed across all jobs
- YAML and extracted Bash validation passed
- secret, diff, scope, blob, and file-hash checks passed
- independent exact-tree review: READY for this push/PR lifecycle

## Boundaries

- no workflow dispatch is requested
- no runtime or containment result is claimed
- hosted Docker/gVisor interoperability, hostile M2, actionlint, and shellcheck remain NOT PROVEN