### PR TITLE
Bind selected coverage to versioned risk authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ A release that does not change generation semantics leaves every suite
 fingerprint where it was. That is stated for each release under **Suite
 identity**.
 
+## Unreleased
+
+### Fixed
+
+- Stored-run comparison now reports `spec_changed` when a tool's risk changes
+  between inferred and authoritative, even if its resolved risk values and
+  recorded coverage digest stay the same. Each run's recorded specification
+  supplies the authority; existing artifacts, scenario classifications, and
+  comparison exit codes are unchanged.
+
+  **Suite identity:** unchanged.
+
 ## 0.5.4 (2026-09-02)
 
 A gate-correctness patch. `agentcheck gate` could return `PASS` for a target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ identity**.
 
   **Suite identity:** unchanged.
 
+- Coverage now binds effective per-axis tool-risk authority using a versioned
+  specification digest. Existing checksums, scenario denominators and source
+  checks are retained. Unknown digest algorithms fail closed; mixed-algorithm
+  comparisons do not report a spec change merely because the algorithm differs.
+
+  **Compatibility restriction:** older selected-run coverage with an omitted
+  reference set cannot prove its recorded authority and is now rejected by
+  stored-run consumers. Fully rederivable legacy coverage and summaries that
+  originally lacked coverage remain readable. No stored file is rewritten;
+  see `docs/behavioral-coverage.md` for recovery and the remaining reference limits.
+
+  **Suite identity:** unchanged. New coverage digests/checksums intentionally change.
+
 ## 0.5.4 (2026-09-02)
 
 A gate-correctness patch. `agentcheck gate` could return `PASS` for a target

