### PR TITLE
Fix generation refusal on redaction-lossy descriptions

### DIFF
--- a/agentcheck/generate/boundaries.py
+++ b/agentcheck/generate/boundaries.py
@@ -51,6 +51,7 @@ from agentcheck.inspect.capabilities import (
     JsonSchemaType,
     extract_capabilities,
 )
+from agentcheck.privacy import redact_log_text
 from agentcheck.schema_safety import offline_validator
 
 
@@ -747,7 +748,17 @@ def _positive_request(tool: ToolDefinition, arguments: JsonObject) -> str:
     only way the resulting trajectory says anything about the agent.
     """
 
-    action = (tool.description or "").strip() or f"Please {_humanise(tool.name)}."
+    description = (tool.description or "").strip()
+    # A declared description can contain credential-shaped text even when the
+    # tool schema itself is safe. Copying that text into a generated request
+    # makes the artifact boundary reject the entire suite. Never redact in
+    # place (that would change the declaration's meaning and fingerprint);
+    # omit the lossy description and use the existing tool-name fallback.
+    action = (
+        description
+        if description and redact_log_text(description) == description
+        else f"Please {_humanise(tool.name)}."
+    )
     if not action.endswith((".", "!", "?")):
         action = f"{action}."
     if not arguments:

--- a/agentcheck/generate/boundaries.py
+++ b/agentcheck/generate/boundaries.py
@@ -72,6 +72,11 @@ _UNEXPECTED_PROPERTY = "agentcheck_unexpected_property"
 
 _MAX_SCENARIO_ID = 150
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+_IDENTIFIER_TAXONOMY_BULLET_RE = re.compile(
+    r"^\s*[-*+]\s+[^:=\r\n]*/[^:=\r\n]+:\s*"
+    r"(?P<items>(?P<first>(?:[a-z][a-z0-9_]{0,63}|\+\d{1,4}))"
+    r"(?:\s*,\s*(?:[a-z][a-z0-9_]{0,63}|\+\d{1,4})){2,})\s*$"
+)
 
 # Keywords the extractor reports but this slice deliberately does not invert.
 _UNSUPPORTED_KEYWORDS = (
@@ -738,6 +743,43 @@ def _render_value(value: JsonValue) -> str:
     return json.dumps(value, ensure_ascii=False, allow_nan=False, sort_keys=True)
 
 
+def _description_for_positive_request(description: str) -> str:
+    """Omit only lossy Markdown taxonomy lines, or preserve refusal unchanged.
+
+    A slash-delimited category followed by three or more comma-separated
+    identifiers is documentation vocabulary, not a standalone credential
+    assignment. The structure is deliberately narrow: if any lossy line does
+    not have that complete shape, return the original description so the
+    frozen-suite secret check still rejects it. At least one safe line must
+    remain, because falling back to a generic tool name can erase the action
+    semantics that make a positive case useful.
+    """
+
+    if redact_log_text(description) == description:
+        return description
+    kept: list[str] = []
+    removed = False
+    for line in description.splitlines():
+        if redact_log_text(line) == line:
+            kept.append(line)
+            continue
+        match = _IDENTIFIER_TAXONOMY_BULLET_RE.fullmatch(line)
+        if match is not None:
+            identifiers = re.split(r"\s*,\s*", match.group("items"))
+            first_start, first_end = match.span("first")
+            expected = f"{line[:first_start]}[REDACTED]{line[first_end:]}"
+            if all(redact_log_text(item) == item for item in identifiers) and (
+                redact_log_text(line) == expected
+            ):
+                removed = True
+                continue
+        return description
+    candidate = "\n".join(kept).strip()
+    if not removed or not candidate or redact_log_text(candidate) != candidate:
+        return description
+    return candidate
+
+
 def _positive_request(tool: ToolDefinition, arguments: JsonObject) -> str:
     """Ask for the tool's declared action and supply every required value.
 
