### PR TITLE
Prepare AgentCheck 0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,34 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
-## Unreleased
+## 0.5.3 (2026-09-02)
+
+An evidence-integrity patch. Two independently reproduced defects could make a
+generated suite or its coverage report look more complete than the evidence
+behind it. Both are corrections to what AgentCheck reports about itself; no
+framework integration is added and the containment guarantee is unchanged.
 
 ### Fixed
+
+- **Valid OpenAI tools with a nullable array parameter could disappear from
+  the generated suite.** Union extraction discarded a schema branch that
+  carried an explicit, valid `type` whenever that branch also carried
+  structural keywords such as `items`. An `Optional[List[str]]` parameter --
+  emitted by the OpenAI Agents SDK as
+  `anyOf[{type: array, items: {type: string}}, {type: null}]` -- was therefore
+  read as type-unknown, and a tool whose required parameter it was received no
+  cases at all. Explicit types are now retained from any mapping branch under
+  `anyOf`/`oneOf`, while validation against the complete original schema
+  remains the authority for every emitted baseline and boundary value. A union
+  AgentCheck genuinely cannot resolve, such as an unsupported local `$ref`,
+  still fails closed with no cases rather than a guessed one.
+
+  **What you will see:** a tool that previously generated zero cases now
+  generates them.
+
+  **Suite identity:** `GENERATOR_COMPATIBILITY_VERSION` stays `1`. A suite
+  containing an affected tool re-identifies because its case set genuinely
+  changed; unaffected suites stay byte- and fingerprint-exact.
 
 - **A developer-declared `tool_risk` lost its authority in behavioral
   coverage.** Coverage decided whether a tool's risk dimensions were real

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.5.2"
+version = "0.5.3"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release metadata for **0.5.3**, an evidence-integrity patch covering the two independently reproduced corrections landed since `v0.5.2`.

## What ships

| PR | Fix | User-visible effect |
| --- | --- | --- |
| #85 | Nullable array schema generation | A tool with an `Optional[List[str]]` parameter that previously generated **zero** cases now generates them. |
| #88 | Declared `tool_risk` authority in behavioral coverage | On a target declaring `tool_risk` against an SDK adapter, risk requirements previously reported `unknown` now report `missing`/`partial`. |

Both are corrections to what AgentCheck reports about itself. No framework integration is added and the containment guarantee is unchanged. The other commits since `v0.5.2` (#79, #80, #81, #82, #83) are documentation, CI-template, and research-harness changes with no public API or behavior surface.

## Suite identity

`GENERATOR_COMPATIBILITY_VERSION` stays `1`, and the changelog states the consequence per entry rather than once at the top:

- **#85** genuinely changes generated case sets, so a suite containing an affected tool re-identifies. Unaffected suites stay byte- and fingerprint-exact.
- **#88** changes reporting only and moves no fingerprint.

## Release validation

Run locally against this exact tree:

- version consistency — `test_version_decoupling.py`, 12 passed (`pyproject.toml` and `agentcheck.__version__` agree at `0.5.3`)
- secret scan — PASS, no high-signal credential pattern
- workflow safety — PASS, 9 jobs on GitHub-hosted runners; PR workflows read-only, secret-free, environment-free, SHA-pinned
- interpreter integrity — 3.12.3 self-consistent
- build — `agentcheck_ai-0.5.3.tar.gz` and `agentcheck_ai-0.5.3-py3-none-any.whl`
- distribution audit — PASS, 2 artifacts contain only expected files
- clean-install smoke — fresh venv from the built wheel; `agentcheck --version` reports `0.5.3` and `importlib.metadata` agrees

`release.yml` is unchanged since the `0.5.2` release commit `40865f8`.

## Known open item, deliberately not blocking

`AC-P0-6` classified a pre-existing gap: the release gate never consults behavioral coverage, so a target whose declared-destructive tool has zero cases can still reach `pass` / exit `0`. That is unchanged by this release and its remedy is a product decision on strictness. This release makes the underlying coverage report **more** accurate, so it does not worsen that gap. Raised here rather than left implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX563EW92ynBDVWoHBtx9W