--- a/agentcheck/coverage/__init__.py
+++ b/agentcheck/coverage/__init__.py
@@ -3,6 +3,7 @@
 from .analyzer import (
     UnmetRiskObligation,
     analyze_behavioral_coverage,
+    behavioral_coverage_spec_digest,
     risk_obligations_for_spec,
     unmet_risk_obligations,
     verify_behavioral_coverage_binding,
@@ -27,6 +28,7 @@ __all__ = [
     "BehavioralDimension",
     "UnmetRiskObligation",
     "analyze_behavioral_coverage",
+    "behavioral_coverage_spec_digest",
     "risk_obligations_for_spec",
     "unmet_risk_obligations",
     "verify_behavioral_coverage_binding",

--- a/agentcheck/coverage/analyzer.py
+++ b/agentcheck/coverage/analyzer.py
@@ -10,6 +10,7 @@ classification inputs.
 from __future__ import annotations
 
 import hmac
+import re
 from collections import Counter
 from dataclasses import dataclass, replace
 from enum import Enum
@@ -310,8 +311,8 @@ def _scenario_digest(scenarios: Sequence[Scenario]) -> str:
     return canonical_hash(_artifact_normalize(identities))
 
 
-def _spec_digest(spec: AgentSpec) -> str:
-    """Bind exactly the declared spec fields that determine coverage meaning."""
+def _legacy_spec_digest(spec: AgentSpec) -> str:
+    """The historical projection, retained only to verify existing artifacts."""
 
     projection = {
         "tools": [
@@ -342,6 +343,46 @@ def _spec_digest(spec: AgentSpec) -> str:
         ],
     }
     return canonical_hash(_artifact_normalize(projection))
+
+
+_SPEC_DIGEST_ALGORITHM = "coverage-spec.v2"
+
+
+def behavioral_coverage_spec_digest(spec: AgentSpec) -> str:
+    """Bind coverage's declared fields and effective per-axis risk authority.
+
+    The algorithm lives in the digest itself, leaving historical coverage
+    checksum payloads intact. The nested historical digest preserves its exact
+    normalization and ordering rules; new writers never emit that weaker form.
+    """
+
+    authoritative = {
+        RiskAuthority.DEVELOPER_DECLARED,
+        RiskAuthority.FRAMEWORK_AUTHORITATIVE,
+    }
+    assertions = {item.tool_name: item for item in spec.tool_risk.items}
+    axes: list[tuple[str, bool, bool]] = []
+    for tool in spec.tools.items:
+        assertion = assertions.get(tool.value.name)
+        state = destructive = tool.authoritative
+        if assertion is not None:
+            state = assertion.state_changing.authority in authoritative
+            destructive = assertion.destructive.authority in authoritative
+        axes.append((tool.value.name, state, destructive))
+    digest = canonical_hash(_artifact_normalize({
+        "algorithm": _SPEC_DIGEST_ALGORITHM,
+        "legacy_spec_digest": _legacy_spec_digest(spec),
+        "risk_authority": sorted(axes),
+    }))
+    return f"{_SPEC_DIGEST_ALGORITHM}:{digest}"
+
+
+def _is_legacy_spec_digest(digest: str) -> bool:
+    if re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        return True
+    if re.fullmatch(r"coverage-spec\.v2:sha256:[0-9a-f]{64}", digest):
+        return False
+    raise ValueError("unsupported or malformed behavioral coverage spec_digest algorithm")
 
 
 def _add_seed(
@@ -2345,7 +2386,7 @@ def analyze_behavioral_coverage(
     )
     return BehavioralCoverage(
         spec_id=spec.spec_id,
-        spec_digest=_spec_digest(spec),
+        spec_digest=behavioral_coverage_spec_digest(spec),
         scenario_count=len(actual),
         scenario_digest=_scenario_digest(actual),
         reference_scenario_count=len(reference),
@@ -2423,6 +2464,11 @@ def verify_behavioral_coverage_binding(
 ) -> None:
     """Fail closed when derived coverage is presented for different sources."""
 
+    legacy = _is_legacy_spec_digest(coverage.spec_digest)
+    expected_spec_digest = (
+        _legacy_spec_digest(spec)
+        if legacy else behavioral_coverage_spec_digest(spec)
+    )
     actual = tuple(scenarios)
     complete_reference: tuple[Scenario, ...] | None = (
         actual
@@ -2432,7 +2478,7 @@ def verify_behavioral_coverage_binding(
     mismatches: list[str] = []
     if coverage.spec_id != redact_log_text(spec.spec_id):
         mismatches.append("spec_id")
-    if coverage.spec_digest != _spec_digest(spec):
+    if coverage.spec_digest != expected_spec_digest:
         mismatches.append("spec_digest")
     if coverage.scenario_count != len(actual):
         mismatches.append("scenario_count")
@@ -2479,6 +2525,11 @@ def verify_behavioral_coverage_binding(
         suite_fingerprint, _UnspecifiedSuiteFingerprint
     ) and coverage.suite_fingerprint != expected_suite_fingerprint:
         mismatches.append("suite_fingerprint")
+    if legacy and complete_reference is None:
+        # A v1 digest omits risk authority. Without every reference document,
+        # no semantic rederivation can establish that the recorded rows match
+        # this spec. Never certify those rows or shrink their denominator.
+        mismatches.append("legacy_spec_digest_requires_complete_reference_scenarios")
     if complete_reference is not None:
         try:
             rederived = analyze_behavioral_coverage(
@@ -2491,6 +2542,14 @@ def verify_behavioral_coverage_binding(
         except ValueError:
             mismatches.append("derived_coverage")
         else:
+            if legacy:
+                # Compare against the original algorithm/checksum envelope in
+                # memory only; never rewrite or upgrade the stored artifact.
+                rederived = BehavioralCoverage.model_validate({
+                    **rederived.model_dump(),
+                    "spec_digest": expected_spec_digest,
+                    "fingerprint": "",
+                })
             if coverage != rederived:
                 mismatches.append("derived_coverage")
 
@@ -2504,6 +2563,7 @@ def verify_behavioral_coverage_binding(
 __all__ = [
     "UnmetRiskObligation",
     "analyze_behavioral_coverage",
+    "behavioral_coverage_spec_digest",
     "risk_obligations_for_spec",
     "unmet_risk_obligations",
     "verify_behavioral_coverage_binding",

--- a/agentcheck/regression/compare.py
+++ b/agentcheck/regression/compare.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from agentcheck.baseline.build import baseline_from_loaded
 from agentcheck.baseline.compare import compare_baselines
 from agentcheck.baseline.contract import ComparisonItem, EvaluationBaseline
+from agentcheck.domain import AgentSpec, RiskAuthority
 from agentcheck.errors import ConfigurationError
 from agentcheck.report.load import LoadedRun
 
@@ -163,8 +164,11 @@ def _caveats(
     # Every binding below comes from what each run recorded for itself. The
     # configured spec and frozen suite files can postdate either run, so they
     # are never comparison inputs.
-    if base_snapshot.spec_id != head_snapshot.spec_id or (
-        base.behavioral_coverage.spec_digest != head.behavioral_coverage.spec_digest
+    if (
+        base_snapshot.spec_id != head_snapshot.spec_id
+        or base.behavioral_coverage.spec_digest
+        != head.behavioral_coverage.spec_digest
+        or _risk_authority(base.spec) != _risk_authority(head.spec)
     ):
         caveats.append(ComparabilityCaveat.SPEC_CHANGED)
     # The scenario digest is always recorded and hashes the evaluated
@@ -192,6 +196,32 @@ def _caveats(
     elif base.git_revision == head.git_revision:
         caveats.append(ComparabilityCaveat.SOURCE_REVISION_UNCHANGED)
     return tuple(caveats)
+
+
+def _risk_authority(spec: AgentSpec) -> tuple[tuple[str, bool, bool], ...]:
+    """Coverage's per-axis authority, from this run's recorded specification.
+
+    The v1 coverage digest omits ``tool_risk``. Compare its effective authority
+    separately without rewriting stored digests or relaxing source validation.
+    As in coverage, predicates come from ToolDefinition (already digest-bound);
+    assertion values, confidence, and evidence text do not supply authority.
+    A missing assertion retains the legacy tool-schema authority fallback.
+    """
+
+    authoritative = {
+        RiskAuthority.DEVELOPER_DECLARED,
+        RiskAuthority.FRAMEWORK_AUTHORITATIVE,
+    }
+    assertions = {item.tool_name: item for item in spec.tool_risk.items}
+    axes: list[tuple[str, bool, bool]] = []
+    for tool in spec.tools.items:
+        assertion = assertions.get(tool.value.name)
+        state = destructive = tool.authoritative
+        if assertion is not None:
+            state = assertion.state_changing.authority in authoritative
+            destructive = assertion.destructive.authority in authoritative
+        axes.append((tool.value.name, state, destructive))
+    return tuple(sorted(axes))
 
 
 def _deselected_ids(head: LoadedRun) -> frozenset[str]:

--- a/agentcheck/regression/compare.py
+++ b/agentcheck/regression/compare.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from agentcheck.baseline.build import baseline_from_loaded
 from agentcheck.baseline.compare import compare_baselines
 from agentcheck.baseline.contract import ComparisonItem, EvaluationBaseline
+from agentcheck.coverage import behavioral_coverage_spec_digest
 from agentcheck.domain import AgentSpec, RiskAuthority
 from agentcheck.errors import ConfigurationError
 from agentcheck.report.load import LoadedRun
@@ -166,8 +167,15 @@ def _caveats(
     # are never comparison inputs.
     if (
         base_snapshot.spec_id != head_snapshot.spec_id
-        or base.behavioral_coverage.spec_digest
-        != head.behavioral_coverage.spec_digest
+        or (
+            base.behavioral_coverage.spec_digest
+            != head.behavioral_coverage.spec_digest
+            # Both runs have already passed binding validation. Normalize
+            # their own recorded specs, so a digest-algorithm upgrade alone
+            # does not masquerade as a specification change.
+            and behavioral_coverage_spec_digest(base.spec)
+            != behavioral_coverage_spec_digest(head.spec)
+        )
         or _risk_authority(base.spec) != _risk_authority(head.spec)
     ):
         caveats.append(ComparabilityCaveat.SPEC_CHANGED)

--- a/docs/behavioral-coverage.md
+++ b/docs/behavioral-coverage.md
@@ -115,6 +115,31 @@ authentication. Binding checks independently recompute the spec,
 actual-scenario, reference-scenario, and frozen-suite identities when those
 source documents are available.
 
+New reports identify their specification binding as
+`coverage-spec.v2:sha256:<digest>`. It includes the historical tool/schema and
+policy projection plus each declared tool's effective state-changing and
+destructive authority. Missing risk assertions retain the tool-schema authority
+fallback; inferred/unknown and declared/framework authority remain distinct.
+Equivalent authority tiers and display-only provenance do not change this
+binding. The algorithm identifier is itself hashed; malformed or unknown
+algorithms are rejected, never guessed or downgraded.
+
+**Compatibility restriction:** historical `sha256:<digest>` specification
+bindings omitted risk authority. Such recorded coverage is accepted only when
+the complete reference scenario set is available for semantic rederivation,
+with the original checksum and denominator intact. Previously readable legacy
+selected runs whose larger reference set was not persisted are now rejected
+with `legacy_spec_digest_requires_complete_reference_scenarios`. This also
+blocks stored-report rendering, comparison, baseline creation and finding
+review from that unverifiable run. Re-run to create newly bound evidence, or
+verify with the exact original reference documents through the binding API;
+current configured files are not substitutes for recorded sources. Do not
+remove embedded coverage or rewrite its counts/digest to evade this refusal.
+Fully rederivable legacy coverage and summaries that originally had no coverage
+field remain supported. Existing files are never upgraded in place. New reports
+require a reader that understands the v2 specification-binding algorithm;
+older readers reject their binding rather than silently misinterpreting it.
+
 Coverage-sensitive tool identifiers or input schemas that cannot survive
 mandatory artifact redaction or truncation losslessly are reported
 `UNKNOWN`, never `COVERED`. The normalized spec ID is a display/source hint,
@@ -129,8 +154,8 @@ cannot evaluate offline — an unresolvable local reference, for instance — yi
 no controlled reach rather than an escaping error, so the affected behavior is
 reported missing rather than covered.
 
-For a stored selected run, embedded coverage can retain the digest of the full
-reference universe. The loader can verify the coverage checksum and surviving
+For a stored selected run using the new binding, embedded coverage retains the
+digest of the full reference universe. The loader can verify the coverage checksum and surviving
 actual scenario documents, but it cannot independently reconstruct excluded
 scenario fingerprints. When an older summary lacks embedded coverage and only
 selected scenarios remain, AgentCheck derives

--- a/docs/behavioral-regression.md
+++ b/docs/behavioral-regression.md
@@ -59,7 +59,10 @@ Two runs can differ in ways that change what a verdict difference means. Each
 such binding is reported as an explicit caveat rather than silently ignored:
 
 - `spec_changed` — the inspected specification changed, so a difference may
-  describe a different agent.
+  describe a different agent. This includes a change in whether either tool-risk
+  axis is authoritative, even when the resolved risk values are unchanged.
+  Authority comes from each run's recorded specification; provenance-only
+  changes with equivalent authority do not add this caveat.
 - `scenario_set_changed` — the runs evaluated different scenario sets, so added
   and removed scenarios are expected.
 - `suite_fingerprint_changed` — both runs recorded a frozen suite fingerprint

--- a/docs/behavioral-regression.md
+++ b/docs/behavioral-regression.md
@@ -63,6 +63,7 @@ such binding is reported as an explicit caveat rather than silently ignored:
   axis is authoritative, even when the resolved risk values are unchanged.
   Authority comes from each run's recorded specification; provenance-only
   changes with equivalent authority do not add this caveat.
+  Changing only a validated coverage digest's algorithm does not add it either.
 - `scenario_set_changed` — the runs evaluated different scenario sets, so added
   and removed scenarios are expected.
 - `suite_fingerprint_changed` — both runs recorded a frozen suite fingerprint

--- a/tests/agentcheck/test_behavioral_regression.py
+++ b/tests/agentcheck/test_behavioral_regression.py
@@ -15,9 +15,13 @@ import pytest
 from agentcheck.artifacts import ArtifactStore
 from agentcheck.cli import main
 from agentcheck.coverage import (
+    BehavioralCoverage,
     BehavioralCoverageReferenceScope,
     analyze_behavioral_coverage,
+    behavioral_coverage_spec_digest,
+    verify_behavioral_coverage_binding,
 )
+from agentcheck.coverage.analyzer import _legacy_spec_digest
 from agentcheck.domain import (
     AgentProperty,
     AgentSpec,
@@ -46,6 +50,7 @@ from agentcheck.domain import (
     ToolRiskSpec,
     ToolsSpec,
     Verdict,
+    canonical_hash,
     utc_now,
 )
 from agentcheck.errors import ConfigurationError
@@ -242,6 +247,8 @@ def _write_run(
     git_revision: str | None = "revision-a",
     selection: SelectionPlan | None = None,
     assertion_id: str = "a1",
+    coverage: BehavioralCoverage | None = None,
+    legacy_coverage: bool = False,
 ) -> Path:
     spec = spec or _spec()
     scenarios = tuple(scenario for scenario, _ in cases)
@@ -273,9 +280,11 @@ def _write_run(
         if selection is not None and selection.excluded_ids
         else BehavioralCoverageReferenceScope.COMPLETE
     )
-    coverage = analyze_behavioral_coverage(
+    coverage = coverage or analyze_behavioral_coverage(
         spec, scenarios, reference_scope=reference_scope
     )
+    if legacy_coverage:
+        coverage = _as_legacy_coverage(coverage, spec)
     artifacts = ArtifactStore(root, ".agentcheck", run_id)
     artifacts.write_json("agent-spec.json", spec)
     artifacts.write_json(
@@ -315,6 +324,18 @@ def _write_run(
     artifacts.write_json("summary.json", summary)
     artifacts.write_text("report.html", "<html><body>placeholder</body></html>")
     return artifacts.root
+
+
+def _as_legacy_coverage(
+    coverage: BehavioralCoverage, spec: AgentSpec
+) -> BehavioralCoverage:
+    # Preserve the historical payload shape, checksum and semantic rows. The
+    # original F1 test below independently pins the pre-fix writer's digest.
+    return BehavioralCoverage.model_validate({
+        **coverage.model_dump(),
+        "spec_digest": _legacy_spec_digest(spec),
+        "fingerprint": "",
+    })
 
 
 def _selection_for(selected: Sequence[str], excluded: Sequence[str]) -> SelectionPlan:
@@ -709,9 +730,12 @@ def test_risk_authority_change_is_disclosed_with_identical_v1_digests(
     if reverse:
         base_spec, head_spec = head_spec, base_spec
     cases = tuple((scenario, Verdict.PASS) for scenario in suite)
-    base_dir = _write_run(tmp_path, "base", cases, spec=base_spec)
+    base_dir = _write_run(
+        tmp_path, "base", cases, spec=base_spec, legacy_coverage=True
+    )
     head_dir = _write_run(
-        tmp_path, "head", cases, spec=head_spec, git_revision="revision-b"
+        tmp_path, "head", cases, spec=head_spec, git_revision="revision-b",
+        legacy_coverage=True,
     )
     base = load_stored_run(tmp_path, run_id="base")
     head = load_stored_run(tmp_path, run_id="head")
@@ -1049,3 +1073,255 @@ def test_comparison_never_reads_the_configured_suite_file(
 
     after = _compare(tmp_path, "base", "head")
     assert after == before
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("axes", [(0,), (1,), (0, 1)])
+@pytest.mark.parametrize("risk_value", [False, True])
+def test_selected_v2_coverage_binds_each_effective_authority_axis(
+    suite: tuple[Scenario, ...], reverse: bool, axes: tuple[int, ...],
+    risk_value: bool,
+) -> None:
+    non_authoritative = RiskAuthority.INFERRED if risk_value else RiskAuthority.UNKNOWN
+    before = [non_authoritative, non_authoritative]
+    after = before.copy()
+    for axis in axes:
+        after[axis] = RiskAuthority.DEVELOPER_DECLARED
+    specs = [
+        _risk_spec(
+            authorities=(values[0], values[1]),
+            state_changing=risk_value, destructive=risk_value,
+        )
+        for values in (before, after)
+    ]
+    if reverse:
+        specs.reverse()
+    actual, reference = suite[:1], suite[:2]
+    coverage = analyze_behavioral_coverage(
+        specs[0], actual, reference_scenarios=reference
+    )
+    original = coverage.canonical_json()
+    assert coverage.spec_digest.startswith("coverage-spec.v2:sha256:")
+    assert _legacy_spec_digest(specs[0]) == _legacy_spec_digest(specs[1])
+    verify_behavioral_coverage_binding(coverage, specs[0], actual)
+    with pytest.raises(ValueError, match="spec_digest"):
+        verify_behavioral_coverage_binding(coverage, specs[1], actual)
+    assert coverage.reference_scenario_count == 2
+    assert coverage.canonical_json() == original
+
+
+def test_v2_digest_pins_algorithm_and_historical_projection() -> None:
+    spec = _risk_spec(authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2)
+    expected = canonical_hash({
+        "algorithm": "coverage-spec.v2",
+        "legacy_spec_digest": "sha256:6d0ee564eb4c52e3c7cc166ac0615f6c817c1fee45a7288ba8d91692e9dba6db",
+        "risk_authority": [["purge_records", True, True]],
+    })
+    assert behavioral_coverage_spec_digest(spec) == f"coverage-spec.v2:{expected}"
+
+
+def test_v2_authority_binding_ignores_only_equivalent_metadata() -> None:
+    legacy_fallback = _risk_spec(authorities=None, schema_authoritative=True)
+    declared = _risk_spec(
+        authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2,
+        schema_authoritative=True,
+    )
+    framework = _risk_spec(
+        authorities=(RiskAuthority.FRAMEWORK_AUTHORITATIVE,) * 2,
+        schema_authoritative=True,
+    )
+    assert behavioral_coverage_spec_digest(legacy_fallback) == (
+        behavioral_coverage_spec_digest(declared)
+    ) == behavioral_coverage_spec_digest(framework)
+    unknown = _risk_spec(
+        authorities=(RiskAuthority.UNKNOWN,) * 2, state_changing=False, destructive=False
+    )
+    inferred = _risk_spec(
+        authorities=(RiskAuthority.INFERRED,) * 2, state_changing=False, destructive=False
+    )
+    declared_false = _risk_spec(
+        authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2,
+        state_changing=False, destructive=False,
+    )
+    assert behavioral_coverage_spec_digest(unknown) == behavioral_coverage_spec_digest(inferred)
+    assert behavioral_coverage_spec_digest(unknown) != behavioral_coverage_spec_digest(declared_false)
+    orphan = inferred.tool_risk.items[0].model_copy(update={"tool_name": "not-declared"})
+    with_orphan = inferred.model_copy(update={"tool_risk": ToolRiskSpec(
+        items=(*inferred.tool_risk.items, orphan)
+    )})
+    assert behavioral_coverage_spec_digest(inferred) == behavioral_coverage_spec_digest(with_orphan)
+    doubled = inferred.model_copy(update={"tools": ToolsSpec(
+        items=(*inferred.tools.items, *inferred.tools.items)
+    )})
+    assert behavioral_coverage_spec_digest(inferred) != behavioral_coverage_spec_digest(doubled)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("changed_authority", [False, True])
+def test_mixed_digest_algorithms_compare_validated_semantics(
+    tmp_path: Path, suite: tuple[Scenario, ...], reverse: bool,
+    changed_authority: bool,
+) -> None:
+    first = _risk_spec(authorities=(RiskAuthority.INFERRED,) * 2)
+    second = _risk_spec(authorities=(
+        RiskAuthority.DEVELOPER_DECLARED if changed_authority else RiskAuthority.INFERRED,
+    ) * 2)
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "legacy", cases, spec=first, legacy_coverage=True)
+    _write_run(tmp_path, "current", cases, spec=second, git_revision="revision-b")
+    original = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    base, head = ("current", "legacy") if reverse else ("legacy", "current")
+    result = compare_stored_runs(tmp_path, base_run_id=base, head_run_id=head)
+    assert (ComparabilityCaveat.SPEC_CHANGED in result.comparison.caveats) is changed_authority
+    assert result.exit_code == 0
+    assert all(item.category == "unchanged" for item in result.comparison.items)
+    assert {path: path.read_bytes() for path in original} == original
+
+
+def test_legacy_reference_rederivation_preserves_checksum_and_denominator(
+    suite: tuple[Scenario, ...],
+) -> None:
+    spec = _risk_spec(authorities=(RiskAuthority.INFERRED,) * 2)
+    actual, reference = suite[:1], suite[:2]
+    coverage = _as_legacy_coverage(analyze_behavioral_coverage(
+        spec, actual, reference_scenarios=reference, suite_fingerprint="frozen-reference"
+    ), spec)
+    original = coverage.canonical_json()
+    with pytest.raises(ValueError, match="legacy_spec_digest_requires_complete_reference"):
+        verify_behavioral_coverage_binding(coverage, spec, actual)
+    verify_behavioral_coverage_binding(
+        coverage, spec, actual, reference_scenarios=tuple(reversed(reference)),
+        suite_fingerprint="frozen-reference",
+    )
+    for wrong_reference in (actual, (reference[0], reference[0]), suite):
+        with pytest.raises(ValueError, match="reference"):
+            verify_behavioral_coverage_binding(
+                coverage, spec, actual, reference_scenarios=wrong_reference
+            )
+    with pytest.raises(ValueError, match="suite_fingerprint"):
+        verify_behavioral_coverage_binding(
+            coverage, spec, actual, reference_scenarios=reference,
+            suite_fingerprint="wrong-frozen-reference",
+        )
+    substituted = _risk_spec(authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2)
+    with pytest.raises(ValueError, match="derived_coverage"):
+        verify_behavioral_coverage_binding(
+            coverage, substituted, actual, reference_scenarios=reference
+        )
+    assert coverage.reference_scenario_count == 2
+    assert coverage.canonical_json() == original
+
+
+@pytest.mark.parametrize("algorithm", [
+    "coverage-spec.v3:sha256:", "coverage-spec.v2:SHA256:",
+    "coverage-spec.v2:", "SHA256:", "sha256:", "",
+])
+def test_unknown_or_malformed_digest_algorithm_never_falls_back(
+    tmp_path: Path, suite: tuple[Scenario, ...], algorithm: str,
+) -> None:
+    spec = _risk_spec(authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2)
+    coverage = analyze_behavioral_coverage(spec, suite)
+    suffix = "f" * (63 if algorithm == "sha256:" else 64)
+    malformed = BehavioralCoverage.model_validate({
+        **coverage.model_dump(), "spec_digest": algorithm + suffix, "fingerprint": "",
+    })
+    directory = _write_run(
+        tmp_path, "unknown-algorithm", tuple((s, Verdict.PASS) for s in suite),
+        spec=spec, coverage=malformed,
+    )
+    original = {path: path.read_bytes() for path in directory.iterdir() if path.is_file()}
+    with pytest.raises(ConfigurationError, match="spec_digest algorithm"):
+        load_stored_run(tmp_path, run_id="unknown-algorithm")
+    assert {path: path.read_bytes() for path in original} == original
+
+
+def test_v2_cannot_downgrade_or_ignore_a_corrupt_checksum(
+    suite: tuple[Scenario, ...],
+) -> None:
+    spec = _risk_spec(authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2)
+    actual, reference = suite[:1], suite[:2]
+    coverage = analyze_behavioral_coverage(spec, actual, reference_scenarios=reference)
+    downgrade = _as_legacy_coverage(coverage, spec)
+    with pytest.raises(ValueError, match="legacy_spec_digest_requires_complete_reference"):
+        verify_behavioral_coverage_binding(downgrade, spec, actual)
+    wrong_digest = BehavioralCoverage.model_validate({
+        **coverage.model_dump(),
+        "spec_digest": _legacy_spec_digest(spec).replace("sha256:", "coverage-spec.v2:sha256:"),
+        "fingerprint": "",
+    })
+    with pytest.raises(ValueError, match="spec_digest"):
+        verify_behavioral_coverage_binding(wrong_digest, spec, actual)
+    # model_copy deliberately bypasses contract validation: the binding gate
+    # must still independently verify an already-instantiated object's checksum.
+    corrupt = coverage.model_copy(update={"fingerprint": "sha256:" + "0" * 64})
+    with pytest.raises(ValueError, match="fingerprint"):
+        verify_behavioral_coverage_binding(corrupt, spec, actual)
+
+
+@pytest.mark.parametrize("consumer", ["load", "render", "baseline", "baseline-check", "finding", "compare"])
+@pytest.mark.parametrize("failure", ["legacy-selected", "authority-substitution"])
+def test_unverifiable_selected_coverage_is_rejected_by_all_stored_consumers(
+    tmp_path: Path, suite: tuple[Scenario, ...], consumer: str, failure: str,
+) -> None:
+    from agentcheck.baseline.service import check_baseline, create_baseline
+    from agentcheck.report.load import render_stored_run
+    from agentcheck.review.service import record_finding_review
+
+    spec = _risk_spec(authorities=(RiskAuthority.INFERRED,) * 2)
+    actual, reference = suite[:1], suite[:2]
+    coverage = analyze_behavioral_coverage(spec, actual, reference_scenarios=reference)
+    directory = _write_run(
+        tmp_path, "selected", ((actual[0], Verdict.PASS),), spec=spec,
+        coverage=coverage, legacy_coverage=failure == "legacy-selected",
+        selection=_selection_for([actual[0].scenario_id], [reference[1].scenario_id]),
+    )
+    if failure == "authority-substitution":
+        assert load_stored_run(tmp_path, run_id="selected").behavioral_coverage == coverage
+        substituted = _risk_spec(authorities=(RiskAuthority.DEVELOPER_DECLARED,) * 2)
+        (directory / "agent-spec.json").write_text(substituted.canonical_json())
+    if consumer == "baseline-check":
+        _write_run(tmp_path, "baseline-source", ((actual[0], Verdict.PASS),), spec=spec)
+        create_baseline(tmp_path, run_id="baseline-source", out="comparison-baseline.json")
+    original = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    reason = "legacy_spec_digest_requires_complete_reference" if failure == "legacy-selected" else "spec_digest"
+    with pytest.raises(ConfigurationError, match=reason):
+        if consumer == "load":
+            load_stored_run(tmp_path, run_id="selected")
+        elif consumer == "render":
+            render_stored_run(tmp_path, run_id="selected")
+        elif consumer == "baseline":
+            create_baseline(tmp_path, run_id="selected")
+        elif consumer == "baseline-check":
+            check_baseline(
+                tmp_path, baseline_path="comparison-baseline.json", run_id="selected"
+            )
+        elif consumer == "finding":
+            record_finding_review(
+                tmp_path, run_id="selected", finding_id="not-reached", decision="accepted"
+            )
+        else:
+            compare_stored_runs(tmp_path, base_run_id="selected", head_run_id="selected")
+    assert {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()} == original
+
+
+def test_selected_summary_originally_without_coverage_remains_explicitly_limited(
+    tmp_path: Path, suite: tuple[Scenario, ...],
+) -> None:
+    spec = _risk_spec(authorities=None, schema_authoritative=True)
+    actual, reference = suite[:1], suite[:2]
+    directory = _write_run(
+        tmp_path, "pre-coverage-summary", ((actual[0], Verdict.PASS),), spec=spec,
+        selection=_selection_for([actual[0].scenario_id], [reference[1].scenario_id]),
+    )
+    # Construct the historical pre-coverage summary shape, not a recovery path
+    # for a recorded larger denominator; the product never erases this field.
+    path = directory / "summary.json"
+    summary = json.loads(path.read_text())
+    summary.pop("behavioral_coverage")
+    path.write_text(json.dumps(summary))
+    original = {path: path.read_bytes() for path in directory.iterdir() if path.is_file()}
+    coverage = load_stored_run(tmp_path, run_id="pre-coverage-summary").behavioral_coverage
+    assert coverage.reference_scope is BehavioralCoverageReferenceScope.AVAILABLE_SCENARIOS_ONLY
+    assert coverage.reference_scenario_count == coverage.scenario_count == 1
+    assert coverage.spec_digest.startswith("coverage-spec.v2:sha256:")
+    assert {path: path.read_bytes() for path in original} == original

--- a/tests/agentcheck/test_behavioral_regression.py
+++ b/tests/agentcheck/test_behavioral_regression.py
@@ -33,12 +33,17 @@ from agentcheck.domain import (
     InstructionsSpec,
     InterfaceSpec,
     ObservabilitySpec,
+    RiskAuthority,
+    RiskAxis,
     RunTermination,
     RuntimeSpec,
     Scenario,
     SourceKind,
     SourceReference,
     SpecEvidence,
+    ToolDefinition,
+    ToolRiskAssertion,
+    ToolRiskSpec,
     ToolsSpec,
     Verdict,
     utc_now,
@@ -183,6 +188,47 @@ def _evaluation(
         completed_at=now,
         summary=verdict.value,
         infrastructure_error=infrastructure_error,
+    )
+
+
+def _risk_spec(
+    *,
+    authorities: tuple[RiskAuthority, RiskAuthority] | None,
+    state_changing: bool = True,
+    destructive: bool = True,
+    schema_authoritative: bool = False,
+    tool_name: str = "purge_records",
+) -> AgentSpec:
+    tool = _property(
+        ToolDefinition(
+            name=tool_name,
+            input_schema={"type": "object"},
+            state_changing=state_changing,
+            destructive=destructive,
+            replaceable=True,
+        )
+    ).model_copy(update={"authoritative": schema_authoritative})
+    assertions = (
+        (
+            ToolRiskAssertion(
+                tool_name=tool_name,
+                state_changing=RiskAxis(
+                    value=state_changing, authority=authorities[0], confidence=0.9
+                ),
+                destructive=RiskAxis(
+                    value=destructive, authority=authorities[1], confidence=0.9
+                ),
+                evidence=(SpecEvidence(evidence_id="risk", summary="Declared risk."),),
+            ),
+        )
+        if authorities is not None
+        else ()
+    )
+    return _spec().model_copy(
+        update={
+            "tools": ToolsSpec(items=(tool,)),
+            "tool_risk": ToolRiskSpec(items=assertions),
+        }
     )
 
 
@@ -616,6 +662,183 @@ def test_a_changed_spec_is_disclosed_but_shared_identities_still_compare(
     # runs, so its verdict change is still real evidence.
     assert _item(checked.comparison, suite[0].scenario_id).category == "new_regression"
     assert "different agent" in checked.summary
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    ("state_changing", "destructive", "before", "after"),
+    [
+        (
+            True, True,
+            (RiskAuthority.INFERRED, RiskAuthority.INFERRED),
+            (RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.DEVELOPER_DECLARED),
+        ),
+        (
+            True, False,
+            (RiskAuthority.INFERRED, RiskAuthority.UNKNOWN),
+            (RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.UNKNOWN),
+        ),
+        (
+            False, True,
+            (RiskAuthority.UNKNOWN, RiskAuthority.INFERRED),
+            (RiskAuthority.UNKNOWN, RiskAuthority.FRAMEWORK_AUTHORITATIVE),
+        ),
+        (
+            False, False,
+            (RiskAuthority.UNKNOWN, RiskAuthority.UNKNOWN),
+            (RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.DEVELOPER_DECLARED),
+        ),
+    ],
+    ids=["both-axes", "state-only", "destructive-only", "declared-false-vs-unknown"],
+)
+def test_risk_authority_change_is_disclosed_with_identical_v1_digests(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    reverse: bool,
+    state_changing: bool,
+    destructive: bool,
+    before: tuple[RiskAuthority, RiskAuthority],
+    after: tuple[RiskAuthority, RiskAuthority],
+) -> None:
+    base_spec = _risk_spec(
+        authorities=before, state_changing=state_changing, destructive=destructive
+    )
+    head_spec = _risk_spec(
+        authorities=after, state_changing=state_changing, destructive=destructive
+    )
+    if reverse:
+        base_spec, head_spec = head_spec, base_spec
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    base_dir = _write_run(tmp_path, "base", cases, spec=base_spec)
+    head_dir = _write_run(
+        tmp_path, "head", cases, spec=head_spec, git_revision="revision-b"
+    )
+    base = load_stored_run(tmp_path, run_id="base")
+    head = load_stored_run(tmp_path, run_id="head")
+    assert base.spec.spec_id == head.spec.spec_id
+    assert base.behavioral_coverage.spec_digest == head.behavioral_coverage.spec_digest
+    if state_changing and destructive:
+        # Recorded by the v1 writer at main@43148134, before this correction.
+        assert base.behavioral_coverage.spec_digest == (
+            "sha256:6d0ee564eb4c52e3c7cc166ac0615f6c817c1fee45a7288ba8d91692e9dba6db"
+        )
+    assert base.behavioral_coverage.families != head.behavioral_coverage.families
+    original = {
+        path: path.read_bytes()
+        for directory in (base_dir, head_dir)
+        for path in directory.iterdir()
+        if path.is_file()
+    }
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert checked.comparison.caveats == (ComparabilityCaveat.SPEC_CHANGED,)
+    assert checked.comparison.comparability is Comparability.COMPARABLE
+    assert all(item.category == "unchanged" for item in checked.comparison.items)
+    assert checked.exit_code == 0  # A disclosure is not a behavioral regression.
+    assert "specification changed" in checked.summary
+    assert {path: path.read_bytes() for path in original} == original
+
+
+@pytest.mark.parametrize("schema_authoritative", [False, True])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("recorded_coverage", [False, True])
+def test_risk_authority_comparison_preserves_absent_assertion_fallback(
+    tmp_path: Path,
+    suite: tuple[Scenario, ...],
+    schema_authoritative: bool,
+    reverse: bool,
+    recorded_coverage: bool,
+) -> None:
+    legacy = _risk_spec(authorities=None, schema_authoritative=schema_authoritative)
+    matched = (
+        RiskAuthority.DEVELOPER_DECLARED
+        if schema_authoritative
+        else RiskAuthority.INFERRED
+    )
+    different = (
+        RiskAuthority.INFERRED
+        if schema_authoritative
+        else RiskAuthority.DEVELOPER_DECLARED
+    )
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    legacy_dir = _write_run(tmp_path, "legacy", cases, spec=legacy)
+    # Specs predating risk provenance did not serialize an empty section.
+    spec_path = legacy_dir / "agent-spec.json"
+    spec_document = json.loads(spec_path.read_text(encoding="utf-8"))
+    del spec_document["tool_risk"]
+    spec_path.write_text(json.dumps(spec_document), encoding="utf-8")
+    if not recorded_coverage:
+        summary_path = legacy_dir / "summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        del summary["behavioral_coverage"]
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    for run_id, authority, expected_change in (
+        ("matched", matched, False), ("different", different, True)
+    ):
+        _write_run(
+            tmp_path, run_id, cases, git_revision="revision-b",
+            spec=_risk_spec(
+                authorities=(authority, authority),
+                schema_authoritative=schema_authoritative,
+            ),
+        )
+        base_id, head_id = (run_id, "legacy") if reverse else ("legacy", run_id)
+        checked = compare_stored_runs(
+            tmp_path, base_run_id=base_id, head_run_id=head_id
+        )
+        changed = ComparabilityCaveat.SPEC_CHANGED in checked.comparison.caveats
+        assert changed is expected_change
+        assert checked.exit_code == 0
+
+
+def test_risk_authority_comparison_ignores_equivalent_provenance_and_order(
+    tmp_path: Path, suite: tuple[Scenario, ...]
+) -> None:
+    declared = _risk_spec(
+        authorities=(RiskAuthority.DEVELOPER_DECLARED, RiskAuthority.DEVELOPER_DECLARED)
+    )
+    unknown = _risk_spec(
+        authorities=(RiskAuthority.UNKNOWN, RiskAuthority.UNKNOWN),
+        state_changing=False, destructive=False, tool_name="lookup_records",
+    )
+    base_spec = declared.model_copy(update={
+        "tools": ToolsSpec(items=declared.tools.items + unknown.tools.items),
+        "tool_risk": ToolRiskSpec(items=declared.tool_risk.items + unknown.tool_risk.items),
+    })
+    declared_assertion = declared.tool_risk.items[0]
+    unknown_assertion = unknown.tool_risk.items[0]
+    changed_assertions = tuple(
+        assertion.model_copy(update={
+            "state_changing": assertion.state_changing.model_copy(update={
+                "authority": authority, "confidence": confidence,
+            }),
+            "destructive": assertion.destructive.model_copy(update={
+                "authority": authority, "confidence": confidence,
+            }),
+            "evidence": (SpecEvidence(evidence_id="changed", summary="Different provenance."),),
+            "conflicts": ("Different recorded conflict.",),
+        })
+        for assertion, authority, confidence in (
+            (unknown_assertion, RiskAuthority.INFERRED, 0.5),
+            (declared_assertion, RiskAuthority.FRAMEWORK_AUTHORITATIVE, 1.0),
+        )
+    )
+    head_spec = base_spec.model_copy(update={
+        "tools": ToolsSpec(items=tuple(reversed(base_spec.tools.items))),
+        "tool_risk": ToolRiskSpec(items=changed_assertions),
+    })
+    assert analyze_behavioral_coverage(
+        base_spec, suite
+    ) == analyze_behavioral_coverage(head_spec, suite)
+    cases = tuple((scenario, Verdict.PASS) for scenario in suite)
+    _write_run(tmp_path, "base", cases, spec=base_spec)
+    _write_run(tmp_path, "head", cases, spec=head_spec, git_revision="revision-b")
+
+    checked = compare_stored_runs(tmp_path, base_run_id="base", head_run_id="head")
+
+    assert checked.comparison.caveats == ()
+    assert checked.exit_code == 0
 
 
 def test_a_changed_seed_is_disclosed(


### PR DESCRIPTION
## Scope and integration

This PR targets merged `main` and contains only the independently reviewed F2 delta: bind selected behavioral coverage to versioned specification authority and refuse legacy selected coverage whose missing reference scenarios prevent semantic verification.

F1's stored-run `SPEC_CHANGED` correction was separately merged in #94. Its behavior is retained, not reintroduced as a second F1 change.

Frozen head: `108cde008b4e1ae7e329ab22efaaf7a6eb1d321f`.
Target / merge-base: `11e54276d7ebc2bbdf6452141023390e50250f17`.
Delta: exactly seven files, 396 insertions / 11 deletions.

This successor records main's squash-merge ancestry because GitHub reported the prior graph as conflicting. Before the ancestry-only merge, both author and independent reviewer verified that merged main's entire tree equals the original reviewed F2 parent's tree (`3448c3a9796332ed829dbaf9b28d95725a7428be`). The successor's entire tree equals the previously reviewed F2 head `74090b85` (`bba180062180db80d657af37a02bb0efd6fd260f`); the complete target-base patch is byte-identical to the reviewed F2 patch. No manual source resolution or source change occurred. Independent target-base review is READY at exact `108cde00`.

## Changes

- New coverage writers emit `coverage-spec.v2:sha256:<digest>`, binding the algorithm identity, unchanged historical tool/schema/policy projection, and each declared tool's effective state/destructive authority.
- Preserve absent-assertion schema-authority fallback, equivalent authority tiers, ordering independence and tool multiplicity.
- Retain checksums, stored spec IDs, scope, suite identity, scenario count/multiset digests, full-reference rederivation and recorded denominators.
- Validate complete legacy coverage using its original digest/checksum envelope without rewriting artifacts. Reject unknown/malformed algorithms, downgrade attempts and mismatched bindings without fallback.
- Normalize algorithm-only differences during comparison; retain disclosure of actual schema/risk/authority changes and unchanged classification/exit policy.
- Document compatibility loss. No evaluator, generator, scenario identity, workflow, version or real trusted-baseline change.

## Compatibility and limits

Some honestly generated legacy selected runs are now rejected by validated stored-run consumers because their omitted reference scenarios cannot be rederived and the old digest does not bind risk authority. Complete rederivable legacy runs and genuinely older summaries that originally omitted coverage remain supported. New reports require a v2-aware reader.

The direct verifier can use exact supplied reference documents only after existing count/multiset/suite checks. Stored-run loading does not substitute today's configured suite, erase recorded coverage, shrink denominators or rewrite old files. This is artifact consistency, not authentication against an actor rewriting every unkeyed artifact.

The shared loader enforces refusal before rendering, comparison, baseline create/check or finding-review authority is produced. This PR does not resolve #93 or the separate confirmation/evaluator release boundary, authorize a baseline refresh, or clear release gates.

## Evidence

- Author: 176 focused coverage/regression/report tests pass; Ruff, focused mypy, secret scan and whitespace checks pass. Source execution was at original `74090b85`; whole-tree and target-patch identity prove its applicability to the successor without relabeling it as a new execution.
- Author: ten executed in-memory omission mutations killed by 39 decisive assertion failures, zero setup/teardown errors.
- Independent exact-head semantic review: READY, no blocking findings; the same 176 focused tests pass, 106 validated specs exercise 1,058 directed authority-substitution refusals and 145 equivalent pairs, and five independently designed mutations are killed.
- Original pre-fix complete artifacts remain readable, original stale selected artifact is refused, and all 32 historical files remain byte-identical. Loaded module paths/source bytes are bound to the frozen checkout.
- F1-only CI run `33922915017` succeeded at `78643ec1`. The old PR run `33927285851` at `74090b85` is superseded and cannot satisfy successor CI. The normal push starts fresh hosted checks for exact `108cde00`; no full local duplication or manual workflow rerun.

Publication is not approval, merge or release. Required CI, review/protection gates and independent release holds remain mandatory.
