### PR TITLE
Prepare AgentCheck 0.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
-## Unreleased
+## 0.5.4 (2026-09-02)
+
+A gate-correctness patch. `agentcheck gate` could return `PASS` for a target
+whose declared-destructive tool was never tested. It now refuses, and says
+which tool, which requirement, and what to do about it. Nothing about
+generation, containment, or framework support changes.
 
 ### Fixed
 

--- a/agentcheck/__init__.py
+++ b/agentcheck/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "TurnResult",
     "load_config",
 ]
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "agentcheck-ai"
 # `agentcheck.generate.GENERATOR_COMPATIBILITY_VERSION`, so bumping this line
 # does not move scenario fingerprints or re-identify equivalent suites.
 # `tests/agentcheck/test_version_decoupling.py` holds that guarantee.
-version = "0.5.3"
+version = "0.5.4"
 description = "Behavioral testing for AI agents"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release metadata for **0.5.4**, a gate-correctness patch carrying the AC-P0-6 fix from #91.

## What ships

`agentcheck gate` could return `PASS` for a target whose declared-destructive tool was never tested. It decided from executed-case verdicts and the baseline comparison alone and never consulted behavioral coverage, so a tool explicitly declared `state_changing` or `destructive` could have zero generated cases, contribute no verdict, and leave the build green with nothing saying so.

A declaration — `tool_risk` in `agentcheck.json`, or a custom agent's own `ToolDefinition` — now makes four behaviours required for that tool. Any of them without evidence blocks with exit `3`, naming the tool, the requirement, and what to do next, in both the render and `--json`.

**This is a behaviour change for existing users:** a target that declares a tool's risk but never exercises it moves from exit `0` to exit `3`. That is a false green being corrected. The changelog states it plainly.

## Suite identity

`GENERATOR_COMPATIBILITY_VERSION` stays `1`. This changes a release decision, not generation, so every suite fingerprint stays where it was.

## Release validation

Run locally against this exact tree:

- version consistency — `test_version_decoupling.py`, 12 passed (`pyproject.toml` and `agentcheck.__version__` agree at `0.5.4`)
- secret scan — PASS
- workflow safety — PASS, 9 jobs on GitHub-hosted runners; PR workflows read-only, secret-free, environment-free, SHA-pinned
- interpreter integrity — 3.12.3 self-consistent
- build — `agentcheck_ai-0.5.4.tar.gz` and `agentcheck_ai-0.5.4-py3-none-any.whl`
- distribution audit — PASS, 2 artifacts contain only expected files
- clean-install smoke — fresh venv from the built wheel; `agentcheck --version` reports `0.5.4`
- extras smoke — `[openai-agents]` resolves 0.22.0 and the gate-floor API imports

`release.yml` is unchanged since the 0.5.3 release commit `54298b99`.

## Provenance

#91 went through **five independent review rounds**. Rounds 1-3 found six HIGH defects, all from one root cause — reconstructing per-tool truth from a rendered coverage report, which is a bounded, redacted presentation. The implementation was redesigned to evaluate obligations directly from the spec and scenarios. Round 4 confirmed the calculus admits no false PASS or false BLOCK; round 5 returned READY.

## Known limits, stated in the block message itself

- `max_cases` bounds a run before obligations are evaluated, so a bounded run can report obligations unmet simply because those cases were not selected.
- Generation caps cases per origin, so past roughly ten declared-risky tools the generator stops emitting the cases this floor requires. The message says explicitly not to delete a true risk declaration to go green.

Raising those caps is tracked separately as `AC-P0-8` and is not part of this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX563EW92ynBDVWoHBtx9W