@@ -749,14 +791,9 @@ def _positive_request(tool: ToolDefinition, arguments: JsonObject) -> str:
     """
 
     description = (tool.description or "").strip()
-    # A declared description can contain credential-shaped text even when the
-    # tool schema itself is safe. Copying that text into a generated request
-    # makes the artifact boundary reject the entire suite. Never redact in
-    # place (that would change the declaration's meaning and fingerprint);
-    # omit the lossy description and use the existing tool-name fallback.
     action = (
-        description
-        if description and redact_log_text(description) == description
+        _description_for_positive_request(description)
+        if description
         else f"Please {_humanise(tool.name)}."
     )
     if not action.endswith((".", "!", "?")):

--- a/tests/agentcheck/test_positive_path_cases.py
+++ b/tests/agentcheck/test_positive_path_cases.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from agents import Agent, function_tool
 from pydantic import BaseModel
 
 from agentcheck.adapters import OpenAIAgentsAdapter
 from agentcheck.config import AgentCheckConfig
+from agentcheck.errors import ScenarioValidationError
 from agentcheck.generate.boundaries import build_positive_path_cases
 from agentcheck.generate.suite import CaseOrigin, build_frozen_suite
 from agentcheck.privacy import redact_log_text
@@ -107,14 +109,14 @@ def test_the_request_asks_for_the_action_without_naming_the_tool_call() -> None:
     assert "Use the update_seat tool with exactly these arguments" not in content
 
 
-def test_credential_shaped_tool_description_falls_back_without_weakening_redaction() -> None:
-    """A lossy declaration must not make an otherwise safe suite unfreezable."""
+def test_credential_shaped_taxonomy_line_is_omitted_without_weakening_redaction() -> None:
+    """A descriptive identifier taxonomy must not block the whole safe suite."""
 
     @function_tool
     def add_emoji_reaction(emoji_name: str) -> str:
         """Add an emoji reaction.
 
