### PR TITLE
Keep declared tool risk authoritative in behavioral coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## Unreleased
+
+### Fixed
+
+- **A developer-declared `tool_risk` lost its authority in behavioral
+  coverage.** Coverage decided whether a tool's risk dimensions were real
+  requirements by reading the tool property's `authoritative` flag, which
+  records how the tool *schema* was obtained and is always `false` on the
+  OpenAI Agents SDK and PydanticAI adapters. Neither SDK carries risk itself,
+  so for those targets the `tool_risk` block in `agentcheck.json` is the entire
+  risk authority -- and it was being discarded. A tool explicitly declared
+  destructive reported `fabricated_success_after_failure`, `duplicate_action`,
+  `ambiguous_outcome`, and `retry_control` as `unknown` with
+  `risk_metadata_not_authoritative`, so those requirements never entered the
+  missing denominator. Risk authority now comes from `spec.tool_risk`, per
+  axis, while the predicate stays on the `ToolDefinition` that generation and
+  the derived policy pack already use. Declaring one axis still never upgrades
+  the other's authority, and an undeclared tool whose risk is merely inferred
+  still reports `risk_metadata_not_authoritative`.
+
+  **What you will see:** on a target that declares `tool_risk` against an SDK
+  adapter, previously `unknown` risk requirements now report `missing` or
+  `partial`. This is reported coverage becoming accurate, not a behavior
+  change in your agent. Requirements for a tool declared explicitly non-risky
+  are now correctly absent rather than unknown.
+
+  **Suite identity:** unchanged. This affects how coverage is reported, not
+  what is generated, so `GENERATOR_COMPATIBILITY_VERSION` and every suite
+  fingerprint stay where they were.
+
 ## 0.5.2 (2026-08-31)
 
 An evidence-integrity patch that makes incomplete, inconsistent, or drifting

