### PR TITLE
Disclose recorded risk authority changes in run comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## Unreleased
+
+### Fixed
+
+- Stored-run comparison now reports `spec_changed` when a tool's risk changes
+  between inferred and authoritative, even if its resolved risk values and
+  recorded coverage digest stay the same. Each run's recorded specification
+  supplies the authority; existing artifacts, scenario classifications, and
+  comparison exit codes are unchanged.
+
+  **Suite identity:** unchanged.
+
 ## 0.5.4 (2026-09-02)
 
 A gate-correctness patch. `agentcheck gate` could return `PASS` for a target

--- a/agentcheck/regression/compare.py
+++ b/agentcheck/regression/compare.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from agentcheck.baseline.build import baseline_from_loaded
 from agentcheck.baseline.compare import compare_baselines
 from agentcheck.baseline.contract import ComparisonItem, EvaluationBaseline
+from agentcheck.domain import AgentSpec, RiskAuthority
 from agentcheck.errors import ConfigurationError
 from agentcheck.report.load import LoadedRun
 
@@ -163,8 +164,11 @@ def _caveats(
     # Every binding below comes from what each run recorded for itself. The
     # configured spec and frozen suite files can postdate either run, so they
     # are never comparison inputs.
-    if base_snapshot.spec_id != head_snapshot.spec_id or (
-        base.behavioral_coverage.spec_digest != head.behavioral_coverage.spec_digest
+    if (
+        base_snapshot.spec_id != head_snapshot.spec_id
+        or base.behavioral_coverage.spec_digest
+        != head.behavioral_coverage.spec_digest
+        or _risk_authority(base.spec) != _risk_authority(head.spec)
     ):
         caveats.append(ComparabilityCaveat.SPEC_CHANGED)
     # The scenario digest is always recorded and hashes the evaluated
@@ -192,6 +196,32 @@ def _caveats(
     elif base.git_revision == head.git_revision:
         caveats.append(ComparabilityCaveat.SOURCE_REVISION_UNCHANGED)
     return tuple(caveats)
+
+
+def _risk_authority(spec: AgentSpec) -> tuple[tuple[str, bool, bool], ...]:
+    """Coverage's per-axis authority, from this run's recorded specification.
+
+    The v1 coverage digest omits ``tool_risk``. Compare its effective authority
+    separately without rewriting stored digests or relaxing source validation.
+    As in coverage, predicates come from ToolDefinition (already digest-bound);
+    assertion values, confidence, and evidence text do not supply authority.
+    A missing assertion retains the legacy tool-schema authority fallback.
+    """
+
+    authoritative = {
+        RiskAuthority.DEVELOPER_DECLARED,
+        RiskAuthority.FRAMEWORK_AUTHORITATIVE,
+    }
+    assertions = {item.tool_name: item for item in spec.tool_risk.items}
+    axes: list[tuple[str, bool, bool]] = []
+    for tool in spec.tools.items:
+        assertion = assertions.get(tool.value.name)
+        state = destructive = tool.authoritative
+        if assertion is not None:
+            state = assertion.state_changing.authority in authoritative
+            destructive = assertion.destructive.authority in authoritative
+        axes.append((tool.value.name, state, destructive))
+    return tuple(sorted(axes))
 
 
 def _deselected_ids(head: LoadedRun) -> frozenset[str]:

--- a/docs/behavioral-regression.md
+++ b/docs/behavioral-regression.md
@@ -59,7 +59,10 @@ Two runs can differ in ways that change what a verdict difference means. Each
 such binding is reported as an explicit caveat rather than silently ignored:
 
 - `spec_changed` — the inspected specification changed, so a difference may
-  describe a different agent.
+  describe a different agent. This includes a change in whether either tool-risk
+  axis is authoritative, even when the resolved risk values are unchanged.
+  Authority comes from each run's recorded specification; provenance-only
+  changes with equivalent authority do not add this caveat.
 - `scenario_set_changed` — the runs evaluated different scenario sets, so added
   and removed scenarios are expected.
 - `suite_fingerprint_changed` — both runs recorded a frozen suite fingerprint

--- a/tests/agentcheck/test_behavioral_regression.py
+++ b/tests/agentcheck/test_behavioral_regression.py
@@ -33,12 +33,17 @@ from agentcheck.domain import (
     InstructionsSpec,
     InterfaceSpec,
     ObservabilitySpec,
+    RiskAuthority,
+    RiskAxis,
     RunTermination,
     RuntimeSpec,
     Scenario,
     SourceKind,
     SourceReference,
     SpecEvidence,
+    ToolDefinition,
+    ToolRiskAssertion,
+    ToolRiskSpec,
     ToolsSpec,
     Verdict,
     utc_now,
@@ -183,6 +188,47 @@ def _evaluation(
         completed_at=now,
         summary=verdict.value,
         infrastructure_error=infrastructure_error,
+    )
+
+
+def _risk_spec(
+    *,
+    authorities: tuple[RiskAuthority, RiskAuthority] | None,
+    state_changing: bool = True,
+    destructive: bool = True,
+    schema_authoritative: bool = False,
+    tool_name: str = "purge_records",
+) -> AgentSpec:
+    tool = _property(
+        ToolDefinition(
+            name=tool_name,
+            input_schema={"type": "object"},
+            state_changing=state_changing,
+            destructive=destructive,
+            replaceable=True,
+        )
+    ).model_copy(update={"authoritative": schema_authoritative})
+    assertions = (
+        (
+            ToolRiskAssertion(
+                tool_name=tool_name,
+                state_changing=RiskAxis(
+                    value=state_changing, authority=authorities[0], confidence=0.9
+                ),
+                destructive=RiskAxis(
+                    value=destructive, authority=authorities[1], confidence=0.9
+                ),
+                evidence=(SpecEvidence(evidence_id="risk", summary="Declared risk."),),
+            ),
+        )
+        if authorities is not None
+        else ()
+    )
+    return _spec().model_copy(
+        update={
+            "tools": ToolsSpec(items=(tool,)),
+            "tool_risk": ToolRiskSpec(items=assertions),
+        }
     )
 
 
@@ -616,6 +662,183 @@ def test_a_changed_spec_is_disclosed_but_shared_identities_still_compare(
     # runs, so its verdict change is still real evidence.
     assert _item(checked.comparison, suite[0].scenario_id).category == "new_regression"
     assert "different agent" in checked.summary
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    ("state_changing", "destructive", "before", "after"),
+    [
+        (
+            True, True,
+            (RiskAuthority.INFERRED, RiskAuthority.INFERRED),
+            (RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.DEVELOPER_DECLARED),
+        ),
+        (
+            True, False,
+            (RiskAuthority.INFERRED, RiskAuthority.UNKNOWN),
+            (RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.UNKNOWN),
+        ),
+        (
+            False, True,
+            (RiskAuthority.UNKNOWN, RiskAuthority.INFERRED),
+            (RiskAuthority.UNKNOWN, RiskAuthority.FRAMEWORK_AUTHORITATIVE),
+        ),
+        (
+            False, False,
+            (RiskAuthority.UNKNOWN, RiskAuthority.UNKNOWN),
+            (RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.DEVELOPER_DECLARED),
+        ),
+    ],
+    ids=["both-axes", "state-only", "destructive-only", "declared-false-vs-unknown"],
+)
+def test_risk_authority_change_is_disclosed_with_identical_v1_digests(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    reverse: bool,
+    state_changing: bool,
+    destructive: bool,
+    before: tuple[RiskAuthority, RiskAuthority],
+    after: tuple[RiskAuthority, RiskAuthority],
+) -> None:
+    base_spec = _risk_spec(
+        authorities=before, state_changing=state_changing, destructive=destructive
+    )
+    head_spec = _risk_spec(
+        authorities=after, state_changing=state_changing, destructive=destructive
+    )
+    if reverse:
+        base_spec, head_spec = head_spec, base_spec
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    base_dir = _write_run(tmp_path, "base", cases, spec=base_spec)
+    head_dir = _write_run(
+        tmp_path, "head", cases, spec=head_spec, git_revision="revision-b"
+    )
+    base = load_stored_run(tmp_path, run_id="base")
+    head = load_stored_run(tmp_path, run_id="head")
+    assert base.spec.spec_id == head.spec.spec_id
+    assert base.behavioral_coverage.spec_digest == head.behavioral_coverage.spec_digest
+    if state_changing and destructive:
+        # Recorded by the v1 writer at main@43148134, before this correction.
+        assert base.behavioral_coverage.spec_digest == (
+            "sha256:6d0ee564eb4c52e3c7cc166ac0615f6c817c1fee45a7288ba8d91692e9dba6db"
+        )
+    assert base.behavioral_coverage.families != head.behavioral_coverage.families
+    original = {
+        path: path.read_bytes()
+        for directory in (base_dir, head_dir)
+        for path in directory.iterdir()
+        if path.is_file()
+    }
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert checked.comparison.caveats == (ComparabilityCaveat.SPEC_CHANGED,)
+    assert checked.comparison.comparability is Comparability.COMPARABLE
+    assert all(item.category == "unchanged" for item in checked.comparison.items)
+    assert checked.exit_code == 0  # A disclosure is not a behavioral regression.
+    assert "specification changed" in checked.summary
+    assert {path: path.read_bytes() for path in original} == original
+
+
+@pytest.mark.parametrize("schema_authoritative", [False, True])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("recorded_coverage", [False, True])
+def test_risk_authority_comparison_preserves_absent_assertion_fallback(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    schema_authoritative: bool,
+    reverse: bool,
+    recorded_coverage: bool,
+) -> None:
+    legacy = _risk_spec(authorities=None, schema_authoritative=schema_authoritative)
+    matched = (
+        RiskAuthority.DEVELOPER_DECLARED
+        if schema_authoritative
+        else RiskAuthority.INFERRED
+    )
+    different = (
+        RiskAuthority.INFERRED
+        if schema_authoritative
+        else RiskAuthority.DEVELOPER_DECLARED
+    )
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    legacy_dir = _write_run(tmp_path, "legacy", cases, spec=legacy)
+    # Specs predating risk provenance did not serialize an empty section.
+    spec_path = legacy_dir / "agent-spec.json"
+    spec_document = json.loads(spec_path.read_text(encoding="utf-8"))
+    del spec_document["tool_risk"]
+    spec_path.write_text(json.dumps(spec_document), encoding="utf-8")
+    if not recorded_coverage:
+        summary_path = legacy_dir / "summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        del summary["behavioral_coverage"]
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    for run_id, authority, expected_change in (
+        ("matched", matched, False), ("different", different, True)
+    ):
+        _write_run(
+            tmp_path, run_id, cases, git_revision="revision-b",
+            spec=_risk_spec(
+                authorities=(authority, authority),
+                schema_authoritative=schema_authoritative,
+            ),
+        )
+        base_id, head_id = (run_id, "legacy") if reverse else ("legacy", run_id)
+        checked = compare_stored_runs(
+            tmp_path, base_run_id=base_id, head_run_id=head_id
+        )
+        changed = ComparabilityCaveat.SPEC_CHANGED in checked.comparison.caveats
+        assert changed is expected_change
+        assert checked.exit_code == 0
+
+
+def test_risk_authority_comparison_ignores_equivalent_provenance_and_order(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    declared = _risk_spec(
+        authorities=(RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.DEVELOPER_DECLARED)
+    )
+    unknown = _risk_spec(
+        authorities=(RiskAuthority.UNKNOWN, RiskAuthority.UNKNOWN),
+        state_changing=False, destructive=False, tool_name="lookup_records",
+    )
+    base_spec = declared.model_copy(update={
+        "tools": ToolsSpec(items=declared.tools.items + unknown.tools.items),
+        "tool_risk": ToolRiskSpec(items=declared.tool_risk.items + unknown.tool_risk.items),
+    })
+    declared_assertion = declared.tool_risk.items[0]
+    unknown_assertion = unknown.tool_risk.items[0]
+    changed_assertions = tuple(
+        assertion.model_copy(update={
+            "state_changing": assertion.state_changing.model_copy(update={
+                "authority": authority, "confidence": confidence,
+            }),
+            "destructive": assertion.destructive.model_copy(update={
+                "authority": authority, "confidence": confidence,
+            }),
+            "evidence": (SpecEvidence(evidence_id="changed", summary="Different provenance."),),
+            "conflicts": ("Different recorded conflict.",),
+        })
+        for assertion, authority, confidence in (
+            (unknown_assertion, RiskAuthority.INFERRED, 0.5),
+            (declared_assertion, RiskAuthority.FRAMEWORK_AUTHORITATIVE, 1.0),
+        )
+    )
+    head_spec = base_spec.model_copy(update={
+        "tools": ToolsSpec(items=tuple(reversed(base_spec.tools.items))),
+        "tool_risk": ToolRiskSpec(items=changed_assertions),
+    })
+    assert analyze_behavioral_coverage(
+        base_spec, suite
+    ) == analyze_behavioral_coverage(head_spec, suite)
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases, spec=base_spec)
+    _write_run(tmp_path, "head", cases, spec=head_spec, git_revision="revision-b")
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert checked.comparison.caveats == ()
+    assert checked.exit_code == 0
 
 
 def test_a_changed_seed_is_disclosed(


### PR DESCRIPTION
Stored runs whose tool risk changes from inferred to authoritative could compare without `spec_changed`: both the target identity and the v1 coverage digest omit that authority transition. Compare each run's recorded effective per-axis authority alongside the existing identity checks, including the legacy schema-authority fallback.

The correction preserves stored digests, artifact validation, scenario classifications, and exit-code policy. Equivalent authority, provenance-only changes, and input reordering do not add a caveat. No target execution is needed.

Validation:

- 100 focused coverage/regression tests passed; Ruff and focused mypy passed.
- Removing only the added authority-comparison condition fails all eight transition cases.
- Original pre-fix artifacts remain readable and all 16 files remain unchanged; both comparison directions now disclose `spec_changed` with exit 0.
- Legacy specs without `tool_risk`, including summaries without recorded coverage, retain their existing compatibility behavior.

Separate open finding (F2): selected-run coverage with unavailable reference scenarios still has an incomplete risk-authority source binding. This PR fixes the missed comparison caveat only; it does not migrate stored digests or repair that binding.

Independent semantic review is READY with no findings for exact head `78643ec1d945fde89500dfd502d7c0cf13d0b772`: 100 focused tests, 106 valid authority configurations, 22 stored-artifact comparisons, and six independently authored mutation kills. This records substantive review evidence, not GitHub approval or CI success. Hosted CI and every applicable merge gate remain required.
