### PR TITLE
Fix nullable array schema generation

### DIFF
--- a/agentcheck/inspect/capabilities.py
+++ b/agentcheck/inspect/capabilities.py
@@ -381,10 +381,12 @@ def _declared_types(schema: Mapping[str, Any]) -> tuple[JsonSchemaType, ...] | N
 
 
 def _union_branch_types(schema: Mapping[str, Any]) -> tuple[JsonSchemaType, ...] | None:
-    """Resolve the common ``anyOf``/``oneOf`` union of plain typed branches.
+    """Resolve an ``anyOf``/``oneOf`` union whose branches declare their types.
 
-    Optional arguments are usually declared this way.  Only branches that carry
-    nothing but a ``type`` are resolved; anything richer stays unknown.
+    Optional arguments are usually declared this way.  Structural keywords such
+    as ``items`` constrain a branch without making its explicit ``type``
+    ambiguous; candidate values remain independently proved by the full schema
+    validator before generation emits them.
     """
 
     for keyword in ("anyOf", "oneOf"):
@@ -394,7 +396,7 @@ def _union_branch_types(schema: Mapping[str, Any]) -> tuple[JsonSchemaType, ...]
         resolved: set[JsonSchemaType] = set()
         for branch in branches:
             mapping = _mapping(branch)
-            if mapping is None or set(mapping) != {"type"}:
+            if mapping is None:
                 return None
             branch_types = _declared_types(mapping)
             if branch_types is None:

--- a/tests/agentcheck/test_positive_path_cases.py
+++ b/tests/agentcheck/test_positive_path_cases.py
@@ -14,7 +14,7 @@ is the only way the resulting trajectory says anything about the agent.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List, Optional
 
 from agents import Agent, function_tool
 from pydantic import BaseModel
@@ -23,6 +23,7 @@ from agentcheck.adapters import OpenAIAgentsAdapter
 from agentcheck.config import AgentCheckConfig
 from agentcheck.generate.boundaries import build_positive_path_cases
 from agentcheck.generate.suite import CaseOrigin, build_frozen_suite
+from agentcheck.inspect.capabilities import extract_capabilities
 from agentcheck.schema_safety import offline_validator
 
 
@@ -36,6 +37,12 @@ def update_seat(confirmation_number: str, new_seat: str) -> str:
 def lookup_account(account_id: str) -> str:
     """Look up an account."""
     raise AssertionError("original handler must never run")
+
+
+class UnsupportedStructuredValue(BaseModel):
+    """Forces one union branch through a local schema reference."""
+
+    label: str
 
 
 def _spec(*tools: Any, output_type: Any = None):
@@ -144,6 +151,56 @@ def test_tools_without_a_constructible_baseline_are_omitted() -> None:
         raise AssertionError("original handler must never run")
 
     assert _positive(_spec(opaque)) == ()
+
+
+def test_schema_union_matrix_preserves_known_types_and_unknowns() -> None:
+    """Structural union branches stay known; implicit branch types do not.
+
+    OpenAI Agents SDK 0.22 emits ``Optional[List[str]]`` as an ``anyOf`` whose
+    array branch carries both ``type`` and ``items``.  That structural keyword
+    must not make the declared array type disappear from generation.  A branch
+    expressed only through ``$ref`` remains unknown and fail-closed.
+    """
+
+    @function_tool
+    def scalar(value: str) -> str:
+        """Accept one scalar string."""
+        raise AssertionError("original handler must never run")
+
+    @function_tool
+    def nullable_scalar(value: Optional[str]) -> str:
+        """Accept one nullable scalar string."""
+        raise AssertionError("original handler must never run")
+
+    @function_tool
+    def array(value: List[str]) -> str:
+        """Accept one array of strings."""
+        raise AssertionError("original handler must never run")
+
+    @function_tool
+    def nullable_array(value: Optional[List[str]]) -> str:
+        """Accept one nullable array of strings."""
+        raise AssertionError("original handler must never run")
+
+    @function_tool
+    def unsupported_union(value: str | UnsupportedStructuredValue) -> str:
+        """Accept a scalar or locally referenced structured value."""
+        raise AssertionError("original handler must never run")
+
+    specs = [
+        _spec(tool)
+        for tool in (scalar, nullable_scalar, array, nullable_array, unsupported_union)
+    ]
+    case_counts = [len(_positive(spec)) for spec in specs]
+    types_known = [
+        extract_capabilities([spec.tools.items[0].value])[0]
+        .arguments.parameters[0]
+        .types_known
+        for spec in specs
+    ]
+
+    assert case_counts == [1, 1, 1, 1, 0]
+    assert types_known == [True, True, True, True, False]
 
 
 def test_a_zero_parameter_tool_has_a_constructible_baseline() -> None:

--- a/tests/agentcheck/test_positive_path_cases.py
+++ b/tests/agentcheck/test_positive_path_cases.py
@@ -23,7 +23,7 @@ from agentcheck.adapters import OpenAIAgentsAdapter
 from agentcheck.config import AgentCheckConfig
 from agentcheck.generate.boundaries import build_positive_path_cases
 from agentcheck.generate.suite import CaseOrigin, build_frozen_suite
-from agentcheck.inspect.capabilities import extract_capabilities
+from agentcheck.inspect.capabilities import JsonSchemaType, extract_capabilities
 from agentcheck.schema_safety import offline_validator
 
 
@@ -192,15 +192,30 @@ def test_schema_union_matrix_preserves_known_types_and_unknowns() -> None:
         for tool in (scalar, nullable_scalar, array, nullable_array, unsupported_union)
     ]
     case_counts = [len(_positive(spec)) for spec in specs]
-    types_known = [
+    parameter_types = [
         extract_capabilities([spec.tools.items[0].value])[0]
         .arguments.parameters[0]
-        .types_known
+        .types
         for spec in specs
     ]
+    nullable_array_definition = specs[3].tools.items[0].value
+    nullable_array_arguments = _positive(specs[3])[0].allowed_tool_behavior[
+        0
+    ].arguments_match
 
     assert case_counts == [1, 1, 1, 1, 0]
-    assert types_known == [True, True, True, True, False]
+    assert parameter_types == [
+        (JsonSchemaType.STRING,),
+        (JsonSchemaType.NULL, JsonSchemaType.STRING),
+        (JsonSchemaType.ARRAY,),
+        (JsonSchemaType.ARRAY, JsonSchemaType.NULL),
+        (),
+    ]
+    assert nullable_array_arguments == {"value": []}
+    assert isinstance(nullable_array_arguments["value"], list)
+    assert offline_validator(nullable_array_definition.input_schema).is_valid(
+        dict(nullable_array_arguments)
+    )
 
 
 def test_a_zero_parameter_tool_has_a_constructible_baseline() -> None:


### PR DESCRIPTION
## Summary

- resolve explicit JSON Schema union-branch types even when a branch also carries structural constraints such as `items`
- keep the complete original schema validator authoritative for every synthesized baseline and emitted case
- freeze an OpenAI Agents SDK matrix for `str`, `Optional[str]`, `List[str]`, `Optional[List[str]]`, and a genuinely unsupported `$ref` union

## Independent reproduction

On exact `main@1a7c4cda41fe24a2f7e27115a9248a915911a0e6` with `openai-agents==0.22.0`, one standalone three-tool agent produced:

- `str`: `types_known=true`; 4 tool-tagged cases (1 positive path, 3 schema boundaries)
- `Optional[str]`: `types_known=true`; 4 tool-tagged cases (1 positive path, 3 schema boundaries)
- `Optional[List[str]]`: `types_known=false`; 0 tool-tagged cases

The focused regression failed before the fix with positive-case counts `[1, 1, 0]`.

After the fix, the three standalone tools each produce 4 tool-tagged cases and `Optional[List[str]]` resolves to `array | null`. The expanded regression freezes positive-case counts `[1, 1, 1, 1, 0]` and `types_known` `[true, true, true, true, false]`; the `$ref`-only branch remains fail-closed.

## Validation

- `python -m pytest tests/agentcheck/test_capabilities.py tests/agentcheck/test_boundaries.py tests/agentcheck/test_positive_path_cases.py -q` — 140 passed
- `python -m ruff check agentcheck/inspect/capabilities.py tests/agentcheck/test_positive_path_cases.py` — passed
- `python -m mypy agentcheck/inspect/capabilities.py agentcheck/generate/boundaries.py` — passed

## Boundaries

- no MailOps access or dependency
- no declared-risk authority, coverage/gate, release, or unrelated changes
- `GENERATOR_COMPATIBILITY_VERSION` remains `1`: affected suites already re-identify through their newly generated cases; otherwise-equivalent suites remain unchanged