-        Login/password: key, lock, closed_lock_with_key
+        - Login/password: key, lock, closed_lock_with_key
         """
         raise AssertionError("original handler must never run")
 
@@ -135,9 +137,59 @@ def test_credential_shaped_tool_description_falls_back_without_weakening_redacti
     )
 
     assert positive.scenario.conversation_turns[0].content.startswith(
-        "Please add emoji reaction."
+        "Add an emoji reaction."
     )
     assert literal not in positive.scenario.conversation_turns[0].content
+
+
+def test_unambiguous_secret_in_declared_description_still_refuses_suite() -> None:
+    """A safe summary must not let a genuine assignment disappear."""
+
+    @function_tool
+    def execute(order_id: str) -> str:
+        """Issue a customer refund for the supplied order. password=actual-secret-value"""
+        raise AssertionError("original handler must never run")
+
+    with pytest.raises(ScenarioValidationError, match="credential-shaped content"):
+        build_frozen_suite(_spec(execute), AgentCheckConfig(), seed=1729)
+
+
+def test_taxonomy_line_with_an_independent_secret_still_refuses_suite() -> None:
+    """A taxonomy shape must not hide a separately recognizable provider key."""
+
+    @function_tool
+    def execute(order_id: str) -> str:
+        """Issue a customer refund for the supplied order.
+
+        - Login/password: key, lock, sk-live-abcdef0123456789
+        """
+        raise AssertionError("original handler must never run")
+
+    with pytest.raises(ScenarioValidationError, match="credential-shaped content"):
+        build_frozen_suite(_spec(execute), AgentCheckConfig(), seed=1729)
+
+
+def test_taxonomy_omission_preserves_description_when_tool_name_is_generic() -> None:
+    """The safe declared action must survive removal of a taxonomy line."""
+
+    @function_tool
+    def execute(order_id: str) -> str:
+        """Issue a customer refund for the supplied order.
+
+        Example interface symbols:
+        - Login/password: key, lock, closed_lock_with_key
+        """
+        raise AssertionError("original handler must never run")
+
+    suite = build_frozen_suite(_spec(execute), AgentCheckConfig(), seed=1729)
+    positive = next(
+        case for case in suite.cases if case.lineage.origin is CaseOrigin.POSITIVE_PATH
+    )
+    content = positive.scenario.conversation_turns[0].content
+
+    assert content.startswith("Issue a customer refund for the supplied order.")
+    assert not content.startswith("Please execute.")
+    assert "Login/password" not in content
 
 
 def test_declining_to_call_is_not_a_defect() -> None:

--- a/tests/agentcheck/test_positive_path_cases.py
+++ b/tests/agentcheck/test_positive_path_cases.py
@@ -23,6 +23,7 @@ from agentcheck.adapters import OpenAIAgentsAdapter
 from agentcheck.config import AgentCheckConfig
 from agentcheck.generate.boundaries import build_positive_path_cases
 from agentcheck.generate.suite import CaseOrigin, build_frozen_suite
+from agentcheck.privacy import redact_log_text
 from agentcheck.schema_safety import offline_validator
 
 
@@ -104,6 +105,39 @@ def test_the_request_asks_for_the_action_without_naming_the_tool_call() -> None:
     # Supplies the values rather than commanding a call.
     assert "confirmation_number is" in content
     assert "Use the update_seat tool with exactly these arguments" not in content
+
+
+def test_credential_shaped_tool_description_falls_back_without_weakening_redaction() -> None:
+    """A lossy declaration must not make an otherwise safe suite unfreezable."""
+
+    @function_tool
+    def add_emoji_reaction(emoji_name: str) -> str:
+        """Add an emoji reaction.
+
+        Login/password: key, lock, closed_lock_with_key
+        """
+        raise AssertionError("original handler must never run")
+
+    literal = "Login/password: key, lock, closed_lock_with_key"
+
+    # The redaction boundary remains conservative for both the public-repo
+    # collision and an unmistakable credential assignment.
+    assert redact_log_text(literal) == (
+        "Login/password: [REDACTED], lock, closed_lock_with_key"
+    )
+    assert redact_log_text("password=actual-secret-value") == "password=[REDACTED]"
+
+    suite = build_frozen_suite(
+        _spec(add_emoji_reaction), AgentCheckConfig(), seed=1729
+    )
+    positive = next(
+        case for case in suite.cases if case.lineage.origin is CaseOrigin.POSITIVE_PATH
+    )
+
+    assert positive.scenario.conversation_turns[0].content.startswith(
+        "Please add emoji reaction."
+    )
+    assert literal not in positive.scenario.conversation_turns[0].content
 
 
 def test_declining_to_call_is_not_a_defect() -> None:


### PR DESCRIPTION
## What and why

A supported OpenAI Agents SDK 0.22 target could not freeze any generated suite because one public tool description contains the harmless emoji guidance `Login/password: key, lock, closed_lock_with_key`. The credential redactor correctly remains conservative, but copying the lossy declaration into a generated user request made the suite boundary reject the whole target.

This change keeps credential redaction unchanged. Positive-path generation omits only one narrow documentation shape: a Markdown bullet that maps a slash-delimited category to at least three bounded identifier-like examples, where the redactor performs exactly the single assignment rewrite and every identifier is independently redaction-safe. Any other lossy description remains intact and the existing frozen-suite check refuses it. Safe action text around an omitted taxonomy line is preserved instead of falling back to a possibly generic tool name.

## Safety and compatibility

- [x] Original declared tool handlers still never execute during simulated evaluation.
- [x] Unknown tools still fail closed; no plausible result is synthesized.
- [x] Worker isolation, network denial, source integrity, and verdict semantics are unchanged or explicitly reviewed.
- [x] No safety or wall-clock budget was widened.
- [x] Fingerprint, schema, protocol, and stored-artifact compatibility impact is stated.
- [x] Replay is not described as deterministic provider-output replay.

Compatibility impact: successful suites whose declarations were already redaction-safe are byte-identical. Exact base/head control: generator `1`, suite fingerprint `sha256:4477daab5844704423ade3afc1a5cc144e62afb1e054444386a9236446b7b890`, encoded suite SHA-256 `474ad4b393477ec11d24cbf908219560fa08130a819e4ac3baf258ff65d1a719`, and positive-case fingerprint `sha256:56fad92524e4f51bbbd2241e9a5d8b1fe425002341b416becef6287f443a6586` all match signed main. Affected targets previously produced no frozen suite. No generator-version, schema, or protocol change.

## Validation

- Red regression on unchanged `main`: exact Slack literal caused `ScenarioValidationError` at generated conversation content.
- Initial independent review found that the broad fallback weakened genuine-secret refusal and could erase action meaning; the successor commit adds both missing suite-level controls and narrows the rule.
- Focused generator, artifact, representative-input, outcome, and confirmation tests: 62 passed.
- Stored-suite compatibility tests: 11 passed.
- Ruff on changed files: passed.
- mypy on `agentcheck/generate/boundaries.py`: passed.
- Exact pinned target replay: `slack-samples/bolt-python-support-agent@583a0174c8f29745d6ebf08f08e2a82498eb625b`, OpenAI Agents SDK 0.22.0; inspect found 7 tools, and corrected generate wrote 44 cases with 0 rejected while preserving the safe declared action text and omitting the lossy taxonomy line. No behavioral execution was attempted.
- Provider requests: 0
- API spend: $0

Independent review is required before merge.