--- a/agentcheck/coverage/analyzer.py
+++ b/agentcheck/coverage/analyzer.py
@@ -457,18 +457,22 @@ def _risk_group_applicability(
     ``state_changing`` leaves the destructive-gated dimensions unknown rather
     than pruning them.
 
-    Risk authority is read from ``spec.tool_risk``, not from
-    ``AgentProperty.authoritative`` on the tool item. That flag records how the
-    tool *schema* was obtained -- read first-hand from a declaration, or
-    reconstructed from a framework object -- and is unconditionally ``False`` on
-    both SDK adapters. Neither the OpenAI Agents SDK nor PydanticAI can carry
-    risk itself, so for those targets a developer declaration is the entire risk
-    authority; keying coverage off the schema flag discarded it and dropped four
-    real requirements out of the missing denominator.
+    The predicate is read from the ``ToolDefinition``, which is the single
+    source of truth every other consumer already gates on (``generate``'s fault
+    variants, the derived policy pack). Only *authority* comes from
+    ``spec.tool_risk``, which is the same split ``policies.derived`` uses -- so
+    coverage cannot disagree with generation about whether a dimension applies.
 
-    A spec carrying no assertion for a tool has no risk provenance to read, so
-    it falls back to that schema flag -- exactly what decided this before risk
-    assertions existed -- rather than degrading every such tool to UNKNOWN.
+    Authority is deliberately not read from ``AgentProperty.authoritative`` on
+    the tool item. That flag records how the tool *schema* was obtained -- read
+    first-hand from a declaration, or reconstructed from a framework object --
+    and is unconditionally ``False`` on both SDK adapters. Neither the OpenAI
+    Agents SDK nor PydanticAI can carry risk itself, so for those targets a
+    developer declaration is the entire risk authority; keying coverage off the
+    schema flag discarded it and dropped real requirements out of the missing
+    denominator. A tool with no recorded assertion has no risk provenance to
+    read and falls back to that flag, which is exactly what decided this before
+    risk assertions existed.
     """
 
     risk_by_name = {item.tool_name: item for item in spec.tool_risk.items}
@@ -477,43 +481,28 @@ def _risk_group_applicability(
         tool = tool_item.value
         assertion = risk_by_name.get(tool.name)
         if assertion is None:
-            if tool_item.authoritative:
-                action = (
-                    _Applicability.APPLICABLE
-                    if (tool.state_changing or tool.destructive)
-                    else None
-                )
-                destructive_group = (
-                    _Applicability.APPLICABLE if tool.destructive else None
-                )
-            else:
-                action = _Applicability.UNKNOWN
-                destructive_group = _Applicability.UNKNOWN
-            groups[tool.name] = (action, destructive_group)
-            continue
+            state_declared = destructive_declared = tool_item.authoritative
+        else:
+            state_declared = assertion.state_changing.authority in _AUTHORITATIVE_RISK
+            destructive_declared = assertion.destructive.authority in _AUTHORITATIVE_RISK
 
-        destructive = assertion.destructive
-        state_changing = assertion.state_changing
-        destructive_declared = destructive.authority in _AUTHORITATIVE_RISK
-        state_declared = state_changing.authority in _AUTHORITATIVE_RISK
-
-        if (destructive.value and destructive_declared) or (
-            state_changing.value and state_declared
+        if (tool.destructive and destructive_declared) or (
+            tool.state_changing and state_declared
         ):
             action = _Applicability.APPLICABLE
         elif (
             destructive_declared
             and state_declared
-            and not destructive.value
-            and not state_changing.value
+            and not tool.destructive
+            and not tool.state_changing
         ):
             action = None
         else:
             action = _Applicability.UNKNOWN
 
-        if destructive.value and destructive_declared:
+        if tool.destructive and destructive_declared:
             destructive_group = _Applicability.APPLICABLE
-        elif destructive_declared and not destructive.value:
+        elif destructive_declared and not tool.destructive:
             destructive_group = None
         else:
             destructive_group = _Applicability.UNKNOWN
@@ -523,9 +512,10 @@ def _risk_group_applicability(
 
 
 def _seed_from_spec(
-    spec: AgentSpec, seeds: dict[tuple[BehavioralDimension, str], _Seed]
+    spec: AgentSpec,
+    seeds: dict[tuple[BehavioralDimension, str], _Seed],
+    risk_groups: dict[str, tuple[_Applicability | None, _Applicability | None]],
 ) -> None:
-    risk_groups = _risk_group_applicability(spec)
     for tool_item in sorted(spec.tools.items, key=lambda value: value.value.name):
         tool = tool_item.value
         subject = _tool_subject(tool.name)
@@ -2164,13 +2154,15 @@ def analyze_behavioral_coverage(
         if tool.name not in ambiguous_tool_names
     }
     seeds: dict[tuple[BehavioralDimension, str], _Seed] = {}
-    _seed_from_spec(spec, seeds)
-    spec_risk_groups = _risk_group_applicability(spec)
+    # One computation feeds both the spec seeds and the scenario-suppression
+    # set, so the two cannot describe different risk-authority policies.
+    risk_groups = _risk_group_applicability(spec)
+    _seed_from_spec(spec, seeds, risk_groups)
     non_authoritative_risk_tools = {
         item.value.name
         for item in spec.tools.items
         if _Applicability.UNKNOWN
-        in spec_risk_groups.get(
+        in risk_groups.get(
             item.value.name, (_Applicability.UNKNOWN, _Applicability.UNKNOWN)
         )
     }

--- a/agentcheck/coverage/analyzer.py
+++ b/agentcheck/coverage/analyzer.py
@@ -21,10 +21,10 @@ from referencing.exceptions import Unresolvable
 from agentcheck.domain import (
     AgentSpec,
     FaultType,
-    RiskAuthority,
     OracleStrength,
     OutputCriterion,
     OutputCriterionKind,
+    RiskAuthority,
     Scenario,
     SimulatedToolStatus,
     ToolBehaviorConstraint,

--- a/agentcheck/coverage/analyzer.py
+++ b/agentcheck/coverage/analyzer.py
@@ -21,6 +21,7 @@ from referencing.exceptions import Unresolvable
 from agentcheck.domain import (
     AgentSpec,
     FaultType,
+    RiskAuthority,
     OracleStrength,
     OutputCriterion,
     OutputCriterionKind,
@@ -435,15 +436,96 @@ def _prerequisite_pairs(scenario: Scenario) -> tuple[tuple[str, str], ...]:
     )
 
 
+_AUTHORITATIVE_RISK = frozenset(
+    {RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.FRAMEWORK_AUTHORITATIVE}
+)
+
+
+def _risk_group_applicability(
+    spec: AgentSpec,
+) -> dict[str, tuple[_Applicability | None, _Applicability | None]]:
+    """Per tool, the applicability of the action-gated and destructive-gated
+    risk dimensions, decided by the authority of the axis that gates each group.
+
+    ``fabricated_success_after_failure`` and ``duplicate_action`` are gated on
+    "state-changing or destructive"; ``ambiguous_outcome`` and ``retry_control``
+    are gated on "destructive" alone. A group is APPLICABLE when its predicate
+    is true *and* the axis that made it true was declared, and is ``None`` -- no
+    requirement at all -- only when the predicate is authoritatively false.
+    Anything resting on inference or an un-inferable axis stays UNKNOWN, so
+    declaring one axis never upgrades the other's authority: declaring only
+    ``state_changing`` leaves the destructive-gated dimensions unknown rather
+    than pruning them.
+
+    Risk authority is read from ``spec.tool_risk``, not from
+    ``AgentProperty.authoritative`` on the tool item. That flag records how the
+    tool *schema* was obtained -- read first-hand from a declaration, or
+    reconstructed from a framework object -- and is unconditionally ``False`` on
+    both SDK adapters. Neither the OpenAI Agents SDK nor PydanticAI can carry
+    risk itself, so for those targets a developer declaration is the entire risk
+    authority; keying coverage off the schema flag discarded it and dropped four
+    real requirements out of the missing denominator.
+
+    A spec carrying no assertion for a tool has no risk provenance to read, so
+    it falls back to that schema flag -- exactly what decided this before risk
+    assertions existed -- rather than degrading every such tool to UNKNOWN.
+    """
+
+    risk_by_name = {item.tool_name: item for item in spec.tool_risk.items}
+    groups: dict[str, tuple[_Applicability | None, _Applicability | None]] = {}
+    for tool_item in spec.tools.items:
+        tool = tool_item.value
+        assertion = risk_by_name.get(tool.name)
+        if assertion is None:
+            if tool_item.authoritative:
+                action = (
+                    _Applicability.APPLICABLE
+                    if (tool.state_changing or tool.destructive)
+                    else None
+                )
+                destructive_group = (
+                    _Applicability.APPLICABLE if tool.destructive else None
+                )
+            else:
+                action = _Applicability.UNKNOWN
+                destructive_group = _Applicability.UNKNOWN
+            groups[tool.name] = (action, destructive_group)
+            continue
+
+        destructive = assertion.destructive
+        state_changing = assertion.state_changing
+        destructive_declared = destructive.authority in _AUTHORITATIVE_RISK
+        state_declared = state_changing.authority in _AUTHORITATIVE_RISK
+
+        if (destructive.value and destructive_declared) or (
+            state_changing.value and state_declared
+        ):
+            action = _Applicability.APPLICABLE
+        elif (
+            destructive_declared
+            and state_declared
+            and not destructive.value
+            and not state_changing.value
+        ):
+            action = None
+        else:
+            action = _Applicability.UNKNOWN
+
+        if destructive.value and destructive_declared:
+            destructive_group = _Applicability.APPLICABLE
+        elif destructive_declared and not destructive.value:
+            destructive_group = None
+        else:
+            destructive_group = _Applicability.UNKNOWN
+
+        groups[tool.name] = (action, destructive_group)
+    return groups
+
+
 def _seed_from_spec(
     spec: AgentSpec, seeds: dict[tuple[BehavioralDimension, str], _Seed]
 ) -> None:
-    risk_dimensions = (
-        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
-        BehavioralDimension.DUPLICATE_ACTION,
-        BehavioralDimension.AMBIGUOUS_OUTCOME,
-        BehavioralDimension.RETRY_CONTROL,
-    )
+    risk_groups = _risk_group_applicability(spec)
     for tool_item in sorted(spec.tools.items, key=lambda value: value.value.name):
         tool = tool_item.value
         subject = _tool_subject(tool.name)
@@ -460,40 +542,36 @@ def _seed_from_spec(
                 tool_name=tool.name,
             )
 
-        if not tool_item.authoritative:
-            for dimension in risk_dimensions:
+        action, destructive_group = risk_groups.get(
+            tool.name, (_Applicability.UNKNOWN, _Applicability.UNKNOWN)
+        )
+        for applicability, dimensions in (
+            (
+                action,
+                (
+                    BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+                    BehavioralDimension.DUPLICATE_ACTION,
+                ),
+            ),
+            (
+                destructive_group,
+                (
+                    BehavioralDimension.AMBIGUOUS_OUTCOME,
+                    BehavioralDimension.RETRY_CONTROL,
+                ),
+            ),
+        ):
+            # ``None`` is the authoritative "this tool cannot do that" answer
+            # and carries no requirement, exactly as an unset risk flag
+            # produced no seed before.
+            if applicability is None:
+                continue
+            for dimension in dimensions:
                 _add_seed(
                     seeds,
                     dimension,
                     subject,
-                    _Applicability.UNKNOWN,
-                    tool_name=tool.name,
-                )
-            continue
-
-        state_changing = tool.state_changing or tool.destructive
-        if state_changing:
-            for dimension in (
-                BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
-                BehavioralDimension.DUPLICATE_ACTION,
-            ):
-                _add_seed(
-                    seeds,
-                    dimension,
-                    subject,
-                    _Applicability.APPLICABLE,
-                    tool_name=tool.name,
-                )
-        if tool.destructive:
-            for dimension in (
-                BehavioralDimension.AMBIGUOUS_OUTCOME,
-                BehavioralDimension.RETRY_CONTROL,
-            ):
-                _add_seed(
-                    seeds,
-                    dimension,
-                    subject,
-                    _Applicability.APPLICABLE,
+                    applicability,
                     tool_name=tool.name,
                 )
 
@@ -2087,8 +2165,14 @@ def analyze_behavioral_coverage(
     }
     seeds: dict[tuple[BehavioralDimension, str], _Seed] = {}
     _seed_from_spec(spec, seeds)
+    spec_risk_groups = _risk_group_applicability(spec)
     non_authoritative_risk_tools = {
-        item.value.name for item in spec.tools.items if not item.authoritative
+        item.value.name
+        for item in spec.tools.items
+        if _Applicability.UNKNOWN
+        in spec_risk_groups.get(
+            item.value.name, (_Applicability.UNKNOWN, _Applicability.UNKNOWN)
+        )
     }
     _seed_from_scenarios(reference, seeds, non_authoritative_risk_tools)
     lossy_tool_names = {

--- a/tests/agentcheck/test_tool_risk_authority.py
+++ b/tests/agentcheck/test_tool_risk_authority.py
@@ -16,6 +16,11 @@ from agents import Agent, function_tool
 from agentcheck.adapters import CustomAgentAdapter, OpenAIAgentsAdapter, UnsupportedTargetError
 from agentcheck.config import ToolRiskDeclaration
 from agentcheck.domain import RiskAuthority, ToolDefinition
+from agentcheck.coverage import (
+    BehavioralCoverageStatus,
+    BehavioralDimension,
+    analyze_behavioral_coverage,
+)
 from agentcheck.generate.boundaries import build_outcome_variant_cases
 from agentcheck.inspect.risk_authority import resolve_tool_risk, unmatched_tool_risk_names
 from agentcheck.policies.derived import derive_tool_risk_pack
@@ -331,3 +336,170 @@ def test_a_misspelled_tool_risk_name_refuses_prepare_for_a_custom_agent() -> Non
             declared_tool_risk={"cancle_order": ToolRiskDeclaration(destructive=False)},
         )
     assert "unknown_tool_risk_declaration" in {issue.code for issue in excinfo.value.issues}
+
+
+# --- coverage: a declaration must keep its authority on an SDK adapter ------
+#
+# The documented contract (README, docs/fault-testing.md) is that a developer
+# declaration is *always* authoritative, and that `risk_metadata_not_authoritative`
+# means "a lexical classification rather than a declared one". Behavioral
+# coverage used to key that decision off the tool *property's* `authoritative`
+# flag, which records how the tool schema was obtained and is unconditionally
+# False on both SDK adapters -- so an explicit declaration silently lost its
+# authority and four real requirements dropped out of the missing denominator.
+
+RISK_DIMENSIONS = (
+    BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE,
+    BehavioralDimension.DUPLICATE_ACTION,
+    BehavioralDimension.AMBIGUOUS_OUTCOME,
+    BehavioralDimension.RETRY_CONTROL,
+)
+
+# Deliberately reads as a pure lookup so nothing is inferable as risky: the
+# declaration is then the only risk signal on either target.
+PURGE_DESCRIPTION = "Look up a record by id."
+
+
+@function_tool(name_override="purge_record", description_override=PURGE_DESCRIPTION)
+def purge_record(record_id: str) -> str:
+    raise AssertionError("original handler must never run")
+
+
+PURGE_RECORD = ToolDefinition(
+    name="purge_record",
+    description=PURGE_DESCRIPTION,
+    input_schema={
+        "type": "object",
+        "properties": {"record_id": {"type": "string"}},
+        "required": ["record_id"],
+        "additionalProperties": False,
+    },
+    # Declares no risk of its own, exactly like the SDK tool above.
+    state_changing=False,
+    destructive=False,
+)
+
+
+class _PurgeCustomAgent:
+    name = "T"
+    instructions = "Assist."
+    tools = (PURGE_RECORD,)
+
+    def start(self, message, tools):  # pragma: no cover - never reached
+        raise AssertionError("no turn runs in this test")
+
+    def resume(self, state, message, tools):  # pragma: no cover - never reached
+        raise AssertionError("no turn runs in this test")
+
+
+def _risk_status(spec):
+    coverage = analyze_behavioral_coverage(spec, [])
+    return {
+        family.dimension: (requirement.status, requirement.reason_code)
+        for family in coverage.families
+        for requirement in family.requirements
+        if requirement.subject == "tool:purge_record"
+        and family.dimension in RISK_DIMENSIONS
+    }
+
+
+def test_declared_risk_keeps_coverage_authority_on_the_openai_adapter() -> None:
+    """An explicit `tool_risk` declaration makes the risk dimensions real
+    requirements rather than `unknown`. The SDK cannot carry risk itself, so the
+    declaration is the whole authority and must not be discarded merely because
+    the schema was reconstructed from a framework object."""
+
+    spec = _spec(
+        purge_record,
+        tool_risk={
+            "purge_record": ToolRiskDeclaration(state_changing=True, destructive=True)
+        },
+    )
+    assertion = next(a for a in spec.tool_risk.items if a.tool_name == "purge_record")
+    assert assertion.destructive.authority is RiskAuthority.DEVELOPER_DECLARED
+    assert assertion.state_changing.authority is RiskAuthority.DEVELOPER_DECLARED
+
+    statuses = _risk_status(spec)
+    assert set(statuses) == set(RISK_DIMENSIONS)
+    for dimension, (status, reason) in statuses.items():
+        assert status is not BehavioralCoverageStatus.UNKNOWN, (
+            f"{dimension.value} reported {reason!r} despite an explicit "
+            "developer risk declaration"
+        )
+        assert reason != "risk_metadata_not_authoritative"
+
+
+def test_declared_risk_coverage_matches_the_custom_adapter_exactly() -> None:
+    """Identical declaration, identical tool contract, different adapter: the
+    reported risk requirements must match. Pinning the custom adapter as the
+    control makes this a real cross-adapter equivalence rather than a
+    restatement of whatever the OpenAI adapter happens to do."""
+
+    declaration = {
+        "purge_record": ToolRiskDeclaration(state_changing=True, destructive=True)
+    }
+    openai_statuses = _risk_status(_spec(purge_record, tool_risk=declaration))
+    custom_statuses = _risk_status(
+        CustomAgentAdapter().inspect(_PurgeCustomAgent(), declared_tool_risk=declaration)
+    )
+
+    assert custom_statuses == {
+        BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE: (
+            BehavioralCoverageStatus.MISSING,
+            "fabricated_success_case_missing",
+        ),
+        BehavioralDimension.DUPLICATE_ACTION: (
+            BehavioralCoverageStatus.MISSING,
+            "duplicate_action_case_missing",
+        ),
+        BehavioralDimension.AMBIGUOUS_OUTCOME: (
+            BehavioralCoverageStatus.MISSING,
+            "ambiguous_outcome_case_missing",
+        ),
+        BehavioralDimension.RETRY_CONTROL: (
+            BehavioralCoverageStatus.MISSING,
+            "retry_control_case_missing",
+        ),
+    }
+    assert openai_statuses == custom_statuses
+
+
+def test_undeclared_sdk_risk_still_reports_unknown() -> None:
+    """The fix must not launder inference into authority: with no declaration
+    the same tool keeps reporting `risk_metadata_not_authoritative`."""
+
+    statuses = _risk_status(_spec(purge_record))
+    assert set(statuses) == set(RISK_DIMENSIONS)
+    for status, reason in statuses.values():
+        assert status is BehavioralCoverageStatus.UNKNOWN
+        assert reason == "risk_metadata_not_authoritative"
+
+
+def test_declaring_one_axis_does_not_upgrade_the_other_in_coverage() -> None:
+    """`bash` is deliberately unclassifiable, so declaring only `state_changing`
+    leaves `destructive` un-inferable: the action-gated dimensions become real
+    requirements while the destructive-gated ones stay unknown."""
+
+    spec = _spec(bash, tool_risk={"bash": ToolRiskDeclaration(state_changing=True)})
+    coverage = analyze_behavioral_coverage(spec, [])
+    reasons = {
+        family.dimension: requirement.reason_code
+        for family in coverage.families
+        for requirement in family.requirements
+        if requirement.subject == "tool:bash" and family.dimension in RISK_DIMENSIONS
+    }
+    assert (
+        reasons[BehavioralDimension.FABRICATED_SUCCESS_AFTER_FAILURE]
+        != "risk_metadata_not_authoritative"
+    )
+    assert (
+        reasons[BehavioralDimension.DUPLICATE_ACTION]
+        != "risk_metadata_not_authoritative"
+    )
+    assert (
+        reasons[BehavioralDimension.AMBIGUOUS_OUTCOME]
+        == "risk_metadata_not_authoritative"
+    )
+    assert (
+        reasons[BehavioralDimension.RETRY_CONTROL] == "risk_metadata_not_authoritative"
+    )

--- a/tests/agentcheck/test_tool_risk_authority.py
+++ b/tests/agentcheck/test_tool_risk_authority.py
@@ -14,13 +14,14 @@ import pytest
 from agents import Agent, function_tool
 
 from agentcheck.adapters import CustomAgentAdapter, OpenAIAgentsAdapter, UnsupportedTargetError
-from agentcheck.config import ToolRiskDeclaration
+from agentcheck.config import AgentCheckConfig, ToolRiskDeclaration
 from agentcheck.domain import RiskAuthority, ToolDefinition
 from agentcheck.coverage import (
     BehavioralCoverageStatus,
     BehavioralDimension,
     analyze_behavioral_coverage,
 )
+from agentcheck.generate import build_frozen_suite
 from agentcheck.generate.boundaries import build_outcome_variant_cases
 from agentcheck.inspect.risk_authority import resolve_tool_risk, unmatched_tool_risk_names
 from agentcheck.policies.derived import derive_tool_risk_pack
@@ -513,3 +514,59 @@ def test_declaring_one_axis_does_not_upgrade_the_other_in_coverage() -> None:
     assert (
         reasons[BehavioralDimension.RETRY_CONTROL] == "risk_metadata_not_authoritative"
     )
+
+
+def test_scenario_risk_suppression_follows_declared_authority() -> None:
+    """The other half of the fix: the set that suppresses scenario-derived risk
+    evidence must also follow declared authority, not the schema flag.
+
+    `_seed_from_scenarios` refuses to let generator `source:behavioral_outcome`
+    variants launder UNKNOWN into applicability for a tool whose risk is merely
+    inferred. Keying that set off `AgentProperty.authoritative` suppressed it
+    for *every* SDK tool, declaration or not.
+
+    Reverting only that set leaves the whole suite green, because a declared
+    risky tool's spec seed is already APPLICABLE and `_add_seed` merges by max
+    rank -- the suppression is invisible. The discriminator is a tool declared
+    explicitly NOT risky: its spec seed carries no requirement at all, so the
+    scenario seed is the only one, and whether it is APPLICABLE or UNKNOWN is
+    observable.
+    """
+
+    agent = Agent(
+        name="T", instructions="Assist.", tools=[purge_record], model="gpt-4.1-mini"
+    )
+    # Generated with no declaration, so `purge_record` is inferred risky and the
+    # suite really does contain `source:behavioral_outcome` variants for it.
+    inferred_spec = OpenAIAgentsAdapter().inspect(agent)
+    suite = build_frozen_suite(inferred_spec, AgentCheckConfig(), seed=SEED)
+    assert any(
+        "source:behavioral_outcome" in scenario.dimension_tags
+        and "tool:purge_record" in scenario.dimension_tags
+        for scenario in suite.scenarios
+    ), "fixture no longer generates the behavioural-outcome variants it relies on"
+
+    # Now analysed against a spec whose developer declares the tool NOT risky.
+    declared_safe = OpenAIAgentsAdapter().inspect(
+        agent,
+        declared_tool_risk={
+            "purge_record": ToolRiskDeclaration(
+                state_changing=False, destructive=False
+            )
+        },
+    )
+    coverage = analyze_behavioral_coverage(declared_safe, suite.scenarios)
+    reported = {
+        family.dimension: (requirement.status, requirement.reason_code)
+        for family in coverage.families
+        for requirement in family.requirements
+        if requirement.subject == "tool:purge_record"
+        and family.dimension in RISK_DIMENSIONS
+    }
+    assert set(reported) == set(RISK_DIMENSIONS)
+    for dimension, (status, reason) in reported.items():
+        assert reason != "risk_metadata_not_authoritative", (
+            f"{dimension.value} was suppressed as non-authoritative even though "
+            "the developer declared this tool's risk explicitly"
+        )
+        assert status is not BehavioralCoverageStatus.UNKNOWN

--- a/tests/agentcheck/test_tool_risk_authority.py
+++ b/tests/agentcheck/test_tool_risk_authority.py
@@ -355,8 +355,13 @@ RISK_DIMENSIONS = (
     BehavioralDimension.RETRY_CONTROL,
 )
 
-# Deliberately reads as a pure lookup so nothing is inferable as risky: the
-# declaration is then the only risk signal on either target.
+# `purge` is in the destructive verb set, so this tool IS classified risky by
+# inference (INFERRED, confidence 0.6) despite the benign description. That is
+# deliberate and is exactly the interesting case: inference and declaration
+# agree on the *value*, so any behaviour difference is attributable to
+# authority alone. It also makes `test_undeclared_sdk_risk_still_reports_unknown`
+# a real control -- inference alone must not reach authority even when it
+# happens to be right.
 PURGE_DESCRIPTION = "Look up a record by id."
 
 
@@ -374,7 +379,8 @@ PURGE_RECORD = ToolDefinition(
         "required": ["record_id"],
         "additionalProperties": False,
     },
-    # Declares no risk of its own, exactly like the SDK tool above.
+    # Declares no risk of its own, so the agentcheck.json declaration is the
+    # only thing that can make it risky on this adapter.
     state_changing=False,
     destructive=False,
 )
@@ -407,7 +413,9 @@ def test_declared_risk_keeps_coverage_authority_on_the_openai_adapter() -> None:
     """An explicit `tool_risk` declaration makes the risk dimensions real
     requirements rather than `unknown`. The SDK cannot carry risk itself, so the
     declaration is the whole authority and must not be discarded merely because
-    the schema was reconstructed from a framework object."""
+    the schema was reconstructed from a framework object. Without the
+    declaration this same tool is only *inferred* risky, which stays unknown --
+    see `test_undeclared_sdk_risk_still_reports_unknown`."""
 
     spec = _spec(
         purge_record,
@@ -466,7 +474,9 @@ def test_declared_risk_coverage_matches_the_custom_adapter_exactly() -> None:
 
 def test_undeclared_sdk_risk_still_reports_unknown() -> None:
     """The fix must not launder inference into authority: with no declaration
-    the same tool keeps reporting `risk_metadata_not_authoritative`."""
+    the same tool is still classified risky by inference (INFERRED, 0.6) yet
+    keeps reporting `risk_metadata_not_authoritative`. Inference being *right*
+    about the value must not make it authoritative."""
 
     statuses = _risk_status(_spec(purge_record))
     assert set(statuses) == set(RISK_DIMENSIONS)


### PR DESCRIPTION
## AC-P0-5: developer-declared `tool_risk` lost authority in behavioral coverage

Independently reproduced on exact `main@a1dde028` with `openai-agents==0.22.0`, using only AgentCheck-owned standalone targets. No external repository was accessed or depended on.

### Reproduction

Two matched targets declare the **same** tool contract and the **same** `tool_risk` declaration (`state_changing=True, destructive=True`). Only the adapter differs.

Correction to an earlier version of this description: `purge` is in the destructive verb set, so this tool *is* also classified risky by inference (`INFERRED`, confidence 0.6) despite its benign description — it is not, as first stated, un-inferable. Inference and declaration agreeing on the value is what makes the comparison clean: the value is constant, so authority is the only variable. Without the declaration the same tool still reports `unknown`, which the third regression test pins.

Both adapters resolve the declaration identically — `RiskAuthority.DEVELOPER_DECLARED`, confidence `1.0`, `destructive=True`. Coverage then diverged:

| `analyze_behavioral_coverage(spec, [])` | OpenAI Agents SDK (before) | Custom adapter (control) |
| --- | --- | --- |
| `fabricated_success_after_failure` | `unknown` / `risk_metadata_not_authoritative` | `missing` / `fabricated_success_case_missing` |
| `duplicate_action` | `unknown` / `risk_metadata_not_authoritative` | `missing` / `duplicate_action_case_missing` |
| `ambiguous_outcome` | `unknown` / `risk_metadata_not_authoritative` | `missing` / `ambiguous_outcome_case_missing` |
| `retry_control` | `unknown` / `risk_metadata_not_authoritative` | `missing` / `retry_control_case_missing` |
| status totals | `{missing: 3, unknown: 4}` | `{missing: 7}` |

Four requirements the developer explicitly asked for silently left the missing denominator. PydanticAI reproduces this identically, so the defect is in the shared coverage analyzer rather than the OpenAI adapter specifically — a correction to the original report's framing.

### Root cause

`_seed_from_spec` decided risk applicability from `AgentProperty.authoritative` on the tool item. That flag records how the tool *schema* was obtained — read first-hand from a declaration, or reconstructed from a framework object — and is unconditionally `False` on both SDK adapters (`openai_agents.py`, `pydantic_ai.py`) and `True` on `custom.py`. Neither SDK can carry risk itself, so for those targets the declaration is the entire risk authority, and the schema flag discarded it. `non_authoritative_risk_tools` used the same wrong signal.

This contradicted the documented contract: README states a developer declaration is *always* authoritative, and `docs/fault-testing.md` defines the reason code as *"a lexical classification rather than a declared one"*.

### Fix

Risk authority now comes from `spec.tool_risk`, decided **per axis** by the axis that actually gates each dimension group:

- applicable when the gating predicate is true *and* the axis that made it true was declared;
- no requirement at all only when the predicate is authoritatively false;
- otherwise unknown.

So declaring one axis still never upgrades the other's, and an undeclared SDK tool still reports `risk_metadata_not_authoritative`. A spec carrying no assertion for a tool falls back to the schema flag — exactly what decided this before risk assertions existed — which keeps synthetic and legacy specs behaving as before.

After the fix the OpenAI and PydanticAI adapters both match the custom control exactly (`{missing: 7}`).

### End-to-end impact on real generated suites

The table above uses an empty scenario set to isolate the seeding decision. The
defect is not limited to that probe -- it changes what real generated suites
report, because a tool's spec-derived seed is only upgraded when some scenario
happens to bind it.

A 12-tool target, every tool declared `state_changing=True, destructive=True`,
with its full generated suite (112 scenarios):

| | before | after |
| --- | --- | --- |
| risk-dimension requirements | `{partial: 12, unknown: 36}` | `{missing: 5, partial: 43}` |
| tools reporting `risk_metadata_not_authoritative` | **12 of 12** | **0** |
| all-subject totals | `{missing: 3, partial: 45, unknown: 36}` | `{missing: 8, partial: 76}` |

36 risk requirements the developer explicitly asked for were reported `unknown`
rather than entering the denominator. A single-tool target with its full
generated suite goes from `{partial: 4, unknown: 3}` to `{partial: 7}`.

For a declared-destructive tool that has **zero** cases in the evaluated suite
-- the same shape AC-P0-4's Finding 1 produced -- all four dimensions went from
`unknown` / `risk_metadata_not_authoritative` to `missing`. In that scenario an
*undeclared* second tool still reports `unknown` after the fix, which is the
intended distinction.

Reproducers and before/after transcripts: `repro_generated_suite.py`,
`repro_multitool_suite.py`, `repro_custom_suite.py`, `repro_untested_tool.py`,
`repro_zero_case_tool.py`, each with `red-main-*` / `green-after-fix-*` output.

### Tests

Four regression tests, red on `a1dde028` before the change:

- declared risk keeps coverage authority on the OpenAI adapter;
- OpenAI coverage matches the custom adapter exactly (pinned to explicit statuses, so it is a real cross-adapter equivalence rather than a restatement of current behavior);
- **undeclared** SDK risk still reports `unknown` — guards against laundering inference into authority;
- declaring one axis does not upgrade the other in coverage.

### Review

Two independent reviews, both **READY** with no correctness defect found.

The second reviewed this exact head's logic: it enumerated the per-axis truth table exhaustively, confirmed the no-assertion fallback reproduces base behaviour on all 8 states, and proved the predicate-source refactor behaviour-identical by instrumenting 492 live calls across the full suite (1747 passed, 1 skipped) with zero divergences.

Two findings were fixed here:

- **A fifth regression test** pins the `non_authoritative_risk_tools` half of the fix. Mutation-reverting just that to the schema flag previously left the entire 1747-test suite green — it is invisible to the obvious test because a declared risky tool's spec seed is already `APPLICABLE` and `_add_seed` merges by max rank. The discriminator is a tool declared explicitly *non*-risky: its spec seed emits no requirement, so the scenario seed's applicability becomes observable. Verified to fail under that exact mutation.
- **A CHANGELOG entry.** I first rejected this because there is no `## Unreleased` section; that was wrong — commit `6790f03` (PR #67) created one mid-cycle for exactly this class of user-visible fix. Suite identity is unchanged and the entry says so.

One finding is deferred rather than dropped: `_spec_digest` omits `spec.tool_risk[*].authority`, so `regression/compare.py` emits no `SPEC_CHANGED` caveat when a declaration agreeing with inference is added. The shipped report path is safe (`verify_behavioral_coverage_binding` re-derives; `report/render.py` refuses the unsafe combination). Changing the digest projection alters coverage-binding identity, so it belongs in its own change.

### Validation

- 319 passed, 1 skipped across the `coverage or risk or fault or policy or pydantic or version or changelog` slice; the independent reviewer additionally ran the full suite (1747 passed, 1 skipped).
- Ruff and mypy clean on both changed files.
- Focused local validation per `decisions/ci-development-model.md`; the exhaustive matrix is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX563EW92ynBDVWoHBtx9W


